### PR TITLE
Update GH Subsystem To Support GitHub Apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,7 +1636,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plaid"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "paste",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,7 +1636,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plaid"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "paste",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b79b82693f705137f8fb9b37871d99e4f9a7df12b917eed79c3d3954830a60b"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -117,13 +117,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -139,15 +139,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -177,6 +177,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.3"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bytecheck"
@@ -233,15 +239,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.88"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -251,9 +257,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -270,7 +276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "indexmap 1.9.3",
  "strsim",
@@ -490,7 +496,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -501,7 +507,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -575,7 +581,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -631,7 +637,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -746,7 +752,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -830,9 +836,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
  "bytes",
  "fnv",
@@ -840,7 +846,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -862,7 +868,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.10",
+ "ahash 0.8.11",
  "allocator-api2",
 ]
 
@@ -913,9 +919,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -1040,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1065,24 +1071,24 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.2.0"
+version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ea04a7c5c055c175f189b6dc6ba036fd62306b58c66c9f6389036c503a3f4"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
 dependencies = [
  "base64 0.21.7",
  "js-sys",
@@ -1146,10 +1152,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.7.1"
+name = "mach2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memmap2"
@@ -1171,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -1410,22 +1425,22 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1474,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "paste",
  "serde",
@@ -1519,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1593,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -1630,7 +1645,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1639,7 +1654,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1656,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1668,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1679,20 +1694,20 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "region"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
- "mach",
- "winapi",
+ "mach2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1706,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -1892,6 +1907,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bf37232d3bb9a2c4e641ca2a11d83b5062066f88df7fed36c28772046d65ba"
 
 [[package]]
+name = "semver"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+
+[[package]]
 name = "serde"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1919,14 +1940,14 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -2026,9 +2047,9 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -2077,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2110,7 +2131,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -2154,22 +2175,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2220,9 +2241,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2245,7 +2266,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2260,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2330,7 +2351,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2446,9 +2467,9 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "version_check"
@@ -2505,9 +2526,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2515,24 +2536,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2542,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2552,22 +2573,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
@@ -2580,9 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer"
-version = "4.2.5"
+version = "4.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5467c7a23f9be04d5691590bea509dbea27e5ba5810d0020bef908456a495f33"
+checksum = "5c15724dc25d1ee57962334aea8e41ade2675e5ea2ac6b8d42da6051b0face66"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2596,6 +2617,7 @@ dependencies = [
  "shared-buffer",
  "target-lexicon",
  "thiserror",
+ "tracing",
  "wasm-bindgen",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
@@ -2608,9 +2630,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "4.2.5"
+version = "4.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510ad01a668d774f3a103a7c219bbc0970be93e8f1b27e2fdb48d1f4ccd1deff"
+checksum = "55a7f3b3a96f8d844c25e2c032af9572306dd63fa93dc17bcca4c5458ac569bd"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2635,9 +2657,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "4.2.5"
+version = "4.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54bf93078990d83960d798de3c5935bddaba771fc2fefb9ed6bab9c0bbdea5c1"
+checksum = "102e2c5bacac69495c4025767e2fa26797ffb27f242dccb7cf57d9cefd944386"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2654,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "4.2.5"
+version = "4.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b374fd34d97b1c091d8675f9bc472df52dc6787d139d3762d42c7dc84813a9b"
+checksum = "0ea737fa08f95d6abc4459f42a70a9833e8974b814e74971d77ef473814f4d4c"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -2666,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "4.2.5"
+version = "4.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab1347a1f81bf5929289db82b4f3966e9aecc4f874115110b6c0894ee8d9e77"
+checksum = "0346ed39c185c1c5c1094e6c0271d798276a34f80e1e5576bcb2e32fa2e7f05a"
 dependencies = [
  "wasmer",
  "wasmer-types",
@@ -2677,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "4.2.5"
+version = "4.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0caf1c87937b52aba8e9f920a278e1beda282f7439612c0b48f51a58e7a87bab"
+checksum = "b0689110e291b0f07fc665f2824e5ff81df120848e8a9acfbf1a9bf7990773f9"
 dependencies = [
  "bytecheck",
  "enum-iterator",
@@ -2693,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "4.2.5"
+version = "4.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58315c25492bc72a33f47a7d7fb0869a0106fc0164ec051e349a9e1eddba9a01"
+checksum = "4cd41f822a1ac4242d478754e8ceba2806a00ea5072803622e1fe91e8e28b2a1"
 dependencies = [
  "backtrace",
  "cc",
@@ -2721,12 +2743,13 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.95.0"
+version = "0.121.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ea896273ea99b15132414be1da01ab0d8836415083298ecaffbe308eaac87a"
+checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
- "indexmap 1.9.3",
- "url",
+ "bitflags 2.5.0",
+ "indexmap 2.2.6",
+ "semver",
 ]
 
 [[package]]
@@ -2752,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3045,5 +3068,5 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +177,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +277,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.4",
 ]
@@ -845,7 +858,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -881,7 +894,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http",
+ "http 0.2.12",
  "httpdate",
  "mime",
  "sha1",
@@ -893,8 +906,14 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.12",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -929,13 +948,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -968,8 +1021,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -982,17 +1035,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
- "rustls",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "rustls 0.21.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.2.0",
+ "hyper-util",
+ "log",
+ "rustls 0.22.3",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.2.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.2.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1068,6 +1192,16 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "iri-string"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21859b667d66a4c1dacd9df0863b3efb65785474255face87f5bca39dd8407c0"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "itoa"
@@ -1250,7 +1384,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "memchr",
@@ -1324,6 +1458,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "octocrab"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dedddd64be5eb5ea9311d1934a09ce32ef9be22fd29990bb2a5552c17712306e"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "base64 0.22.0",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "either",
+ "futures",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-rustls 0.26.0",
+ "hyper-timeout",
+ "hyper-util",
+ "jsonwebtoken",
+ "once_cell",
+ "percent-encoding",
+ "pin-project",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "snafu",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +1510,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "os_str_bytes"
@@ -1457,7 +1636,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plaid"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1467,13 +1646,16 @@ dependencies = [
  "env_logger",
  "futures",
  "hex",
+ "http 1.1.0",
  "jsonwebtoken",
  "log",
  "lru",
+ "octocrab",
  "paste",
  "plaid_stl",
  "rand",
  "rcgen",
+ "regex",
  "reqwest",
  "ring 0.16.20",
  "serde",
@@ -1731,10 +1913,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -1742,15 +1924,15 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.10",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1843,8 +2025,35 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1857,6 +2066,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
+dependencies = [
+ "base64 0.21.7",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1867,10 +2092,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "scoped-tls"
@@ -1899,6 +2144,38 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "self_cell"
@@ -1951,6 +2228,16 @@ checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -2052,6 +2339,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "snafu"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75976f4748ab44f6e5332102be424e7c2dc18daeaf7e725f2040c3ebb133512e"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b19911debfb8c2fb1107bc6cb2d61868aaf53a988449213959bb1b5b1ed95f"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,6 +2392,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -2275,7 +2589,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.3",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -2324,6 +2649,49 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.5.0",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -2378,7 +2746,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand",
@@ -2457,6 +2825,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2496,21 +2865,21 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "headers",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "log",
  "mime",
  "mime_guess",
  "multer",
  "percent-encoding",
  "pin-project",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "scoped-tls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
@@ -3070,3 +3439,9 @@ dependencies = [
  "quote",
  "syn 2.0.55",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,7 +1636,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plaid"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "async-trait",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,7 @@
 [workspace]
+resolver = "2"
 
-members = [
-    "plaid",
-    "plaid-stl",
-]
+members = ["plaid", "plaid-stl"]
 
 [profile.release]
 lto = true

--- a/plaid-stl/Cargo.lock
+++ b/plaid-stl/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "plaid_stl"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "paste",
  "serde",

--- a/plaid-stl/Cargo.lock
+++ b/plaid-stl/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "plaid_stl"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "paste",
  "serde",

--- a/plaid-stl/Cargo.lock
+++ b/plaid-stl/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "plaid_stl"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "paste",
  "serde",

--- a/plaid-stl/Cargo.toml
+++ b/plaid-stl/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "plaid_stl"
-version = "0.11.0"
+version = "0.11.2"
 edition = "2021"
 #
 

--- a/plaid-stl/Cargo.toml
+++ b/plaid-stl/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "plaid_stl"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 #
 

--- a/plaid-stl/Cargo.toml
+++ b/plaid-stl/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "plaid_stl"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 #
 

--- a/plaid-stl/src/github/mod.rs
+++ b/plaid-stl/src/github/mod.rs
@@ -4,6 +4,11 @@ use serde::Serialize;
 
 use crate::PlaidFunctionError;
 
+pub enum ReviewPatAction {
+    Approve,
+    Deny,
+}
+
 // TODO: Do not use this function, it is deprecated and will be removed soon
 pub fn add_user_to_team(team: &str, user: &str, org: &str, role: &str) -> Result<(), i32> {
     add_user_to_team_detailed(team, user, org, role).map_err(|_| -4)
@@ -261,4 +266,79 @@ pub fn fetch_commit(user: &str, repo: &str, commit: &str) -> Result<String, Plai
     // This should be safe because unless the Plaid runtime is expressly trying
     // to mess with us, this came from a String in the API module.
     Ok(String::from_utf8(return_buffer).unwrap())
+}
+
+pub fn list_fpat_requests_for_org(org: &str) -> Result<String, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(github, list_fpat_requests_for_org);
+    }
+    const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
+
+    let mut params: HashMap<&'static str, &str> = HashMap::new();
+    params.insert("org", org);
+
+    let request = serde_json::to_string(&params).unwrap();
+
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let res = unsafe {
+        github_list_fpat_requests_for_org(
+            request.as_bytes().as_ptr(),
+            request.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    Ok(String::from_utf8(return_buffer).unwrap())
+}
+
+pub fn review_fpat_requests_for_org(
+    org: String,
+    pat_request_ids: &[u64],
+    action: ReviewPatAction,
+    reason: String,
+) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(github, review_fpat_requests_for_org);
+    }
+    #[derive(Serialize)]
+    struct Request {
+        org: String,
+        pat_request_ids: Vec<u64>,
+        action: String,
+        reason: String,
+    }
+
+    let request = Request {
+        org,
+        pat_request_ids: pat_request_ids.to_vec(),
+        action: match action {
+            ReviewPatAction::Approve => "approve".to_string(),
+            ReviewPatAction::Deny => "deny".to_string(),
+        },
+        reason,
+    };
+
+    let request = serde_json::to_string(&request).unwrap();
+
+    let res = unsafe {
+        github_review_fpat_requests_for_org(request.as_bytes().as_ptr(), request.as_bytes().len())
+    };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    match res {
+        0 => Ok(()),
+        x => Err(x.into()),
+    }
 }

--- a/plaid/Cargo.toml
+++ b/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plaid/Cargo.toml
+++ b/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -18,11 +18,14 @@ crossbeam-channel = "0.5"
 env_logger = "0.8"
 futures = "0.3"
 hex = "0.4"
+http = "1"
 log = "0.4"
 lru = "0.12"
+octocrab = "0.37"
 paste = "1.0"
 plaid_stl = { path = "../plaid-stl" }
 rcgen = { version = "0.10", features = ["x509-parser"] }
+regex = "1"
 ring = "0.16.20"
 reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",

--- a/plaid/Cargo.toml
+++ b/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plaid/Cargo.toml
+++ b/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plaid/resources/Cargo.toml
+++ b/plaid/resources/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plaid/resources/Cargo.toml
+++ b/plaid/resources/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "plaid"
+version = "0.10.1"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default = []
+quorum = ["quorum-agent"]
+
+[dependencies]
+async-trait = "0.1.56"
+base64 = "0.13"
+chrono = "0.4"
+clap = "3.0.0-beta.2"
+crossbeam-channel = "0.5"
+env_logger = "0.8"
+futures = "0.3"
+hex = "0.4"
+log = "0.4"
+lru = "0.12"
+paste = "1.0"
+plaid_stl = { path = "../plaid-stl" }
+rcgen = { version = "0.10", features = ["x509-parser"] }
+ring = "0.16.20"
+reqwest = { version = "0.11", default-features = false, features = [
+    "rustls-tls",
+    "json",
+] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+sled = "0.34.7"
+time = "0.3"
+tokio = { version = "1", features = ["full"] }
+toml = "0.5"
+warp = { version = "0.3", features = ["tls"] }
+wasmer = { version = "4", features = ["cranelift"] }
+wasmer-middlewares = "4"
+jsonwebtoken = { version = "9.2" }
+
+# Uncomment to build with Quorum. This is needed
+# because otherwise cargo will try and find this
+# to build the lockfile.
+quorum-agent = { path = "../../quorum/quorum-agent", default_features = false, optional = true }
+rand = "0.8.5"
+
+[[example]]
+name = "github-tailer"
+path = "examples/tailers/github.rs"

--- a/plaid/resources/Cargo.toml
+++ b/plaid/resources/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.10.1"
+version = "0.11.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plaid/resources/Cargo.toml
+++ b/plaid/resources/Cargo.toml
@@ -18,11 +18,14 @@ crossbeam-channel = "0.5"
 env_logger = "0.8"
 futures = "0.3"
 hex = "0.4"
+http = "1"
 log = "0.4"
 lru = "0.12"
+octocrab = "0.37"
 paste = "1.0"
 plaid_stl = { path = "../plaid-stl" }
 rcgen = { version = "0.10", features = ["x509-parser"] }
+regex = "1"
 ring = "0.16.20"
 reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",

--- a/plaid/resources/Dockerfile_quorum.aarch64
+++ b/plaid/resources/Dockerfile_quorum.aarch64
@@ -1,0 +1,22 @@
+FROM messense/rust-musl-cross:aarch64-musl as builder
+
+RUN rustup component add rustfmt
+RUN mkdir /build
+WORKDIR /build
+COPY plaid plaid
+COPY quorum quorum
+
+COPY plaid/plaid/resources/Cargo.toml plaid/plaid/Cargo.toml
+
+WORKDIR /build/plaid
+RUN cargo build --bin=plaid --release --features quorum
+
+
+FROM alpine:3.6 as alpine
+RUN apk add -U --no-cache ca-certificates
+
+from scratch as runtime
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /build/plaid/target/aarch64-unknown-linux-musl/release/plaid /plaid
+USER 1000
+CMD [ "/plaid", "--config", "/config/plaid.toml" ]

--- a/plaid/resources/plaid.toml
+++ b/plaid/resources/plaid.toml
@@ -85,9 +85,9 @@ domain = ""
 # "Accept" = "application/vnd.github+json"
 # "User-Agent" = "Plaid/0.10"
 
-[apis."github"]
-token = ""
-[apis."github".graphql_queries]
+# [apis."github"]
+# token = ""
+# [apis."github".graphql_queries]
 
 [apis."slack"]
 [apis."slack"."webhooks"]
@@ -130,6 +130,8 @@ headers = ["notarealheader"]
 
 [webhooks."internal".webhooks."FFFF"]
 log_type = "testing"
+logbacks_allowed = "Unlimited"
+
 headers = ["x-forwarded-for"]
 [webhooks."internal".webhooks."FFFF".get_mode]
 response_mode = "rule:testing_test.wasm"

--- a/plaid/src/apis/github/graphql.rs
+++ b/plaid/src/apis/github/graphql.rs
@@ -30,7 +30,7 @@ struct AdvancedRequest {
     variables: HashMap<String, serde_json::Value>,
 }
 
-const GITHUB_GQL_API: &str = "https://api.github.com/graphql";
+const GITHUB_GQL_API: &str = "/graphql";
 
 impl Github {
     async fn make_gql_request(&self, query: String, module: &str) -> Result<String, ApiError> {

--- a/plaid/src/apis/github/graphql.rs
+++ b/plaid/src/apis/github/graphql.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
-use crate::{apis::{ApiError, github::GitHubError}};
+use crate::apis::{github::GitHubError, ApiError};
 
 use super::Github;
 
@@ -32,65 +32,82 @@ struct AdvancedRequest {
 
 const GITHUB_GQL_API: &str = "https://api.github.com/graphql";
 
-
 impl Github {
-    pub async fn make_graphql_query(&self, request: &str, _: &str) -> Result<String, ApiError> {
+    async fn make_gql_request(&self, query: String, module: &str) -> Result<String, ApiError> {
+        let request = self.client._post(GITHUB_GQL_API, Some(&query)).await;
+
+        match request {
+            Ok(r) => {
+                if r.status() == 200 {
+                    let body = self.client.body_to_string(r).await.map_err(|e| {
+                        ApiError::GitHubError(GitHubError::GraphQLRequestError(e.to_string()))
+                    })?;
+
+                    Ok(body)
+                } else {
+                    let status = r.status();
+                    let body = self.client.body_to_string(r).await.map_err(|e| {
+                        ApiError::GitHubError(GitHubError::GraphQLRequestError(e.to_string()))
+                    })?;
+
+                    warn!("Failed GraphQL query from module: {module}. Status Code: {status} Return was: {body}");
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status.as_u16(),
+                    )))
+                }
+            }
+            Err(e) => Err(ApiError::GitHubError(GitHubError::ClientError(e))),
+        }
+    }
+
+    pub async fn make_graphql_query(
+        &self,
+        request: &str,
+        module: &str,
+    ) -> Result<String, ApiError> {
         let request: Request = serde_json::from_str(request).map_err(|_| ApiError::BadRequest)?;
 
         let query = match self.config.graphql_queries.get(&request.query_name) {
             Some(query) => query.to_owned(),
-            None => return Err(ApiError::GitHubError(GitHubError::GraphQLQueryUnknown(request.query_name))),
+            None => {
+                return Err(ApiError::GitHubError(GitHubError::GraphQLQueryUnknown(
+                    request.query_name,
+                )))
+            }
         };
 
-        let query = serde_json::to_string(&GraphQLQuery{query: query, variables: request.variables}).map_err(|_| ApiError::GitHubError(GitHubError::GraphQLUnserializable))?;
-        
-        let request = self.client
-            .post(GITHUB_GQL_API)
-            .header("User-Agent", "Rust/Plaid")
-            .header("Accept", "application/vnd.github.v3+json")
-            .header("Authorization", format!("token {}", self.config.token))
-            .header("Content-Type", "application/json; charset=utf-8")
-            .body(query.to_string());
+        let query = serde_json::to_string(&GraphQLQuery {
+            query: query,
+            variables: request.variables,
+        })
+        .map_err(|_| ApiError::GitHubError(GitHubError::GraphQLUnserializable))?;
 
-        match request.send().await {
-            Ok(r) => if r.status() == 200 {
-                Ok(r.text().await.unwrap_or_default())
-            } else {
-                let status = r.status();
-                println!("{}", r.text().await.unwrap());
-                Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(status.as_u16())))
-            },
-            Err(e) => Err(ApiError::NetworkError(e)),
-        }
+        self.make_gql_request(query, module).await
     }
 
-    pub async fn make_advanced_graphql_query(&self, request: &str, _: &str) -> Result<String, ApiError> {
-        let request: AdvancedRequest = serde_json::from_str(request).map_err(|_| ApiError::BadRequest)?;
+    pub async fn make_advanced_graphql_query(
+        &self,
+        request: &str,
+        module: &str,
+    ) -> Result<String, ApiError> {
+        let request: AdvancedRequest =
+            serde_json::from_str(request).map_err(|_| ApiError::BadRequest)?;
 
         let query = match self.config.graphql_queries.get(&request.query_name) {
             Some(query) => query.to_owned(),
-            None => return Err(ApiError::GitHubError(GitHubError::GraphQLQueryUnknown(request.query_name))),
+            None => {
+                return Err(ApiError::GitHubError(GitHubError::GraphQLQueryUnknown(
+                    request.query_name,
+                )))
+            }
         };
 
-        let query = serde_json::to_string(&AdvancedGraphQLQuery{query: query, variables: request.variables}).map_err(|_| ApiError::GitHubError(GitHubError::GraphQLUnserializable))?;
-        
-        let request = self.client
-            .post(GITHUB_GQL_API)
-            .header("User-Agent", "Rust/Plaid")
-            .header("Accept", "application/vnd.github.v3+json")
-            .header("Authorization", format!("token {}", self.config.token))
-            .header("Content-Type", "application/json; charset=utf-8")
-            .body(query.to_string());
+        let query = serde_json::to_string(&AdvancedGraphQLQuery {
+            query: query,
+            variables: request.variables,
+        })
+        .map_err(|_| ApiError::GitHubError(GitHubError::GraphQLUnserializable))?;
 
-        match request.send().await {
-            Ok(r) => if r.status() == 200 {
-                Ok(r.text().await.unwrap_or_default())
-            } else {
-                let status = r.status();
-                println!("{}", r.text().await.unwrap());
-                Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(status.as_u16())))
-            },
-            Err(e) => Err(ApiError::NetworkError(e)),
-        }
+        self.make_gql_request(query, module).await
     }
 }

--- a/plaid/src/apis/github/graphql.rs
+++ b/plaid/src/apis/github/graphql.rs
@@ -33,7 +33,11 @@ struct AdvancedRequest {
 const GITHUB_GQL_API: &str = "/graphql";
 
 impl Github {
-    async fn make_gql_request(&self, query: String, module: &str) -> Result<String, ApiError> {
+    async fn make_gql_request<T: Serialize>(
+        &self,
+        query: T,
+        module: &str,
+    ) -> Result<String, ApiError> {
         let request = self.client._post(GITHUB_GQL_API, Some(&query)).await;
 
         match request {
@@ -76,11 +80,10 @@ impl Github {
             }
         };
 
-        let query = serde_json::to_string(&GraphQLQuery {
+        let query = GraphQLQuery {
             query: query,
             variables: request.variables,
-        })
-        .map_err(|_| ApiError::GitHubError(GitHubError::GraphQLUnserializable))?;
+        };
 
         self.make_gql_request(query, module).await
     }
@@ -102,11 +105,10 @@ impl Github {
             }
         };
 
-        let query = serde_json::to_string(&AdvancedGraphQLQuery {
+        let query = AdvancedGraphQLQuery {
             query: query,
             variables: request.variables,
-        })
-        .map_err(|_| ApiError::GitHubError(GitHubError::GraphQLUnserializable))?;
+        };
 
         self.make_gql_request(query, module).await
     }

--- a/plaid/src/apis/github/mod.rs
+++ b/plaid/src/apis/github/mod.rs
@@ -1,22 +1,50 @@
 mod graphql;
 mod repos;
 mod teams;
+mod validators;
 
-use reqwest::Client;
+use http::{header::USER_AGENT, HeaderMap};
+use jsonwebtoken::EncodingKey;
+use octocrab::Octocrab;
 
 use serde::Deserialize;
 
-use std::{time::Duration, collections::HashMap};
+use std::collections::HashMap;
+
+use super::ApiError;
 
 #[derive(Deserialize)]
+#[serde(untagged)]
+pub enum Authentication {
+    /// If you provide a token then we will initialize the client using that
+    /// method of authentication. This is generally simpler to set up but less
+    /// secure and doesn't have access to all the same APIs (for example approving
+    /// finegrained or classic access tokens)
+    Token { token: String },
+    /// If you provide an app then we will initalize the system as a GitHub app
+    /// This is more secure but requires more setup and is more prone to specific API
+    /// failures if the app has not been granted permissions correctly.
+    App { app_id: u64, private_key: String },
+}
+
+#[derive(Deserialize)]
+/// The configuration structure that forms the API module to service
+/// requests from running Plaid modules.
 pub struct GithubConfig {
-    token: String,
+    /// The authentication method used when configuring the GitHub API module. More
+    /// methods may be added here in the future but one variant of the enum must be defined.
+    /// See the Authentication enum structure above for more details.
+    authentication: Authentication,
+    /// This is a map of GraphQL queries you are allowing rules to execute. These are
+    /// manually specified to reduce the risk of abuse by rules as they are very powerful
+    /// and hard to reason about in a generic way, especially at runtime.
     graphql_queries: HashMap<String, String>,
 }
 
 pub struct Github {
     config: GithubConfig,
-    client: Client,
+    client: Octocrab,
+    validators: HashMap<&'static str, regex::Regex>,
 }
 
 #[derive(Debug)]
@@ -24,18 +52,124 @@ pub enum GitHubError {
     GraphQLUnserializable,
     GraphQLQueryUnknown(String),
     GraphQLInvalidCharacters(String),
-    UnexpectedStatusCode(u16)
+    UnexpectedStatusCode(u16),
+    GraphQLRequestError(String),
+    ClientError(octocrab::Error),
+    InvalidInput(String),
 }
 
 impl Github {
     pub fn new(config: GithubConfig) -> Self {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(5))
-            .build().unwrap();
+        let client = match &config.authentication {
+            Authentication::Token { token } => Octocrab::builder().personal_token(token.clone()),
+            Authentication::App {
+                app_id,
+                private_key,
+            } => {
+                let encoding_key = EncodingKey::from_rsa_pem(private_key.as_bytes())
+                    .expect("Failed to create encoding key from private key for GitHub API");
+
+                Octocrab::builder().app((*app_id).into(), encoding_key)
+            }
+        }
+        .build()
+        .unwrap();
+
+        // Create all the validators and compile all the regexes. If the module contains
+        // any invalid regexes it will panic.
+        let validators = validators::create_validators();
 
         Self {
             config,
             client,
+            validators,
+        }
+    }
+
+    /// Make a generic get request to the GitHub API using the GitHub app library. This exists
+    /// to help facilitate the conversion from a token usage to GitHub app. It also means that
+    /// extra parsing can be avoided since we need to re-serialize anyway to pass back to the rules
+    /// (at least currently).
+    async fn make_generic_get_request(
+        &self,
+        uri: String,
+        module: &str,
+    ) -> Result<(u16, Result<String, ApiError>), ApiError> {
+        info!("Making a get request to {uri} on behalf of {module}");
+
+        // Create a header map to track the Plaid version in logs that are
+        // created by this request.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::ACCEPT,
+            "application/vnd.github.v3+json".parse().unwrap(),
+        );
+        let version = env!("CARGO_PKG_VERSION");
+        headers.insert(USER_AGENT, format!("Rust/Plaid{version}").parse().unwrap());
+
+        let request = self.client._get_with_headers(uri, Some(headers)).await;
+
+        match request {
+            Ok(r) => {
+                let status = r.status().as_u16();
+                let body = self.client.body_to_string(r).await.map_err(|e| {
+                    ApiError::GitHubError(GitHubError::GraphQLRequestError(e.to_string()))
+                });
+                Ok((status, body))
+            }
+            Err(e) => Err(ApiError::GitHubError(GitHubError::ClientError(e))),
+        }
+    }
+
+    /// Make a generic put request to the GitHub API using the GitHub app library. This exists
+    /// to help facilitate the conversion from a token usage to GitHub app. It also means that
+    /// extra parsing can be avoided since we need to re-serialize anyway to pass back to the rules
+    /// (at least currently).
+    async fn make_generic_put_request(
+        &self,
+        uri: String,
+        body: Option<&str>,
+        module: &str,
+    ) -> Result<(u16, Result<String, ApiError>), ApiError> {
+        info!("Making a put request to {uri} on behalf of {module}");
+
+        let request = self.client._put(uri, body).await;
+
+        match request {
+            Ok(r) => {
+                let status = r.status().as_u16();
+                let body = self.client.body_to_string(r).await.map_err(|e| {
+                    ApiError::GitHubError(GitHubError::GraphQLRequestError(e.to_string()))
+                });
+                Ok((status, body))
+            }
+            Err(e) => Err(ApiError::GitHubError(GitHubError::ClientError(e))),
+        }
+    }
+
+    /// Make a generic delete request to the GitHub API using the GitHub app library. This exists
+    /// to help facilitate the conversion from a token usage to GitHub app. It also means that
+    /// extra parsing can be avoided since we need to re-serialize anyway to pass back to the rules
+    /// (at least currently).
+    async fn make_generic_delete_request(
+        &self,
+        uri: String,
+        body: Option<&str>,
+        module: &str,
+    ) -> Result<(u16, Result<String, ApiError>), ApiError> {
+        info!("Making a put request to {uri} on behalf of {module}");
+
+        let request = self.client._delete(uri, body).await;
+
+        match request {
+            Ok(r) => {
+                let status = r.status().as_u16();
+                let body = self.client.body_to_string(r).await.map_err(|e| {
+                    ApiError::GitHubError(GitHubError::GraphQLRequestError(e.to_string()))
+                });
+                Ok((status, body))
+            }
+            Err(e) => Err(ApiError::GitHubError(GitHubError::ClientError(e))),
         }
     }
 }

--- a/plaid/src/apis/github/mod.rs
+++ b/plaid/src/apis/github/mod.rs
@@ -163,10 +163,10 @@ impl Github {
     /// to help facilitate the conversion from a token usage to GitHub app. It also means that
     /// extra parsing can be avoided since we need to re-serialize anyway to pass back to the rules
     /// (at least currently).
-    async fn make_generic_put_request(
+    async fn make_generic_put_request<T: Serialize>(
         &self,
         uri: String,
-        body: Option<&str>,
+        body: Option<&T>,
         module: &str,
     ) -> Result<(u16, Result<String, ApiError>), ApiError> {
         info!("Making a put request to {uri} on behalf of {module}");

--- a/plaid/src/apis/github/pats.rs
+++ b/plaid/src/apis/github/pats.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::apis::{github::GitHubError, ApiError};
+
+use super::Github;
+
+impl Github {
+    pub async fn list_fpat_requests_for_org(
+        &self,
+        params: &str,
+        module: &str,
+    ) -> Result<String, ApiError> {
+        let request: HashMap<&str, &str> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let org = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
+
+        info!("Fetching FPAT Requests For {org}");
+        let address = format!("/orgs/{org}/personal-access-token-requests");
+
+        match self.make_generic_get_request(address, module).await {
+            Ok((status, Ok(body))) => {
+                if status == 200 {
+                    Ok(body)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
+    }
+
+    pub async fn review_fpat_requests_for_org(
+        &self,
+        params: &str,
+        module: &str,
+    ) -> Result<u32, ApiError> {
+        #[derive(Deserialize, Serialize)]
+        struct Request {
+            #[serde(skip_serializing)]
+            org: String,
+            pat_request_ids: Vec<u64>,
+            action: String,
+            reason: String,
+        }
+        let request: Request = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        let org = self.validate_org(&request.org)?;
+
+        match request.action.as_str() {
+            "approve" => {
+                info!(
+                    "Approving FPATs {:?} Requests For {org} because: {}",
+                    request.pat_request_ids, request.reason,
+                );
+            }
+            "deny" => {
+                info!(
+                    "Denying FPATs {:?} Requests For {org} because: {}",
+                    request.pat_request_ids, request.reason,
+                );
+            }
+            _ => {
+                warn!(
+                    "{module} tried to respond to PAT requests with an invalid action: {}",
+                    request.action
+                );
+                return Err(ApiError::BadRequest);
+            }
+        }
+        let address = format!("/orgs/{org}/personal-access-token-requests");
+
+        match self
+            .make_generic_post_request(address, &request, &module)
+            .await
+        {
+            Ok((status, Ok(body))) => {
+                if status == 202 {
+                    Ok(0)
+                } else {
+                    warn!("{module} failed to review FPAT requests for {org}. Status Code: {status} Return was: {body}");
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/plaid/src/apis/github/repos.rs
+++ b/plaid/src/apis/github/repos.rs
@@ -5,107 +5,91 @@ use crate::apis::{github::GitHubError, ApiError};
 use super::Github;
 
 impl Github {
-    pub async fn remove_user_from_repo(&self, params: &str, _: &str) -> Result<u32, ApiError> {
+    pub async fn remove_user_from_repo(&self, params: &str, module: &str) -> Result<u32, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         // GitHub says this is only valid on Organization repositories. Not sure if it's ignored
         // on others? This may not work on standard accounts. Also, pull is the lowest permission level
-        let user = request.get("user").ok_or(ApiError::BadRequest)?;
-        let repo = request.get("repo").ok_or(ApiError::BadRequest)?;
+        let user = self.validate_username(request.get("user").ok_or(ApiError::BadRequest)?)?;
+        let repo =
+            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
 
-        println!("Removing user [{}] from [{}]", user, repo);
-        let address = format!(
-            "https://api.github.com/repos/{}/collaborators/{}",
-            repo, user
-        );
+        let address = format!("https://api.github.com/repos/{repo}/collaborators/{user}",);
+        info!("Removing user [{}] from [{}]", user, repo);
 
-        let request = self
-            .client
-            .delete(address)
-            .header("User-Agent", "Rust/Plaid")
-            .header("Accept", "application/vnd.github.v3+json")
-            .header("Authorization", format!("token {}", self.config.token));
-
-        match request.send().await {
-            Ok(r) => {
-                if r.status() == 204 {
+        match self.make_generic_get_request(address, module).await {
+            Ok((status, _)) => {
+                if status == 204 {
                     Ok(0)
                 } else {
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
-                        r.status().as_u16(),
+                        status,
                     )))
                 }
             }
-            Err(e) => Err(ApiError::NetworkError(e)),
+            Err(e) => Err(e),
         }
     }
 
-    pub async fn add_user_to_repo(&self, params: &str, _: &str) -> Result<u32, ApiError> {
+    pub async fn add_user_to_repo(&self, params: &str, module: &str) -> Result<u32, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         // GitHub says this is only valid on Organization repositories. Not sure if it's ignored
         // on others? This may not work on standard accounts. Also, pull is the lowest permission level
-        let user = request.get("user").ok_or(ApiError::BadRequest)?;
-        let repo = request.get("repo").ok_or(ApiError::BadRequest)?;
+        let user = self.validate_username(request.get("user").ok_or(ApiError::BadRequest)?)?;
+        let repo =
+            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
         let permission = request.get("permission").unwrap_or(&"pull");
 
-        println!("Adding user [{user}] to [{repo}] with permission [{permission}]");
+        info!("Adding user [{user}] to [{repo}] with permission [{permission}]");
         let address = format!("https://api.github.com/repos/{repo}/collaborators/{user}");
 
-        let request = self
-            .client
-            .put(address)
-            .header("User-Agent", "Rust/Plaid")
-            .header("Accept", "application/vnd.github.v3+json")
-            .header("Authorization", format!("token {}", self.config.token))
-            .body(format!("{{\"permission\": \"{permission}\"}}"));
+        let permission = format!("{{\"permission\": \"{permission}\"}}");
 
-        match request.send().await {
-            Ok(r) => {
-                if r.status() == 204 {
+        match self
+            .make_generic_put_request(address, Some(&permission), module)
+            .await
+        {
+            Ok((status, _)) => {
+                if status == 204 {
                     Ok(0)
                 } else {
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
-                        r.status().as_u16(),
+                        status,
                     )))
                 }
             }
-            Err(e) => Err(ApiError::NetworkError(e)),
+            Err(e) => Err(e),
         }
     }
 
-    pub async fn fetch_commit(&self, params: &str, _: &str) -> Result<String, ApiError> {
+    pub async fn fetch_commit(&self, params: &str, module: &str) -> Result<String, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let user = request.get("user").ok_or(ApiError::BadRequest)?;
-        let repo = request.get("repo").ok_or(ApiError::BadRequest)?;
-        let commit = request.get("commit").ok_or(ApiError::BadRequest)?;
+        let user = self.validate_username(request.get("user").ok_or(ApiError::BadRequest)?)?;
+        let repo =
+            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
+        let commit =
+            self.validate_commit_hash(request.get("commit").ok_or(ApiError::BadRequest)?)?;
 
-        let address = format!(" https://api.github.com/repos/{user}/{repo}/commits/{commit}");
+        info!("Fetching commit [{commit}] from [{repo}] by [{user}]");
+        let address = format!("https://api.github.com/repos/{user}/{repo}/commits/{commit}");
 
-        let request = self
-            .client
-            .get(address)
-            .header("User-Agent", "Rust/Plaid")
-            .header("Accept", "application/vnd.github+json")
-            .header("Authorization", format!("token {}", self.config.token));
-
-        match request.send().await {
-            Ok(r) => {
-                if r.status() == 200 {
-                    Ok(r.text().await.unwrap_or_default())
+        match self.make_generic_get_request(address, module).await {
+            Ok((status, Ok(body))) => {
+                if status == 200 {
+                    Ok(body)
                 } else {
-                    let status = r.status();
-                    println!("{}", r.text().await.unwrap());
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
-                        status.as_u16(),
+                        status,
                     )))
                 }
             }
-            Err(e) => Err(ApiError::NetworkError(e)),
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
         }
     }
 }

--- a/plaid/src/apis/github/repos.rs
+++ b/plaid/src/apis/github/repos.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use serde::Serialize;
+
 use crate::apis::{github::GitHubError, ApiError};
 
 use super::Github;
@@ -49,7 +51,14 @@ impl Github {
         info!("Adding user [{user}] to [{repo}] with permission [{permission}]");
         let address = format!("/repos/{repo}/collaborators/{user}");
 
-        let permission = format!("{{\"permission\": \"{permission}\"}}");
+        #[derive(Serialize)]
+        struct Permission {
+            permission: String,
+        }
+
+        let permission = Permission {
+            permission: permission.to_string(),
+        };
 
         match self
             .make_generic_put_request(address, Some(&permission), module)

--- a/plaid/src/apis/github/repos.rs
+++ b/plaid/src/apis/github/repos.rs
@@ -15,10 +15,13 @@ impl Github {
         let repo =
             self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
 
-        let address = format!("https://api.github.com/repos/{repo}/collaborators/{user}",);
+        let address = format!("/repos/{repo}/collaborators/{user}",);
         info!("Removing user [{}] from [{}]", user, repo);
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_delete_request(address, None, module)
+            .await
+        {
             Ok((status, _)) => {
                 if status == 204 {
                     Ok(0)
@@ -44,7 +47,7 @@ impl Github {
         let permission = request.get("permission").unwrap_or(&"pull");
 
         info!("Adding user [{user}] to [{repo}] with permission [{permission}]");
-        let address = format!("https://api.github.com/repos/{repo}/collaborators/{user}");
+        let address = format!("/repos/{repo}/collaborators/{user}");
 
         let permission = format!("{{\"permission\": \"{permission}\"}}");
 
@@ -76,7 +79,7 @@ impl Github {
             self.validate_commit_hash(request.get("commit").ok_or(ApiError::BadRequest)?)?;
 
         info!("Fetching commit [{commit}] from [{repo}] by [{user}]");
-        let address = format!("https://api.github.com/repos/{user}/{repo}/commits/{commit}");
+        let address = format!("/repos/{user}/{repo}/commits/{commit}");
 
         match self.make_generic_get_request(address, module).await {
             Ok((status, Ok(body))) => {

--- a/plaid/src/apis/github/teams.rs
+++ b/plaid/src/apis/github/teams.rs
@@ -15,8 +15,7 @@ impl Github {
         let user = self.validate_username(request.get("user").ok_or(ApiError::BadRequest)?)?;
 
         info!("Removing user [{user}] from [{team_slug}] in [{org}]");
-        let address =
-            format!("https://api.github.com/orgs/{org}/teams/{team_slug}/memberships/{user}");
+        let address = format!("/orgs/{org}/teams/{team_slug}/memberships/{user}");
 
         match self
             .make_generic_delete_request(address, None, module)
@@ -49,8 +48,7 @@ impl Github {
         let role = format!("{{\"role\": \"{role}\"}}");
 
         info!("Adding user [{user}] to [{team_slug}] in [{org}] as [{role}]");
-        let address =
-            format!("https://api.github.com/orgs/{org}/teams/{team_slug}/memberships/{user}");
+        let address = format!("/orgs/{org}/teams/{team_slug}/memberships/{user}");
 
         match self
             .make_generic_put_request(address, Some(&role), module)

--- a/plaid/src/apis/github/teams.rs
+++ b/plaid/src/apis/github/teams.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use serde::Serialize;
+
 use super::Github;
 use crate::apis::{github::GitHubError, ApiError};
 
@@ -45,9 +47,17 @@ impl Github {
         let user = self.validate_username(request.get("user").ok_or(ApiError::BadRequest)?)?;
 
         let role = request.get("role").ok_or(ApiError::BadRequest)?;
-        let role = format!("{{\"role\": \"{role}\"}}");
 
         info!("Adding user [{user}] to [{team_slug}] in [{org}] as [{role}]");
+        #[derive(Serialize)]
+        struct Role {
+            role: String,
+        }
+
+        let role = Role {
+            role: role.to_string(),
+        };
+
         let address = format!("/orgs/{org}/teams/{team_slug}/memberships/{user}");
 
         match self

--- a/plaid/src/apis/github/validators.rs
+++ b/plaid/src/apis/github/validators.rs
@@ -41,7 +41,7 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
     let mut validators = HashMap::new();
 
     // This should be the same as GitHub's actual validation.
-    define_regex_validator!(validators, "repository_name", r"^[\w\-\.]+$");
+    define_regex_validator!(validators, "repository_name", r"^[\w\-\./]+$");
 
     // This is less strict than GitHub's actual requirements but it's good enough
     // to ensure safety.

--- a/plaid/src/apis/github/validators.rs
+++ b/plaid/src/apis/github/validators.rs
@@ -1,0 +1,67 @@
+use std::collections::HashMap;
+
+use crate::apis::ApiError;
+
+use super::{GitHubError, Github};
+
+// new_regex_validator!("REPOSITORY_NAME", "^[\w\-\.]+$");
+
+macro_rules! define_regex_validator {
+    ($validators:expr,$validator:tt,$regex: tt) => {
+        $validators.insert(
+            $validator,
+            regex::Regex::new($regex)
+                .expect(format!("Failed to create {} validator", stringify!($validator)).as_str()),
+        );
+    };
+}
+
+macro_rules! create_regex_validator_func {
+    ($validator:ident) => {
+        paste::item! {
+            impl Github {
+                pub fn [< validate_ $validator>]<'a> (&self, value_to_validate: &'a str) -> Result<&'a str, ApiError> {
+                    let validator = if let Some(validator) = self.validators.get(stringify!($validator)) {
+                        validator
+                    } else {
+                        error!("Validator {} not found in GitHub API. This should be impossible.", stringify!($validator));
+                        return Err(ApiError::ImpossibleError);
+                    };
+
+                    validator.is_match(value_to_validate)
+                        .then(|| value_to_validate)
+                        .ok_or(ApiError::GitHubError(GitHubError::InvalidInput(value_to_validate.to_string())))
+                }
+            }
+        }
+    }
+}
+
+pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
+    let mut validators = HashMap::new();
+
+    // This should be the same as GitHub's actual validation.
+    define_regex_validator!(validators, "repository_name", r"^[\w\-\.]+$");
+
+    // This is less strict than GitHub's actual requirements but it's good enough
+    // to ensure safety.
+    define_regex_validator!(validators, "username", r"^[\w\-]+$");
+
+    // We assume that orgs follow the same rules as users
+    define_regex_validator!(validators, "org", r"^[\w\-]+$");
+
+    // This technically allows team slugs with underscores even though GitHub doesn't
+    // allow that. However for our purposes of safety this should be fine.
+    define_regex_validator!(validators, "team_slug", r"^[\w\-]+$");
+
+    // This validates a SHA-1 hash which is what all commit hashes are.
+    define_regex_validator!(validators, "commit_hash", r"^\b([a-f0-9]{40})\b$");
+
+    validators
+}
+
+create_regex_validator_func!(repository_name);
+create_regex_validator_func!(username);
+create_regex_validator_func!(org);
+create_regex_validator_func!(team_slug);
+create_regex_validator_func!(commit_hash);

--- a/plaid/src/apis/github/validators.rs
+++ b/plaid/src/apis/github/validators.rs
@@ -57,6 +57,9 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
     // This validates a SHA-1 hash which is what all commit hashes are.
     define_regex_validator!(validators, "commit_hash", r"^\b([a-f0-9]{40})\b$");
 
+    // This validates a postive integer
+    define_regex_validator!(validators, "pint", r"^\d+$");
+
     validators
 }
 
@@ -65,3 +68,4 @@ create_regex_validator_func!(username);
 create_regex_validator_func!(org);
 create_regex_validator_func!(team_slug);
 create_regex_validator_func!(commit_hash);
+create_regex_validator_func!(pint);

--- a/plaid/src/apis/mod.rs
+++ b/plaid/src/apis/mod.rs
@@ -58,6 +58,7 @@ pub struct Apis {
 #[derive(Debug)]
 pub enum ApiError {
     BadRequest,
+    ImpossibleError,
     ConfigurationError(String),
     MissingParameter(String),
 

--- a/plaid/src/config.rs
+++ b/plaid/src/config.rs
@@ -165,9 +165,11 @@ where
         "facebook" | "meta" => ResponseMode::Facebook(data.to_owned()),
         "Rule" | "rule" => ResponseMode::Rule(data.to_owned()),
         "Static" | "static" => ResponseMode::Static(data.to_owned()),
-        x => return Err(serde::de::Error::custom(
-            format!("{x} is an unknown response_mode. Must be 'facebook', 'rule', or 'static'"),
-        )),
+        x => {
+            return Err(serde::de::Error::custom(format!(
+                "{x} is an unknown response_mode. Must be 'facebook', 'rule', or 'static'"
+            )))
+        }
     })
 }
 pub async fn configure() -> Result<Configuration, ConfigurationError> {

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -144,6 +144,10 @@ impl_new_function_with_error_buffer!(github, make_graphql_query);
 impl_new_function_with_error_buffer!(github, make_advanced_graphql_query);
 impl_new_function_with_error_buffer!(github, fetch_commit);
 
+// GitHub Functions only available with GitHub App authentication
+impl_new_function!(github, review_fpat_requests_for_org);
+impl_new_function_with_error_buffer!(github, list_fpat_requests_for_org);
+
 // Okta Functions
 impl_new_function!(okta, remove_user_from_group);
 impl_new_function_with_error_buffer!(okta, get_user_data);
@@ -240,7 +244,12 @@ pub fn to_api_function(
         "github_fetch_commit" => {
             Function::new_typed_with_env(&mut store, &env, github_fetch_commit)
         }
-
+        "github_list_fpat_requests_for_org" => {
+            Function::new_typed_with_env(&mut store, &env, github_list_fpat_requests_for_org)
+        }
+        "github_review_fpat_requests_for_org" => {
+            Function::new_typed_with_env(&mut store, &env, github_review_fpat_requests_for_org)
+        }
         // Slack Calls
         "slack_post_to_named_webhook" => {
             Function::new_typed_with_env(&mut store, &env, slack_post_to_named_webhook)

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -147,6 +147,7 @@ impl_new_function_with_error_buffer!(github, fetch_commit);
 // GitHub Functions only available with GitHub App authentication
 impl_new_function!(github, review_fpat_requests_for_org);
 impl_new_function_with_error_buffer!(github, list_fpat_requests_for_org);
+impl_new_function_with_error_buffer!(github, get_repos_for_fpat);
 
 // Okta Functions
 impl_new_function!(okta, remove_user_from_group);
@@ -249,6 +250,9 @@ pub fn to_api_function(
         }
         "github_review_fpat_requests_for_org" => {
             Function::new_typed_with_env(&mut store, &env, github_review_fpat_requests_for_org)
+        }
+        "github_get_repos_for_fpat" => {
+            Function::new_typed_with_env(&mut store, &env, github_get_repos_for_fpat)
         }
         // Slack Calls
         "slack_post_to_named_webhook" => {

--- a/plaid/src/loader/mod.rs
+++ b/plaid/src/loader/mod.rs
@@ -4,8 +4,8 @@ use limits::LimitingTunables;
 
 use lru::LruCache;
 use serde::Deserialize;
+use wasmer::{sys::BaseTunables, Engine, NativeEngineExt, Pages, Target};
 use wasmer::{wasmparser::Operator, CompilerConfig, Cranelift, Module};
-use wasmer::{BaseTunables, Engine, NativeEngineExt, Pages, Target};
 
 use wasmer_middlewares::Metering;
 
@@ -79,9 +79,7 @@ impl PlaidModules {
 
 const CALL_COST: u64 = 10;
 
-pub fn load(
-    config: Configuration,
-) -> Result<PlaidModules, ()> {
+pub fn load(config: Configuration) -> Result<PlaidModules, ()> {
     let module_paths = fs::read_dir(config.module_dir).unwrap();
 
     let mut modules = PlaidModules::default();
@@ -206,7 +204,7 @@ pub fn load(
         let mut module = Module::new(&engine, module_bytes).unwrap();
         module.set_name(&filename);
         for import in module.imports() {
-           info!("\tImport: {}", import.name());
+            info!("\tImport: {}", import.name());
         }
 
         let plaid_module = PlaidModule {

--- a/plaid/src/storage/sled/mod.rs
+++ b/plaid/src/storage/sled/mod.rs
@@ -18,7 +18,7 @@ pub struct Sled {
 impl Sled {
     pub fn new(config: Config) -> Result<Self, StorageError> {
         let db: sled::Db = sled::open(&config.path)
-            .map_err(|_| StorageError::CouldNotAccessStorage(config.path.clone()))?;
+            .map_err(|e| StorageError::CouldNotAccessStorage(e.to_string()))?;
         Ok(Self { db })
     }
 }


### PR DESCRIPTION
There are some APIs that are only available to GitHub apps (FPATs). This adds a new configuration method so that Plaid can make GitHub rest calls as a GitHub app to access these APIs.

We continue to support the only PAT configuration method but App specific APIs will fail if used.