### PR TITLE
Okta tailer 

### DIFF
--- a/plaid/resources/plaid.toml
+++ b/plaid/resources/plaid.toml
@@ -15,6 +15,7 @@ path = "/tmp/sled"
 [loading]
 module_dir = "modules"
 lru_cache_size = 200
+[loading.persistent_response_size]
 
 [loading.secrets]
 [loading.secrets."testing"]

--- a/plaid/src/apis/general/mod.rs
+++ b/plaid/src/apis/general/mod.rs
@@ -12,14 +12,15 @@ use std::time::Duration;
 
 use crate::{data::DelayedMessage, executor::Message};
 
-use super::DEFAULT_TIMEOUT_SECONDS;
+use super::default_timeout_seconds;
 
 #[derive(Deserialize)]
 pub struct GeneralConfig {
     network: network::Config,
     /// The number of seconds until an external API request times out.
-    /// If `None`, the `DEFAULT_TIMEOUT_SECONDS` will be used.
-    api_timeout_seconds: Option<u64>,
+    /// If no value is provided, the result of `default_timeout_seconds()` will be used.
+    #[serde(default = "default_timeout_seconds")]
+    api_timeout_seconds: u64,
 }
 
 pub struct General {
@@ -36,11 +37,8 @@ impl General {
         log_sender: Sender<Message>,
         delayed_log_sender: Sender<DelayedMessage>,
     ) -> Self {
-        let timeout_seconds = config
-            .api_timeout_seconds
-            .unwrap_or(DEFAULT_TIMEOUT_SECONDS);
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(timeout_seconds))
+            .timeout(Duration::from_secs(config.api_timeout_seconds))
             .build()
             .unwrap();
 

--- a/plaid/src/apis/general/mod.rs
+++ b/plaid/src/apis/general/mod.rs
@@ -12,9 +12,14 @@ use std::time::Duration;
 
 use crate::{data::DelayedMessage, executor::Message};
 
+use super::DEFAULT_TIMEOUT_SECONDS;
+
 #[derive(Deserialize)]
 pub struct GeneralConfig {
     network: network::Config,
+    /// The number of seconds until an external API request times out.
+    /// If `None`, the `DEFAULT_TIMEOUT_SECONDS` will be used.
+    api_timeout_seconds: Option<u64>,
 }
 
 pub struct General {
@@ -31,8 +36,11 @@ impl General {
         log_sender: Sender<Message>,
         delayed_log_sender: Sender<DelayedMessage>,
     ) -> Self {
+        let timeout_seconds = config
+            .api_timeout_seconds
+            .unwrap_or(DEFAULT_TIMEOUT_SECONDS);
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(timeout_seconds))
             .build()
             .unwrap();
 

--- a/plaid/src/apis/mod.rs
+++ b/plaid/src/apis/mod.rs
@@ -27,6 +27,8 @@ use crate::{data::DelayedMessage, executor::Message};
 
 use self::rustica::{Rustica, RusticaConfig};
 
+const DEFAULT_TIMEOUT_SECONDS: u64 = 5;
+
 pub struct Api {
     pub runtime: Runtime,
     pub general: Option<General>,

--- a/plaid/src/apis/mod.rs
+++ b/plaid/src/apis/mod.rs
@@ -27,8 +27,6 @@ use crate::{data::DelayedMessage, executor::Message};
 
 use self::rustica::{Rustica, RusticaConfig};
 
-const DEFAULT_TIMEOUT_SECONDS: u64 = 5;
-
 pub struct Api {
     pub runtime: Runtime,
     pub general: Option<General>,
@@ -149,4 +147,11 @@ impl Api {
             web,
         }
     }
+}
+
+/// This function provides the default timeout value in seconds.
+/// It is used as the default value for deserialization of various API configs,
+/// in the event that no value is provided.
+fn default_timeout_seconds() -> u64 {
+    5
 }

--- a/plaid/src/apis/okta/mod.rs
+++ b/plaid/src/apis/okta/mod.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 
 use std::{string::FromUtf8Error, time::Duration};
 
-use super::DEFAULT_TIMEOUT_SECONDS;
+use super::default_timeout_seconds;
 
 #[derive(Deserialize)]
 pub struct OktaConfig {
@@ -15,7 +15,10 @@ pub struct OktaConfig {
     pub domain: String,
     /// The permissioned API key to get user information
     pub token: String,
-    api_timeout_seconds: Option<u64>,
+    /// The number of seconds until an external API request times out.
+    /// If no value is provided, the result of `default_timeout_seconds()` will be used.
+    #[serde(default = "default_timeout_seconds")]
+    api_timeout_seconds: u64,
 }
 
 pub struct Okta {
@@ -31,11 +34,8 @@ pub enum OktaError {
 
 impl Okta {
     pub fn new(config: OktaConfig) -> Self {
-        let timeout_seconds = config
-            .api_timeout_seconds
-            .unwrap_or(DEFAULT_TIMEOUT_SECONDS);
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(timeout_seconds))
+            .timeout(Duration::from_secs(config.api_timeout_seconds))
             .build()
             .unwrap();
 

--- a/plaid/src/apis/okta/mod.rs
+++ b/plaid/src/apis/okta/mod.rs
@@ -5,7 +5,9 @@ use reqwest::Client;
 
 use serde::Deserialize;
 
-use std::{time::Duration, string::FromUtf8Error};
+use std::{string::FromUtf8Error, time::Duration};
+
+use super::DEFAULT_TIMEOUT_SECONDS;
 
 #[derive(Deserialize)]
 pub struct OktaConfig {
@@ -13,6 +15,7 @@ pub struct OktaConfig {
     pub domain: String,
     /// The permissioned API key to get user information
     pub token: String,
+    api_timeout_seconds: Option<u64>,
 }
 
 pub struct Okta {
@@ -28,13 +31,14 @@ pub enum OktaError {
 
 impl Okta {
     pub fn new(config: OktaConfig) -> Self {
+        let timeout_seconds = config
+            .api_timeout_seconds
+            .unwrap_or(DEFAULT_TIMEOUT_SECONDS);
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(5))
-            .build().unwrap();
+            .timeout(Duration::from_secs(timeout_seconds))
+            .build()
+            .unwrap();
 
-        Self {
-            config,
-            client,
-        }
+        Self { config, client }
     }
 }

--- a/plaid/src/apis/pagerduty/mod.rs
+++ b/plaid/src/apis/pagerduty/mod.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 
 use std::{collections::HashMap, time::Duration};
 
-use super::DEFAULT_TIMEOUT_SECONDS;
+use super::default_timeout_seconds;
 
 mod trigger;
 
@@ -14,8 +14,9 @@ pub struct PagerDutyConfig {
     /// same service
     services: HashMap<String, String>,
     /// The number of seconds until an external API request times out.
-    /// If `None`, the `DEFAULT_TIMEOUT_SECONDS` will be used.
-    api_timeout_seconds: Option<u64>,
+    /// If no value is provided, the result of `default_timeout_seconds()` will be used.
+    #[serde(default = "default_timeout_seconds")]
+    api_timeout_seconds: u64,
 }
 
 pub struct PagerDuty {
@@ -30,11 +31,8 @@ pub enum PagerDutyError {
 
 impl PagerDuty {
     pub fn new(config: PagerDutyConfig) -> Self {
-        let timeout_seconds = config
-            .api_timeout_seconds
-            .unwrap_or(DEFAULT_TIMEOUT_SECONDS);
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(timeout_seconds))
+            .timeout(Duration::from_secs(config.api_timeout_seconds))
             .build()
             .unwrap();
 

--- a/plaid/src/apis/pagerduty/mod.rs
+++ b/plaid/src/apis/pagerduty/mod.rs
@@ -1,7 +1,9 @@
 use reqwest::Client;
-use serde::{Deserialize};
+use serde::Deserialize;
 
 use std::{collections::HashMap, time::Duration};
+
+use super::DEFAULT_TIMEOUT_SECONDS;
 
 mod trigger;
 
@@ -11,8 +13,10 @@ pub struct PagerDutyConfig {
     /// the integration key relevant to creating an incident in PagerDuty under that
     /// same service
     services: HashMap<String, String>,
+    /// The number of seconds until an external API request times out.
+    /// If `None`, the `DEFAULT_TIMEOUT_SECONDS` will be used.
+    api_timeout_seconds: Option<u64>,
 }
-
 
 pub struct PagerDuty {
     config: PagerDutyConfig,
@@ -21,18 +25,19 @@ pub struct PagerDuty {
 
 #[derive(Debug)]
 pub enum PagerDutyError {
-    NetworkError(reqwest::Error)
+    NetworkError(reqwest::Error),
 }
 
 impl PagerDuty {
     pub fn new(config: PagerDutyConfig) -> Self {
+        let timeout_seconds = config
+            .api_timeout_seconds
+            .unwrap_or(DEFAULT_TIMEOUT_SECONDS);
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(5))
-            .build().unwrap();
+            .timeout(Duration::from_secs(timeout_seconds))
+            .build()
+            .unwrap();
 
-        Self {
-            config,
-            client,
-        }
+        Self { config, client }
     }
 }

--- a/plaid/src/apis/slack/mod.rs
+++ b/plaid/src/apis/slack/mod.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use std::collections::HashMap;
 
-use super::DEFAULT_TIMEOUT_SECONDS;
+use super::default_timeout_seconds;
 
 #[derive(Deserialize)]
 pub struct SlackConfig {
@@ -20,8 +20,9 @@ pub struct SlackConfig {
     /// be used in various Slack API calls
     bot_tokens: HashMap<String, String>,
     /// The number of seconds until an external API request times out.
-    /// If `None`, the `DEFAULT_TIMEOUT_SECONDS` will be used.
-    api_timeout_seconds: Option<u64>,
+    /// If no value is provided, the result of `default_timeout_seconds()` will be used.
+    #[serde(default = "default_timeout_seconds")]
+    api_timeout_seconds: u64,
 }
 
 pub struct Slack {
@@ -38,11 +39,8 @@ pub enum SlackError {
 
 impl Slack {
     pub fn new(config: SlackConfig) -> Self {
-        let timeout_seconds = config
-            .api_timeout_seconds
-            .unwrap_or(DEFAULT_TIMEOUT_SECONDS);
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(timeout_seconds))
+            .timeout(Duration::from_secs(config.api_timeout_seconds))
             .build()
             .unwrap();
 

--- a/plaid/src/apis/slack/mod.rs
+++ b/plaid/src/apis/slack/mod.rs
@@ -9,15 +9,19 @@ use std::time::Duration;
 
 use std::collections::HashMap;
 
+use super::DEFAULT_TIMEOUT_SECONDS;
+
 #[derive(Deserialize)]
 pub struct SlackConfig {
     /// This contains the mapping of preconfigured webhooks modules
     /// are permitted to use
     webhooks: HashMap<String, String>,
-
     /// This contains the mapping of preconfigured bot tokens that can
     /// be used in various Slack API calls
     bot_tokens: HashMap<String, String>,
+    /// The number of seconds until an external API request times out.
+    /// If `None`, the `DEFAULT_TIMEOUT_SECONDS` will be used.
+    api_timeout_seconds: Option<u64>,
 }
 
 pub struct Slack {
@@ -34,8 +38,11 @@ pub enum SlackError {
 
 impl Slack {
     pub fn new(config: SlackConfig) -> Self {
+        let timeout_seconds = config
+            .api_timeout_seconds
+            .unwrap_or(DEFAULT_TIMEOUT_SECONDS);
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(timeout_seconds))
             .build()
             .unwrap();
 

--- a/plaid/src/apis/splunk/mod.rs
+++ b/plaid/src/apis/splunk/mod.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use std::collections::HashMap;
 
-use super::{ApiError, DEFAULT_TIMEOUT_SECONDS};
+use super::{default_timeout_seconds, ApiError};
 
 #[derive(Deserialize)]
 pub struct SplunkConfig {
@@ -16,8 +16,9 @@ pub struct SplunkConfig {
     /// names
     hec_tokens: HashMap<String, String>,
     /// The number of seconds until an external API request times out.
-    /// If `None`, the `DEFAULT_TIMEOUT_SECONDS` will be used.
-    api_timeout_seconds: Option<u64>,
+    /// If no value is provided, the result of `default_timeout_seconds()` will be used.
+    #[serde(default = "default_timeout_seconds")]
+    api_timeout_seconds: u64,
 }
 
 pub struct Splunk {
@@ -38,11 +39,8 @@ pub enum SplunkError {
 
 impl Splunk {
     pub fn new(config: SplunkConfig) -> Self {
-        let timeout_seconds = config
-            .api_timeout_seconds
-            .unwrap_or(DEFAULT_TIMEOUT_SECONDS);
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(timeout_seconds))
+            .timeout(Duration::from_secs(config.api_timeout_seconds))
             .build()
             .unwrap();
 

--- a/plaid/src/apis/splunk/mod.rs
+++ b/plaid/src/apis/splunk/mod.rs
@@ -6,16 +6,18 @@ use std::time::Duration;
 
 use std::collections::HashMap;
 
-use super::ApiError;
+use super::{ApiError, DEFAULT_TIMEOUT_SECONDS};
 
 #[derive(Deserialize)]
 pub struct SplunkConfig {
     /// The is endpoint to which logs should be sent
     endpoint: String,
-
     /// This contains a mapping of HEC bearer tokens to service
     /// names
     hec_tokens: HashMap<String, String>,
+    /// The number of seconds until an external API request times out.
+    /// If `None`, the `DEFAULT_TIMEOUT_SECONDS` will be used.
+    api_timeout_seconds: Option<u64>,
 }
 
 pub struct Splunk {
@@ -36,8 +38,11 @@ pub enum SplunkError {
 
 impl Splunk {
     pub fn new(config: SplunkConfig) -> Self {
+        let timeout_seconds = config
+            .api_timeout_seconds
+            .unwrap_or(DEFAULT_TIMEOUT_SECONDS);
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(timeout_seconds))
             .build()
             .unwrap();
 
@@ -47,15 +52,29 @@ impl Splunk {
     /// Make a post to a preconfigured slack webhook. This should be preferred
     /// over the arbitrary API call
     pub async fn post_hec(&self, params: &str, module: &str) -> Result<u32, ApiError> {
-        let request: HashMap<String, String> = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        let request: HashMap<String, String> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let hec_name = request.get("hec_name").ok_or(ApiError::MissingParameter("hec_name".to_string()))?.to_string();
-        let log = request.get("log").ok_or(ApiError::MissingParameter("log".to_string()))?.to_string();
-        let token = self.config.hec_tokens.get(&hec_name).ok_or(ApiError::SplunkError(SplunkError::UnknownHec(hec_name.clone())))?;
+        let hec_name = request
+            .get("hec_name")
+            .ok_or(ApiError::MissingParameter("hec_name".to_string()))?
+            .to_string();
+        let log = request
+            .get("log")
+            .ok_or(ApiError::MissingParameter("log".to_string()))?
+            .to_string();
+        let token = self
+            .config
+            .hec_tokens
+            .get(&hec_name)
+            .ok_or(ApiError::SplunkError(SplunkError::UnknownHec(
+                hec_name.clone(),
+            )))?;
 
-        let event: serde_json::Value = serde_json::from_str(&log).map_err(|_| ApiError::BadRequest)?;
-        
-        let splunk_log = SplunkLog{event};
+        let event: serde_json::Value =
+            serde_json::from_str(&log).map_err(|_| ApiError::BadRequest)?;
+
+        let splunk_log = SplunkLog { event };
 
         let body = serde_json::to_string(&splunk_log).map_err(|_| ApiError::BadRequest)?;
 
@@ -67,15 +86,19 @@ impl Splunk {
             .header("Content-Type", "application/json; charset=utf-8")
             .header("Authorization", format!("Splunk {token}"))
             .body(body)
-            .send().await {
+            .send()
+            .await
+        {
             Ok(r) => {
                 let status = r.status();
                 if status == 200 {
                     Ok(0)
                 } else {
-                    Err(ApiError::SplunkError(SplunkError::UnexpectedStatusCode(status.as_u16())))
+                    Err(ApiError::SplunkError(SplunkError::UnexpectedStatusCode(
+                        status.as_u16(),
+                    )))
                 }
-            },
+            }
             Err(e) => Err(ApiError::NetworkError(e)),
         }
     }

--- a/plaid/src/apis/yubikey/mod.rs
+++ b/plaid/src/apis/yubikey/mod.rs
@@ -11,7 +11,7 @@ use ring::{
     rand::SystemRandom,
 };
 
-use super::DEFAULT_TIMEOUT_SECONDS;
+use super::default_timeout_seconds;
 
 #[derive(Deserialize)]
 pub struct YubikeyConfig {
@@ -20,8 +20,9 @@ pub struct YubikeyConfig {
     /// Secret key for the Yubico API service
     secret_key: String,
     /// The number of seconds until an external API request times out.
-    /// If `None`, the `DEFAULT_TIMEOUT_SECONDS` will be used.
-    api_timeout_seconds: Option<u64>,
+    /// If no value is provided, the result of `default_timeout_seconds()` will be used.
+    #[serde(default = "default_timeout_seconds")]
+    api_timeout_seconds: u64,
 }
 
 pub struct Yubikey {
@@ -51,11 +52,8 @@ pub enum YubikeyError {
 
 impl Yubikey {
     pub fn new(config: YubikeyConfig) -> Self {
-        let timeout_seconds = config
-            .api_timeout_seconds
-            .unwrap_or(DEFAULT_TIMEOUT_SECONDS);
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(timeout_seconds))
+            .timeout(Duration::from_secs(config.api_timeout_seconds))
             .build()
             .unwrap();
 

--- a/plaid/src/data/okta/mod.rs
+++ b/plaid/src/data/okta/mod.rs
@@ -36,10 +36,10 @@ where
         match limit {
             1..=1000 => Ok(Some(limit)),
             0 => Err(serde::de::Error::custom(
-                "Invalid splay value provided. Minimum limit is 1",
+                "Invalid limit value provided. Minimum limit is 1",
             )),
             _ => Err(serde::de::Error::custom(
-                "Invalid splay value provided. Maximum limit is 1000",
+                "Invalid limit value provided. Maximum limit is 1000",
             )),
         }
     } else {

--- a/plaid/src/data/okta/mod.rs
+++ b/plaid/src/data/okta/mod.rs
@@ -1,59 +1,78 @@
-use plaid_stl::messages::{Generator, LogSource, LogbacksAllowed};
-
-use crossbeam_channel::Sender;
-
-use reqwest::Client;
-
-use serde::{Deserialize, Serialize};
-
-use serde_json::Value;
-use time::{format_description::well_known::Rfc3339, OffsetDateTime};
-
-use std::time::Duration;
-
 use crate::executor::Message;
+use crossbeam_channel::Sender;
+use plaid_stl::messages::{Generator, LogSource, LogbacksAllowed};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::time::Duration;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 #[derive(Deserialize)]
 pub struct OktaConfig {
+    /// API token used to authenticate to Okta
     token: String,
+    /// Domain that API calls will be sent to
     domain: String,
     #[serde(default)]
     pub logbacks_allowed: LogbacksAllowed,
 }
 
 pub struct Okta {
+    /// A `reqwest` client to send API calls with
     client: Client,
+    /// Contains domain and token
     config: OktaConfig,
+    /// The most recent time we have polled Okta for new system logs. This value is used
+    /// to filter the response from the Okta API.
     since: OffsetDateTime,
+    /// Sending channel used to send logs into the execution system
     logger: Sender<Message>,
 }
 
 /// We try not to parse anything complicated since our job is just
 /// to pass it on.
+/// See https://developer.okta.com/docs/reference/api/system-log/#logevent-object for full docs
 #[derive(Deserialize, Serialize)]
 struct OktaLog {
+    /// Timestamp when the event is published
     published: String,
+    /// Describes the entity that performs an action
     actor: Value,
+    /// The client that requests an action
     client: Value,
+    /// Type of device that the client operates from (for example, Computer)
     device: Value,
+    /// The authentication data of an action
     #[serde(rename = "authenticationContext")]
     authentication_context: Value,
+    /// The display message for an event
     #[serde(rename = "displayMessage")]
     display_message: Value,
+    /// Type of event that is published
     #[serde(rename = "eventType")]
     event_type: Value,
+    /// The outcome of an action
     outcome: Value,
+    /// The security data of an action
     #[serde(rename = "securityContext")]
     security_context: Value,
+    /// Indicates how severe the event is: DEBUG, INFO, WARN, ERROR
     severity: Value,
+    /// The debug request data of an action
     #[serde(rename = "debugContext")]
     debug_context: Value,
+    /// Associated Events API Action
     #[serde(rename = "legacyEventType")]
     legacy_event_type: Value,
+    /// The transaction details of an action
     transaction: Value,
+    /// Unique identifier for an individual event
     uuid: Value,
+    /// Versioning indicator
     version: Value,
+    /// The request that initiates an action
     request: Value,
+    /// Zero or more targets of an action
     target: Value,
 }
 
@@ -64,26 +83,34 @@ impl Okta {
             .build()
             .unwrap();
 
-        let date = OffsetDateTime::now_utc();
-
         Self {
             client,
             config,
-            since: date,
+            since: OffsetDateTime::now_utc(),
             logger,
         }
     }
 
     pub async fn fetch_system_logs(&mut self) -> Result<(), ()> {
         // Start with the most recent logs
-        let mut newest_timestamp = None;
-        let mut oldest_timestamp = None;
+        let mut most_recent_log_seen = OffsetDateTime::UNIX_EPOCH;
 
         loop {
+            // Okta requires the query parameter to be in RFC3339 format. We attempt to format it here.
+            // On failure, we return and allow the data orchestrator to restart the loop
+            let since = match self.since.format(&Rfc3339) {
+                Ok(since) => since,
+                Err(e) => {
+                    error!("Failed to parse datetime to RFC3339 format. Error: {e}");
+                    return Ok(());
+                }
+            };
+
             let address = format!(
-                "https://{}/api/v1/logs?sortOrder=DESCENDING&since={:?}",
-                self.config.domain, self.since
+                "https://{}/api/v1/logs?sortOrder=DESCENDING&since={since}",
+                self.config.domain,
             );
+
             let response = self
                 .client
                 .get(address)
@@ -92,22 +119,40 @@ impl Okta {
                 .send()
                 .await
                 .map_err(|e| {
-                    println!("Could not get logs from Okta: {}", e);
+                    error!("Could not get logs from Okta: {e}");
                 })?;
 
-            let body = response
-                .text()
-                .await
-                .map_err(|e| println!("Could not get logs from Okta: {}", e))?;
-            let logs: Vec<OktaLog> = serde_json::from_str(body.as_str())
-                .map_err(|e| println!("Could not parse data from Okta: {}\n\n{}", e, body))?;
-
-            if logs.is_empty() {
-                info!("Okta returned no logs");
+            // Check the response status code
+            // If it's outside of the 2XX range, we log the error and exit the loop, allowing the
+            // data generator to handle a restart
+            if !response.status().is_success() {
+                let status = response.status();
+                let error_body = response.text().await.ok();
+                error!(
+                    "Call to Okta API failed with code: {status}. Error: {}",
+                    error_body.unwrap_or_default()
+                );
                 return Ok(());
             }
 
-            let mut counter = 0;
+            // Get the body from the response from Okta
+            let body = response
+                .text()
+                .await
+                .map_err(|e| error!("Could not get logs from Okta: {e}"))?;
+
+            // Attempt to deserialize the response from Okta
+            let logs: Vec<OktaLog> = serde_json::from_str(body.as_str())
+                .map_err(|e| error!("Could not parse data from Okta: {e}\n\n{body}"))?;
+
+            // If there have been no new logs since we last polled, we can exit the loop early
+            // Exiting here will result in a 10 second wait between restarts
+            if logs.is_empty() {
+                debug!("No new Okta logs since: {}", self.since);
+                return Ok(());
+            }
+
+            // Loop over the logs we did get from Okta, attempt to parse their timestamps, and send them into the logging system
             for log in &logs {
                 let log_timestamp = match OffsetDateTime::parse(&log.published, &Rfc3339) {
                     Ok(dt) => dt,
@@ -117,38 +162,42 @@ impl Okta {
                     }
                 };
 
-                if newest_timestamp.is_none() || log_timestamp > newest_timestamp.unwrap() {
-                    newest_timestamp = Some(log_timestamp);
+                // Check if this is the latest log we've seen and update if so
+                // We'll use the new most_recent_log_seen time to filter the subsequent
+                // API calls to Okta afterwards
+                if log_timestamp > most_recent_log_seen {
+                    most_recent_log_seen = log_timestamp;
                 }
 
-                if oldest_timestamp.is_none() || log_timestamp < oldest_timestamp.unwrap() {
-                    oldest_timestamp = Some(log_timestamp);
-                }
+                // Attempts to parse the log received from Okta to bytes.
+                let log_bytes = match serde_json::to_vec(&log) {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        error!("Failed to serialize Okta logs to bytes. Error: {e}");
+                        continue;
+                    }
+                };
 
-                if log_timestamp < self.since {
-                    self.since = newest_timestamp.unwrap();
-                    return Ok(());
-                }
-
-                counter += 1;
-                if log_timestamp > self.since {
-                    // Eventually these errors need to bubble up so the service can shut down
-                    // then be restarted by an orchestration service
-                    self.logger
-                        .send(Message::new(
-                            format!("okta"),
-                            serde_json::to_string(&log).unwrap().as_bytes().to_vec(),
-                            LogSource::Generator(Generator::Okta),
-                            self.config.logbacks_allowed.clone(),
-                        ))
-                        .unwrap();
-                }
+                // Send log into logging system to be processed by rule(s)
+                //
+                // Eventually these errors need to bubble up so the service can shut down
+                // then be restarted by an orchestration service
+                self.logger
+                    .send(Message::new(
+                        "okta".to_string(),
+                        log_bytes,
+                        LogSource::Generator(Generator::Okta),
+                        self.config.logbacks_allowed.clone(),
+                    ))
+                    .unwrap();
             }
             info!(
-                "Sent {} logs for processing. Newest time seen is: {:?}",
-                counter, newest_timestamp
+                "Sent {} Okta logs for processing. Newest time seen is: {most_recent_log_seen}",
+                logs.len(),
             );
-            self.since = newest_timestamp.unwrap() + Duration::from_millis(1);
+
+            // Update the time of our most recent log
+            self.since = most_recent_log_seen + Duration::from_millis(1);
         }
     }
 }

--- a/plaid/src/data/okta/mod.rs
+++ b/plaid/src/data/okta/mod.rs
@@ -156,10 +156,7 @@ impl Okta {
                 {
                     Some(published) => published,
                     None => {
-                        error!(
-                            "Missing or invalid 'published' field in Okta log: {:?}",
-                            log
-                        );
+                        error!("Missing or invalid 'published' field in Okta log: {log:?}",);
                         continue;
                     }
                 };


### PR DESCRIPTION
This PR fixes the current issues with the Okta data generator and implements additional customizability to the generator.

The generator was failing due to an issue in the URI string where the date provided did not match the requirements set by the Okta `/log` API. To address this, we convert the timestamp to RFC3339 before sending the request.

We also add additional configuration values for the generator in the form of `limit` and `sleep_duration`. `limit` is passed as a query param to the API to limit the number of logs returned from Okta. If no value is provided, we use Okta's default of 100. `sleep_duration` is intended to mitigate any possibility of getting rate limited by Okta. The `/logs` endpoint restricts us to 50 calls/minute and consequently, it's rate limiting is likely. After successfully fetching and forwarding logs to the execution system, we sleep for this amount of time in between calls. If no value is provided, we will wait for 1 millisecond

**Other changes:**
I also added an Optional configurable timeout duration for the General, Okta, PagerDuty, Slack, Splunk, and Yubikey API implementations. If no timeout duration is provided, Plaid just defaults to 5 seconds. I've been running into some instances lately where requests time out and this is an easy way to give more control to the Plaid admin on how their system should run