### PR TITLE
Move config secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,7 +1629,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plaid"
-version = "0.11.5"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.11.5"
+version = "0.12.0"
 dependencies = [
  "paste",
  "serde",

--- a/plaid-stl/Cargo.toml
+++ b/plaid-stl/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "plaid_stl"
-version = "0.11.5"
+version = "0.12.0"
 edition = "2021"
 #
 

--- a/plaid/Cargo.toml
+++ b/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.11.5"
+version = "0.12.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plaid/resources/Cargo.toml
+++ b/plaid/resources/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.11.5"
+version = "0.12.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plaid/resources/Dockerfile.aarch64
+++ b/plaid/resources/Dockerfile.aarch64
@@ -14,4 +14,4 @@ from scratch as runtime
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /build/target/aarch64-unknown-linux-musl/release/plaid /plaid
 USER 1000
-CMD [ "/plaid", "--config", "/config/plaid.toml" ]
+CMD [ "/plaid", "--config", "/config/plaid.toml", "--secrets", "/config/secrets.json" ]

--- a/plaid/resources/Dockerfile.amd64
+++ b/plaid/resources/Dockerfile.amd64
@@ -14,4 +14,4 @@ from scratch as runtime
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/plaid /plaid
 USER 1000
-CMD [ "/plaid", "--config", "/config/plaid.toml" ]
+CMD [ "/plaid", "--config", "/config/plaid.toml", "--secrets", "/config/secrets.json" ]

--- a/plaid/resources/plaid.toml
+++ b/plaid/resources/plaid.toml
@@ -1,5 +1,4 @@
 execution_threads = 2
-secrets_file = "/plaid/private-resources/secrets.json"
 
 [storage.sled]
 path = "/tmp/sled"

--- a/plaid/resources/plaid.toml
+++ b/plaid/resources/plaid.toml
@@ -19,7 +19,7 @@ lru_cache_size = 200
 
 [loading.secrets]
 [loading.secrets."testing"]
-"test_secret" = "modulesecret_test_secret"
+"test_secret" = "plaid-secret{test-secret}"
 
 [loading.log_type_overrides]
 

--- a/plaid/resources/plaid.toml
+++ b/plaid/resources/plaid.toml
@@ -19,7 +19,7 @@ lru_cache_size = 200
 
 [loading.secrets]
 [loading.secrets."testing"]
-"test_secret" = "plaid-secret{test-secret}"
+"test_secret" = "{plaid-secret{test-secret}}"
 
 [loading.log_type_overrides]
 

--- a/plaid/resources/plaid.toml
+++ b/plaid/resources/plaid.toml
@@ -1,4 +1,5 @@
 execution_threads = 2
+secrets_file = "/plaid/private-resources/secrets.json"
 
 [storage.sled]
 path = "/tmp/sled"
@@ -19,7 +20,7 @@ lru_cache_size = 200
 
 [loading.secrets]
 [loading.secrets."testing"]
-"test_secret" = "This is a test secret and it's data that should be passed to a module"
+"test_secret" = "modulesecret_test_secret"
 
 [loading.log_type_overrides]
 

--- a/plaid/resources/secrets.example.json
+++ b/plaid/resources/secrets.example.json
@@ -1,0 +1,3 @@
+{
+    "{plaid-secret{test-secret}}": "This is a test secret"
+}

--- a/plaid/src/config.rs
+++ b/plaid/src/config.rs
@@ -233,7 +233,7 @@ pub async fn configure() -> Result<Configuration, ConfigurationError> {
     let config: Configuration = match toml::from_str(&config) {
         Ok(config) => config,
         Err(e) => {
-            error!("Encountered parsing error while reading configuration!. Error: {e}");
+            error!("Encountered parsing error while reading configuration with interpolated secrets!. Error: {e}");
             return Err(ConfigurationError::ParsingError);
         }
     };

--- a/plaid/src/config.rs
+++ b/plaid/src/config.rs
@@ -121,6 +121,8 @@ pub struct Configuration {
     /// Set what modules will be loaded, what logging channels they're going to use
     /// and their computation and memory limits.
     pub loading: LoaderConfiguration,
+    /// Path to the file where secrets are stored.
+    pub secrets_file: String,
 }
 
 #[derive(Debug)]

--- a/plaid/src/loader/errors.rs
+++ b/plaid/src/loader/errors.rs
@@ -1,0 +1,6 @@
+#[derive(Debug)]
+pub enum Errors {
+    BadFilename,
+    ModuleParseFailure,
+    ModuleCompilationFailure,
+}

--- a/plaid/src/loader/mod.rs
+++ b/plaid/src/loader/mod.rs
@@ -4,12 +4,9 @@ mod utils;
 
 use lru::LruCache;
 use serde::Deserialize;
-use serde_json::Map;
-use serde_json::Value;
-use utils::read_and_configure_secrets;
 use utils::{
     configure_and_compile_module, get_module_computation_limit, get_module_page_count,
-    read_and_parse_modules,
+    read_and_configure_secrets, read_and_parse_modules,
 };
 use wasmer::Engine;
 use wasmer::Module;
@@ -139,12 +136,12 @@ impl PlaidModules {
     }
 }
 
-pub fn load(config: Configuration, secrets: &Map<String, Value>) -> Result<PlaidModules, ()> {
+pub fn load(config: Configuration) -> Result<PlaidModules, ()> {
     let module_paths = fs::read_dir(config.module_dir).unwrap();
 
     let mut modules = PlaidModules::default();
 
-    let byte_secrets = read_and_configure_secrets(secrets, config.secrets);
+    let byte_secrets = read_and_configure_secrets(config.secrets);
 
     for path in module_paths {
         let (filename, module_bytes) = match path {

--- a/plaid/src/loader/mod.rs
+++ b/plaid/src/loader/mod.rs
@@ -37,7 +37,7 @@ pub struct Configuration {
     pub lru_cache_size: Option<usize>,
     /// The secrets that are available to modules. No actual secrets should be included in this map.
     /// Instead, the values here should be names of secrets whose values are present in
-    /// `secrets_file`. This makes it possible for to check in your Plaid config without exposing secrets.
+    /// the secrets file. This makes it possible for to check in your Plaid config without exposing secrets.
     pub secrets: HashMap<String, HashMap<String, String>>,
     /// See persistent_response_size in PlaidModule for an explanation on how to use this
     pub persistent_response_size: HashMap<String, usize>,

--- a/plaid/src/loader/mod.rs
+++ b/plaid/src/loader/mod.rs
@@ -113,7 +113,8 @@ impl PlaidModule {
     /// This function sets up the computation metering, configures the module tunables, and
     /// compiles the module using the provided bytecode and settings.
     ///
-    /// This function returns a PlaidModule with
+    /// This function returns a PlaidModule with `secrets`, `cache`, and `persistent_response` set to `None.`
+    /// __Ensure that you set these values if needed after calling this function__.
     fn configure_and_compile(
         filename: &str,
         computation_amount: &LimitAmount,

--- a/plaid/src/loader/mod.rs
+++ b/plaid/src/loader/mod.rs
@@ -1,16 +1,21 @@
+mod errors;
 mod limits;
-
-use limits::LimitingTunables;
+mod utils;
 
 use lru::LruCache;
 use serde::Deserialize;
-use wasmer::{sys::BaseTunables, Engine, NativeEngineExt, Pages, Target};
-use wasmer::{wasmparser::Operator, CompilerConfig, Cranelift, Module};
-
-use wasmer_middlewares::Metering;
+use serde_json::Map;
+use serde_json::Value;
+use utils::read_and_configure_secrets;
+use utils::{
+    configure_and_compile_module, get_module_computation_limit, get_module_page_count,
+    read_and_parse_modules,
+};
+use wasmer::Engine;
+use wasmer::Module;
 
 use std::collections::HashMap;
-use std::fs;
+use std::fs::{self};
 use std::num::NonZeroUsize;
 use std::sync::{Arc, RwLock};
 
@@ -33,7 +38,9 @@ pub struct Configuration {
     pub memory_page_count: LimitAmount,
     /// The size of the LRU cache for each module. Not setting it means LRUs are disabled
     pub lru_cache_size: Option<usize>,
-    /// The secrets that are available to modules
+    /// The secrets that are available to modules. No actual secrets should be included in this map.
+    /// Instead, the values here should be names of secrets whose values are present in
+    /// `secrets_file`. This makes it possible for to check in your Plaid config without exposing secrets.
     pub secrets: HashMap<String, HashMap<String, String>>,
     /// See persistent_response_size in PlaidModule for an explanation on how to use this
     pub persistent_response_size: HashMap<String, usize>,
@@ -132,58 +139,26 @@ impl PlaidModules {
     }
 }
 
-const CALL_COST: u64 = 10;
-
-pub fn load(config: Configuration) -> Result<PlaidModules, ()> {
+pub fn load(config: Configuration, secrets: &Map<String, Value>) -> Result<PlaidModules, ()> {
     let module_paths = fs::read_dir(config.module_dir).unwrap();
 
     let mut modules = PlaidModules::default();
 
-    let cost_function = |operator: &Operator| -> u64 {
-        match operator {
-            Operator::Call { .. } => CALL_COST,
-            Operator::CallIndirect { .. } => CALL_COST,
-            Operator::ReturnCall { .. } => CALL_COST,
-            Operator::ReturnCallIndirect { .. } => CALL_COST,
-            _ => 1,
-        }
-    };
-
-    let byte_secrets: HashMap<String, HashMap<String, Vec<u8>>> = config
-        .secrets
-        .into_iter()
-        .map(|(key, value)| {
-            (
-                key,
-                value
-                    .into_iter()
-                    .map(|(inner_key, inner_value)| (inner_key, inner_value.as_bytes().to_vec()))
-                    .collect(),
-            )
-        })
-        .collect();
+    let byte_secrets = read_and_configure_secrets(secrets, config.secrets);
 
     for path in module_paths {
-        // Get the module file name and read in the bytes
-        let (filename, module_bytes) = if let Ok(path) = path {
-            // Path's can be weird so we just try to make it a UTF8 string,
-            // if it's not UTF8, we'll fail reading it and skip it.
-            let filename = path.file_name().to_string_lossy().to_string();
-
-            // Also skip any files that aren't wasm files
-            if !filename.ends_with(".wasm") {
+        let (filename, module_bytes) = match path {
+            Ok(path) => {
+                if let Ok(filename_and_bytes) = read_and_parse_modules(&path) {
+                    filename_and_bytes
+                } else {
+                    continue;
+                }
+            }
+            Err(e) => {
+                error!("Bad entry in modules directory - skipping. Error: {e}");
                 continue;
             }
-
-            // Read in the bytes of the module
-            let module_bytes = match std::fs::read(path.path()) {
-                Ok(b) => b,
-                _ => continue,
-            };
-
-            (filename, module_bytes)
-        } else {
-            continue;
         };
 
         // See if a type is defined in the configuration file, if not then we will grab the first part
@@ -204,72 +179,34 @@ pub fn load(config: Configuration) -> Result<PlaidModules, ()> {
             .copied()
             .map(PersistentResponse::new);
 
-        // Get the computation limit for the module by checking the following in order:
-        // Module Override
-        // Log Type amount
-        // Default amount
-        let computation_limit = match (
-            config
-                .computation_amount
-                .module_overrides
-                .get(&filename.to_string()),
-            config.computation_amount.log_type.get(&type_),
-            config.computation_amount.default,
-        ) {
-            (Some(amount), _, _) => *amount,
-            (None, Some(amount), _) => *amount,
-            (None, None, amount) => amount,
+        // Get the computation limit for the module
+        let computation_limit =
+            get_module_computation_limit(&config.computation_amount, &filename, &type_);
+
+        // Get the memory limit for the module
+        let page_count = get_module_page_count(&config.memory_page_count, &filename, &type_);
+
+        // Configure and compile module
+        let Ok((module, engine)) =
+            configure_and_compile_module(computation_limit, page_count, module_bytes, &filename)
+        else {
+            continue;
         };
-
-        // Get the memory limit for the module by checking the following in order:
-        // Module Override
-        // Log Type amount
-        // Default amount
-        let page_count = match (
-            config
-                .memory_page_count
-                .module_overrides
-                .get(&filename.to_string()),
-            config.memory_page_count.log_type.get(&type_),
-            config.memory_page_count.default,
-        ) {
-            (Some(amount), _, _) => *amount,
-            (None, Some(amount), _) => *amount,
-            (None, None, amount) => amount,
-        };
-
-        // Page count is at max 32 bits. Nothing should ever allocate that many pages
-        // but we're likely to hit this if someone spams the number key on their keyboard
-        // for "unlimited memory".
-        let page_count = if page_count > u32::MAX as u64 {
-            u32::MAX
-        } else {
-            page_count as u32
-        };
-
-        let metering = Arc::new(Metering::new(computation_limit, cost_function));
-        let mut compiler = Cranelift::default();
-        compiler.push_middleware(metering);
-
-        let base = BaseTunables::for_target(&Target::default());
-        let tunables = LimitingTunables::new(base, Pages(page_count));
-        let mut engine: Engine = compiler.into();
-        engine.set_tunables(tunables);
 
         info!("Name: [{filename}] Computation Limit: [{computation_limit}] Memory Limit: [{page_count} pages] Log Type: [{type_}]");
-
-        let cache = match config.lru_cache_size {
-            None | Some(0) => None,
-            Some(size) => Some(Arc::new(RwLock::new(LruCache::new(
-                NonZeroUsize::new(size).unwrap(),
-            )))),
-        };
-
-        let mut module = Module::new(&engine, module_bytes).unwrap();
-        module.set_name(&filename);
         for import in module.imports() {
             info!("\tImport: {}", import.name());
         }
+
+        // Configure cache for module
+        let cache = config.lru_cache_size.and_then(|size| {
+            if size == 0 {
+                None // No cache if provided size is 0
+            } else {
+                NonZeroUsize::new(size)
+                    .map(|non_zero_size| Arc::new(RwLock::new(LruCache::new(non_zero_size))))
+            }
+        });
 
         let plaid_module = PlaidModule {
             computation_limit,

--- a/plaid/src/loader/utils.rs
+++ b/plaid/src/loader/utils.rs
@@ -2,7 +2,6 @@ use super::errors::Errors;
 use super::limits::LimitingTunables;
 use super::LimitAmount;
 
-use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::fs::DirEntry;
 use std::sync::Arc;
@@ -132,7 +131,6 @@ pub fn configure_and_compile_module(
 /// This setup allows for configuration files to be checked in, referencing secret names
 /// that are mapped to actual secret values stored in the secrets file.
 pub fn read_and_configure_secrets(
-    secrets: &Map<String, Value>,
     secrets_configuration: HashMap<String, HashMap<String, String>>,
 ) -> HashMap<String, HashMap<String, Vec<u8>>> {
     secrets_configuration
@@ -142,18 +140,7 @@ pub fn read_and_configure_secrets(
                 key,
                 value
                     .into_iter()
-                    .map(|(inner_key, inner_value)| {
-                        (
-                            inner_key,
-                            secrets
-                                .get(&inner_value)
-                                .unwrap()
-                                .as_str()
-                                .unwrap()
-                                .as_bytes()
-                                .to_vec(),
-                        )
-                    })
+                    .map(|(inner_key, inner_value)| (inner_key, inner_value.as_bytes().to_vec()))
                     .collect(),
             )
         })

--- a/plaid/src/loader/utils.rs
+++ b/plaid/src/loader/utils.rs
@@ -120,16 +120,7 @@ pub fn configure_and_compile_module(
     Ok((module, engine))
 }
 
-/// Reads and configures secrets for modules.
-///
-/// This function takes a `Map<String, Value>` representing the secrets read from a file,
-/// and a `HashMap<String, HashMap<String, String>>` representing the secrets configuration.
-/// The secrets configuration maps a user-defined secret name to the actual secret name in the read file.
-/// It returns a `HashMap<String, HashMap<String, Vec<u8>>>` where the secrets have been
-/// configured according to the provided configuration.
-///
-/// This setup allows for configuration files to be checked in, referencing secret names
-/// that are mapped to actual secret values stored in the secrets file.
+/// Configures secrets for modules.
 pub fn read_and_configure_secrets(
     secrets_configuration: HashMap<String, HashMap<String, String>>,
 ) -> HashMap<String, HashMap<String, Vec<u8>>> {

--- a/plaid/src/loader/utils.rs
+++ b/plaid/src/loader/utils.rs
@@ -1,0 +1,161 @@
+use super::errors::Errors;
+use super::limits::LimitingTunables;
+use super::LimitAmount;
+
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+use std::fs::DirEntry;
+use std::sync::Arc;
+use wasmer::{sys::BaseTunables, Engine, NativeEngineExt, Pages, Target};
+use wasmer::{wasmparser::Operator, CompilerConfig, Cranelift, Module};
+use wasmer_middlewares::Metering;
+
+const CALL_COST: u64 = 10;
+
+/// Returns the cost associated with a given WebAssembly operator.
+///
+/// This function is used as part of the Wasmer middleware to determine the computational
+/// cost of executing various WebAssembly operators. It assigns a specific cost to call-related
+/// operators and a default cost to all other operators.
+pub fn cost_function(operator: &Operator) -> u64 {
+    match operator {
+        Operator::Call { .. } => CALL_COST,
+        Operator::CallIndirect { .. } => CALL_COST,
+        Operator::ReturnCall { .. } => CALL_COST,
+        Operator::ReturnCallIndirect { .. } => CALL_COST,
+        _ => 1,
+    }
+}
+
+/// Get the module file name and read in the bytes
+pub fn read_and_parse_modules(path: &DirEntry) -> Result<(String, Vec<u8>), Errors> {
+    // Path's can be weird so we just try to make it a UTF8 string,
+    // if it's not UTF8, we'll fail reading it and skip it.
+    let filename = path.file_name().to_string_lossy().to_string();
+
+    // Also skip any files that aren't wasm files
+    if !filename.ends_with(".wasm") {
+        return Err(Errors::BadFilename);
+    }
+
+    // Read in the bytes of the module
+    let module_bytes = match std::fs::read(path.path()) {
+        Ok(b) => b,
+        Err(e) => {
+            error!("Failed to read module at [{:?}]. Error: {e}", path.path());
+            return Err(Errors::ModuleParseFailure);
+        }
+    };
+
+    Ok((filename, module_bytes))
+}
+
+/// Get the computation limit for the module by checking the following in order:
+/// 1. Module Override
+/// 2. Log Type amount
+/// 3. Default amount
+pub fn get_module_computation_limit(
+    limit_amount: &LimitAmount,
+    filename: &str,
+    log_type: &str,
+) -> u64 {
+    if let Some(amount) = limit_amount.module_overrides.get(filename) {
+        *amount
+    } else if let Some(amount) = limit_amount.log_type.get(log_type) {
+        *amount
+    } else {
+        limit_amount.default
+    }
+}
+
+/// Get the memory limit for the module by checking the following in order:
+/// 1. Module Override
+/// 2. Log Type amount
+/// 3. Default amount
+pub fn get_module_page_count(limit_amount: &LimitAmount, filename: &str, log_type: &str) -> u32 {
+    let page_count = if let Some(amount) = limit_amount.module_overrides.get(filename) {
+        *amount
+    } else if let Some(amount) = limit_amount.log_type.get(log_type) {
+        *amount
+    } else {
+        limit_amount.default
+    };
+
+    // Page count is at max 32 bits. Nothing should ever allocate that many pages
+    // but we're likely to hit this if someone spams the number key on their keyboard
+    // for "unlimited memory".
+    if page_count > u32::MAX as u64 {
+        u32::MAX
+    } else {
+        page_count as u32
+    }
+}
+
+/// Configure and compile a module with specified computation limits and memory page count.
+///
+/// This function sets up the computation metering, configures the module tunables, and
+/// compiles the module using the provided bytecode and settings.
+pub fn configure_and_compile_module(
+    computation_limit: u64,
+    page_count: u32,
+    module_bytes: Vec<u8>,
+    filename: &str,
+) -> Result<(Module, Engine), Errors> {
+    let metering = Arc::new(Metering::new(computation_limit, cost_function));
+    let mut compiler = Cranelift::default();
+    compiler.push_middleware(metering);
+
+    // Configure module tunables - this includes our computation limit and page count
+    let base = BaseTunables::for_target(&Target::default());
+    let tunables = LimitingTunables::new(base, Pages(page_count));
+    let mut engine: Engine = compiler.into();
+    engine.set_tunables(tunables);
+
+    // Compile the module using the middleware and tunables we just set up
+    let mut module = Module::new(&engine, module_bytes).map_err(|e| {
+        error!("Failed to compile module [{filename}]. Error: {e}");
+        Errors::ModuleCompilationFailure
+    })?;
+    module.set_name(&filename);
+
+    Ok((module, engine))
+}
+
+/// Reads and configures secrets for modules.
+///
+/// This function takes a `Map<String, Value>` representing the secrets read from a file,
+/// and a `HashMap<String, HashMap<String, String>>` representing the secrets configuration.
+/// The secrets configuration maps a user-defined secret name to the actual secret name in the read file.
+/// It returns a `HashMap<String, HashMap<String, Vec<u8>>>` where the secrets have been
+/// configured according to the provided configuration.
+///
+/// This setup allows for configuration files to be checked in, referencing secret names
+/// that are mapped to actual secret values stored in the secrets file.
+pub fn read_and_configure_secrets(
+    secrets: &Map<String, Value>,
+    secrets_configuration: HashMap<String, HashMap<String, String>>,
+) -> HashMap<String, HashMap<String, Vec<u8>>> {
+    secrets_configuration
+        .into_iter()
+        .map(|(key, value)| {
+            (
+                key,
+                value
+                    .into_iter()
+                    .map(|(inner_key, inner_value)| {
+                        (
+                            inner_key,
+                            secrets
+                                .get(&inner_value)
+                                .unwrap()
+                                .as_str()
+                                .unwrap()
+                                .as_bytes()
+                                .to_vec(),
+                        )
+                    })
+                    .collect(),
+            )
+        })
+        .collect()
+}

--- a/plaid/src/main.rs
+++ b/plaid/src/main.rs
@@ -8,10 +8,11 @@ use data::Data;
 use executor::*;
 use plaid_stl::messages::LogSource;
 use reqwest::header::HeaderMap;
+use serde_json::Value;
 use storage::Storage;
 use tokio::{sync::RwLock, task::JoinSet};
 
-use std::{collections::HashMap, convert::Infallible, net::SocketAddr, pin::Pin, sync::Arc, time::{SystemTime, UNIX_EPOCH}};
+use std::{collections::HashMap, convert::Infallible, fs, net::SocketAddr, pin::Pin, sync::Arc, time::{SystemTime, UNIX_EPOCH}};
 
 use crossbeam_channel::{bounded, TrySendError};
 use warp::{hyper::body::Bytes, path, Filter};
@@ -24,6 +25,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Reading configuration");
     let config = config::configure().await?;
     let (log_sender, log_receiver) = bounded(2048);
+
+    // Read secrets and parse into a serde_json Value. This will be used by the APIs module, the data module, 
+    // and the loader module to configure secrets
+    info!("Reading secrets file at {}", config.secrets_file);
+    let secret_bytes = fs::read(config.secrets_file).expect("Could not read from provided secrets");
+    let secrets = serde_json::from_slice::<Value>(&secret_bytes).expect("Invalid JSON in secrets file"); 
+    let secrets_map = secrets.as_object().expect("Invalid secrets file formatting");
 
     info!("Starting logging subsystem");
     let (els, _logging_handler) = Logger::start(config.logging);
@@ -60,7 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Loading all the modules");
     // Load all the modules that form our Nanoservices and Plaid rules
-    let modules = Arc::new(loader::load(config.loading).unwrap());
+    let modules = Arc::new(loader::load(config.loading, secrets_map).unwrap());
     let modules_by_name = Arc::new(modules.get_modules());
 
     info!(


### PR DESCRIPTION
This PR implements a mechanism to interpolate secrets Plaid's config at runtime. We read the config in as a string, read the secrets in as a `Map<String, serde_json::Value>` and replace all occurrences of `String` with its corresponding value in the provided secrets file.

Example:
With a secrets file like: 
```json
{
    "{plaid-secret{test-secret}}": "This is a test secret",
}
```

and a config like:
```toml
[loading.secrets]
[loading.secrets."testing"]
"test_secret" = "{plaid-secret{test-secret}}"
```

We're able to run a simple rule that parrots our secret back to us:

```
[2024-07-12T16:42:49Z INFO  plaid] Plaid is booting up, please standby...
[2024-07-12T16:42:49Z INFO  plaid] Reading configuration
[2024-07-12T16:42:49Z INFO  plaid] Reading secrets file at plaid/private-resources/secrets.json
[2024-07-12T16:42:49Z INFO  plaid] Starting logging subsystem
[2024-07-12T16:42:49Z INFO  plaid] Logging subsystem started
[2024-07-12T16:42:49Z INFO  plaid::logging] Configured logger: stdout
[2024-07-12T16:42:49Z INFO  plaid] Storage system configured
[2024-07-12T16:42:49Z INFO  plaid::data] Started Data collection tasks
[2024-07-12T16:42:49Z INFO  plaid] Configurating APIs for Modules
[2024-07-12T16:42:49Z INFO  plaid] Loading all the modules
[2024-07-12T16:42:49Z INFO  plaid::loader] Name: [testing_test.wasm] Computation Limit: [55000000] Memory Limit: [250 pages] Log Type: [testing]
[2024-07-12T16:42:49Z INFO  plaid::loader]      Import: fetch_accessory_data_by_name
[2024-07-12T16:42:49Z INFO  plaid::loader]      Import: fetch_data
[2024-07-12T16:42:49Z INFO  plaid::loader]      Import: fetch_source
[2024-07-12T16:42:49Z INFO  plaid::loader]      Import: print_debug_string
[2024-07-12T16:42:51Z INFO  plaid] Starting the execution threads of which 2 were requested
[2024-07-12T16:42:51Z INFO  plaid::executor] Starting Execution Thread 0
[2024-07-12T16:42:51Z INFO  plaid::executor] Starting Execution Thread 1
[2024-07-12T16:42:51Z INFO  plaid] Configured Webhook Servers
[2024-07-12T16:42:51Z INFO  plaid] Web Server [internal]: 0.0.0.0:4554
[2024-07-12T16:42:51Z INFO  plaid] Web Server [external]: 0.0.0.0:4556
[2024-07-12T16:42:51Z INFO  plaid] Starting servers, boot up complete
[2024-07-12T16:42:52Z DEBUG plaid::functions::internal] Message from [testing_test.wasm]: Received log: hello!
[2024-07-12T16:42:52Z DEBUG plaid::functions::internal] Message from [testing_test.wasm]: Data from config file: This is a test secret
```