### PR TITLE
Implement WebSocket data generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,16 +678,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1251,6 +1282,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,6 +1430,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,10 +1565,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openssl"
+version = "0.10.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1628,6 +1720,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
 name = "plaid"
 version = "0.12.0"
 dependencies = [
@@ -1636,6 +1734,7 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "env_logger",
+ "futures-util",
  "http 1.1.0",
  "jsonwebtoken",
  "log",
@@ -1652,6 +1751,7 @@ dependencies = [
  "sled",
  "time",
  "tokio",
+ "tokio-tungstenite 0.23.1",
  "toml",
  "warp",
  "wasmer",
@@ -2004,6 +2104,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.5.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2456,6 +2569,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
+name = "tempfile"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fcd239983515c23a32fb82099f97d0b11b8c72f654ed659363a95c3dad7a53"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,6 +2687,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,7 +2726,21 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite 0.23.0",
 ]
 
 [[package]]
@@ -2723,6 +2873,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2801,6 +2970,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,7 +3015,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls 0.25.0",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.21.0",
  "tokio-util",
  "tower-service",
  "tracing",

--- a/plaid-stl/src/messages.rs
+++ b/plaid-stl/src/messages.rs
@@ -5,7 +5,7 @@ pub enum Generator {
     Github,
     Okta,
     Interval(String),
-    Websocket(String),
+    WebSocketExternal(String),
 }
 
 impl std::fmt::Display for Generator {
@@ -14,7 +14,7 @@ impl std::fmt::Display for Generator {
             Generator::Github => write!(f, "github"),
             Generator::Okta => write!(f, "okta"),
             Generator::Interval(job) => write!(f, "interval/{job}"),
-            Generator::Websocket(ws) => write!(f, "websocket/{ws}"),
+            Generator::WebSocketExternal(ws) => write!(f, "websocket/{ws}"),
         }
     }
 }

--- a/plaid-stl/src/messages.rs
+++ b/plaid-stl/src/messages.rs
@@ -5,6 +5,7 @@ pub enum Generator {
     Github,
     Okta,
     Interval(String),
+    Websocket(String),
 }
 
 impl std::fmt::Display for Generator {
@@ -13,6 +14,7 @@ impl std::fmt::Display for Generator {
             Generator::Github => write!(f, "github"),
             Generator::Okta => write!(f, "okta"),
             Generator::Interval(job) => write!(f, "interval/{job}"),
+            Generator::Websocket(ws) => write!(f, "websocket/{ws}"),
         }
     }
 }

--- a/plaid/Cargo.toml
+++ b/plaid/Cargo.toml
@@ -38,6 +38,8 @@ warp = { version = "0.3", features = ["tls"] }
 wasmer = { version = "4", default-features = false, features = ["cranelift"] }
 wasmer-middlewares = "4"
 jsonwebtoken = { version = "9.2" }
+tokio-tungstenite = { version = "0.23.1", features = ["native-tls"] }
+futures-util = "0.3.30"
 
 # Uncomment to build with Quorum. This is needed
 # because otherwise cargo will try and find this

--- a/plaid/resources/plaid.toml
+++ b/plaid/resources/plaid.toml
@@ -119,6 +119,17 @@ secret_key = ""
 
 [data]
 
+# [data.websocket]
+# [data.websocket.websockets]
+# [data.websocket."websockets"."demo_rpc_call"]
+# log_type = "testing"
+# [data.websocket."websockets"."demo_rpc_call".uris]
+# simplystaking = "wss://some_websocket"
+# [data.websocket."websockets"."demo_rpc_call".message_config]
+# message = "{ \"id\": 1, \"jsonrpc\": \"2.0\", \"method\": \"eth_getBlockByNumber\", \"params\": [ \"finalized\", false ]}"
+# sleep_duration = 100
+# [data.websocket."websockets"."demo_rpc_call"."headers"]
+
 [webhooks."internal"]
 listen_address = "0.0.0.0:4554"
 [webhooks."internal".webhooks."AAAA"]

--- a/plaid/resources/plaid.toml
+++ b/plaid/resources/plaid.toml
@@ -127,7 +127,7 @@ secret_key = ""
 # simplystaking = "wss://some_websocket"
 # [data.websocket."websockets"."demo_rpc_call".message_config]
 # message = "{ \"id\": 1, \"jsonrpc\": \"2.0\", \"method\": \"eth_getBlockByNumber\", \"params\": [ \"finalized\", false ]}"
-# sleep_duration = 100
+# sleep_duration = 100 ## This means the message is sent every 0.1 seconds
 # [data.websocket."websockets"."demo_rpc_call"."headers"]
 
 [webhooks."internal"]

--- a/plaid/src/bin/plaid.rs
+++ b/plaid/src/bin/plaid.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // This sender provides an internal route to sending logs. This is what
     // powers the logback functions.
 
-    let delayed_log_sender = Data::start(config.data, log_sender.clone(), storage.clone())
+    let delayed_log_sender = Data::start(config.data, log_sender.clone(), storage.clone(), els.clone())
         .await
         .expect("The data system failed to start")
         .unwrap();

--- a/plaid/src/data/mod.rs
+++ b/plaid/src/data/mod.rs
@@ -167,7 +167,7 @@ impl Data {
             });
         }
 
-        info!("Started Data collection tasks");
+        info!("Started Data Generators");
         Ok(internal_sender)
     }
 }

--- a/plaid/src/data/mod.rs
+++ b/plaid/src/data/mod.rs
@@ -80,11 +80,9 @@ impl DataInternal {
             .interval
             .map(|config| interval::Interval::new(config, logger.clone()));
 
-        let websocket = if let Some(config) = config.websocket {
-            Some(websocket::WebsocketGenerator::new(config, logger.clone()).await)
-        } else {
-            None
-        };
+        let websocket = config
+            .websocket
+            .map(|ws| websocket::WebsocketGenerator::new(ws, logger.clone()));
 
         Ok(Self {
             github,

--- a/plaid/src/data/mod.rs
+++ b/plaid/src/data/mod.rs
@@ -26,7 +26,7 @@ pub struct DataConfig {
     okta: Option<okta::OktaConfig>,
     internal: Option<internal::InternalConfig>,
     interval: Option<interval::IntervalConfig>,
-    websocket: Option<websocket::WebsocketDataGenerator>,
+    websocket: Option<websocket::WebSocketDataGenerator>,
 }
 
 struct DataInternal {

--- a/plaid/src/data/mod.rs
+++ b/plaid/src/data/mod.rs
@@ -39,7 +39,7 @@ struct DataInternal {
     /// Interval manages tracking and execution of jobs that are executed on a defined interval
     interval: Option<interval::Interval>,
     /// Websocket manages the creation and maintenance of WebSockets that provide data to the executor
-    websocket: Option<websocket::WebsocketGenerator>,
+    websocket_external: Option<websocket::WebsocketGenerator>,
 }
 
 pub struct Data {}
@@ -82,7 +82,7 @@ impl DataInternal {
             .interval
             .map(|config| interval::Interval::new(config, logger.clone()));
 
-        let websocket = config
+        let websocket_external = config
             .websocket
             .map(|ws| websocket::WebsocketGenerator::new(ws, logger.clone(), els));
 
@@ -91,7 +91,7 @@ impl DataInternal {
             okta,
             internal: Some(internal?),
             interval,
-            websocket,
+            websocket_external,
         })
     }
 }
@@ -164,7 +164,7 @@ impl Data {
             });
         }
 
-        if let Some(websocket) = di.websocket {
+        if let Some(websocket) = di.websocket_external {
             handle.spawn(async move {
                 websocket.start().await;
             });

--- a/plaid/src/data/websocket/mod.rs
+++ b/plaid/src/data/websocket/mod.rs
@@ -18,6 +18,7 @@ use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream,
 };
 
+/// Represents errors that a WebSocket data generator can encounter
 #[derive(Debug)]
 enum Errors {
     SocketCreationFailure,

--- a/plaid/src/data/websocket/mod.rs
+++ b/plaid/src/data/websocket/mod.rs
@@ -406,14 +406,14 @@ impl WebSocketClient {
                         error!("Write task for WebSocket: [{}] using socket [{}] finished unexpectedly", &self.name, uri_name);
                     },
                     _ = read_handle => {
-                        error!("Write task for WebSocket: [{}] using socket [{}] finished unexpectedly", &self.name, uri_name);
+                        error!("Read task for WebSocket: [{}] using socket [{}] finished unexpectedly", &self.name, uri_name);
                     },
                 }
             }
             None => {
                 tokio::select! {
                     _ = read_handle => {
-                        error!("Write task for WebSocket: [{}] using socket [{}] finished unexpectedly", &self.name, uri_name);
+                        error!("Read task for WebSocket: [{}] using socket [{}] finished unexpectedly", &self.name, uri_name);
                     },
                 }
             }

--- a/plaid/src/data/websocket/mod.rs
+++ b/plaid/src/data/websocket/mod.rs
@@ -130,7 +130,7 @@ pub struct WebsocketGenerator {
 /// # Returns
 /// A new `WebsocketGenerator` instance.
 impl WebsocketGenerator {
-    pub async fn new(config: WebsocketDataGenerator, sender: Sender<Message>) -> Self {
+    pub fn new(config: WebsocketDataGenerator, sender: Sender<Message>) -> Self {
         let clients = config
             .websockets
             .into_iter()

--- a/plaid/src/data/websocket/mod.rs
+++ b/plaid/src/data/websocket/mod.rs
@@ -1,0 +1,408 @@
+mod selector;
+
+use crate::executor::Message;
+use crossbeam_channel::Sender;
+use futures_util::{
+    stream::{SplitSink, SplitStream},
+    SinkExt, StreamExt,
+};
+use http::{HeaderMap, Uri};
+use plaid_stl::messages::{Generator, LogSource, LogbacksAllowed};
+use selector::UriSelector;
+use serde::Deserialize;
+use std::{collections::HashMap, str::FromStr, time::Duration};
+use tokio::{net::TcpStream, task::JoinHandle};
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{client::IntoClientRequest, protocol::Message as WSMessage},
+    MaybeTlsStream, WebSocketStream,
+};
+
+#[derive(Debug)]
+enum Errors {
+    SocketCreationFailure,
+}
+
+#[derive(Deserialize)]
+pub struct WebsocketDataGenerator {
+    websockets: HashMap<String, Websocket>,
+}
+
+#[derive(Deserialize)]
+pub struct Websocket {
+    /// The URI(s) of the WebSocket endpoint. The config allows multiple URIs in the event that one fails,
+    /// a new one can be used in its place.
+    #[serde(deserialize_with = "parse_uris")]
+    uris: Vec<Uri>,
+    /// A string indicating the type of log associated with the WebSocket.
+    log_type: String,
+    /// The message to be sent over the WebSocket connection.
+    message: Option<String>,
+    /// An optional field containing a map of headers to be included in the WebSocket request.
+    #[serde(deserialize_with = "parse_headers")]
+    headers: Option<HeaderMap>,
+    /// Time (in milliseconds) between sending new messages to the receiving end
+    sleep_duration: u64,
+    /// The number of Logbacks this generator is allowed to trigger
+    #[serde(default)]
+    logbacks_allowed: LogbacksAllowed,
+    /// The minimum amount of time (in milliseconds) to wait before retrying a connection to a WebSocket
+    #[serde(default = "min_retry_duration")]
+    min_retry_duration: u64,
+    /// The maximum amount of time (in milliseconds) to wait before retrying a connection to a WebSocket
+    #[serde(default = "max_retry_duration")]
+    max_retry_duration: u64,
+}
+
+/// The default value for `min_retry_duration` if none is provided in the configuration.
+fn min_retry_duration() -> u64 {
+    100
+}
+
+/// The default value for `max_retry_duration` if none is provided in the configuration.
+fn max_retry_duration() -> u64 {
+    60000
+}
+
+/// Custom parser for URI. Returns an error if an invalid URI is provided
+fn parse_uris<'de, D>(deserializer: D) -> Result<Vec<Uri>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let uris_raw = <Vec<String>>::deserialize(deserializer)?;
+
+    let uris = uris_raw
+        .iter()
+        .filter_map(|uri| match Uri::from_str(uri) {
+            Ok(valid_uri) => Some(valid_uri),
+            Err(e) => {
+                error!("Invalid URI provided: {}. Error: {}", uri, e);
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if uris.is_empty() {
+        Err(serde::de::Error::custom(&format!("No valid URIs provided")))
+    } else {
+        Ok(uris)
+    }
+}
+
+/// Custom parser to convert user provided `HashMap<String, String>` of headers to include in the request
+/// to a `http::HeaderMap`. Returns an error if the conversion to `HeaderMap` fails.
+fn parse_headers<'de, D>(deserializer: D) -> Result<Option<HeaderMap>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let headers: Option<HashMap<String, String>> = Option::deserialize(deserializer)?;
+
+    if let Some(ref headers) = headers {
+        match headers.try_into() {
+            Ok(map) => Ok(Some(map)),
+            Err(e) => Err(serde::de::Error::custom(format!(
+                "Invalid headers provided: {e}"
+            ))),
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+/// A generator that manages multiple WebSocket clients for data generation.
+///
+/// The `WebsocketGenerator` struct holds a collection of `WebSocketClient` instances and provides
+/// methods to initialize and start these clients.
+pub struct WebsocketGenerator {
+    clients: Vec<WebSocketClient>,
+}
+
+/// Creates a new `WebsocketGenerator` instance with the specified configuration and message sender.
+///
+/// This function initializes the WebSocket clients based on the provided configuration and returns
+/// a `WebsocketGenerator` instance containing these clients.
+///
+/// # Parameters
+/// - `config`: The configuration for the WebSocket data generator, containing a list of WebSocket
+///   configurations.
+/// - `sender`: A channel sender for sending messages to the executor.
+///
+/// # Returns
+/// A new `WebsocketGenerator` instance.
+impl WebsocketGenerator {
+    pub async fn new(config: WebsocketDataGenerator, sender: Sender<Message>) -> Self {
+        let clients = config
+            .websockets
+            .into_iter()
+            .map(|(name, config)| WebSocketClient::new(config, sender.clone(), name))
+            .collect();
+
+        Self { clients }
+    }
+
+    /// Starts all WebSocket clients managed by this generator.
+    ///
+    /// This function initializes the WebSocket clients, logs the number of clients being initialized,
+    /// and then spawns an asynchronous task for each client. Each task runs in a loop, attempting to
+    /// start the client and reopening the connection with a new URI if an error occurs.
+    pub async fn start(self) {
+        info!(
+            "Initializing {} WebSocket data generators...",
+            self.clients.len()
+        );
+
+        for mut client in self.clients {
+            tokio::spawn(async move {
+                loop {
+                    // This will only return if an error occurred - indicating that we need to reopen the connection with a new URI
+                    client.start().await;
+                    error!("Socket [{}] closed. Attempting to restart...", client.name);
+
+                    client.uri_selector.mark_failed();
+                }
+            });
+        }
+    }
+}
+
+/// Represents a WebSocket client responsible for generating and sending logs.
+struct WebSocketClient {
+    /// The configuration of the client
+    configuration: Websocket,
+    /// The sending channel to send logs to the executor.
+    sender: Sender<Message>,
+    /// The name of the WebSocket as defined in the configuration.
+    name: String,
+    /// Manages a list of URI entries and handles the selection and retry logic for connection attempts.
+    uri_selector: UriSelector,
+}
+
+impl WebSocketClient {
+    /// Establishes a WebSocket connection to the given URI and initializes the struct
+    /// with the provided parameters.
+    fn new(configuration: Websocket, sender: Sender<Message>, name: String) -> Self {
+        let uri_selector = UriSelector::new(
+            configuration.uris.clone(),
+            Duration::from_millis(configuration.min_retry_duration),
+            Duration::from_millis(configuration.max_retry_duration),
+        );
+
+        Self {
+            configuration,
+            sender,
+            name,
+            uri_selector,
+        }
+    }
+
+    /// Establishes a WebSocket connection and manages the read and write tasks.
+    ///
+    /// This function attempts to establish a WebSocket connection using the URI provided by the
+    /// `uri_selector`. If the connection is successful, the WebSocket is marked as healthy. The function
+    /// then splits the WebSocket into write and read halves and spawns separate tasks to handle
+    /// writing messages to and reading messages from the WebSocket. Finally, it waits for these tasks
+    /// to complete.
+    ///
+    /// # Tasks
+    /// - **Write Task**: Periodically sends a predefined message to the WebSocket.
+    /// - **Read Task**: Reads messages from the WebSocket and forwards them to the executor.
+    ///
+    /// # Behavior
+    /// - If the WebSocket connection is established successfully, the WebSocket is marked as healthy.
+    /// - The WebSocket is split into write and read halves.
+    /// - Separate asynchronous tasks are spawned to handle writing to and reading from the WebSocket.
+    /// - The function waits for both tasks to complete, handling any unexpected terminations.
+    async fn start(&mut self) {
+        let uri = self.uri_selector.next_uri();
+
+        if let Ok(socket) = establish_connection(&uri, &self.configuration.headers).await {
+            // Mark the WebSocket as healthy again
+            self.uri_selector.reset_failure();
+
+            let (write, read) = socket.split();
+
+            let write_handle = self.spawn_write_task(write, uri.clone()).await;
+            let read_handle = self
+                .spawn_read_task(read, self.sender.clone(), uri.clone())
+                .await;
+
+            self.await_tasks(write_handle, read_handle).await;
+        }
+    }
+
+    /// Spawns a task to periodically send a predefined message to the WebSocket.
+    ///
+    /// This function creates a task that periodically sends a message to the
+    /// WebSocket. The message to be sent and the interval between sends are defined in the
+    /// configuration of the current instance. If an error occurs while sending the message, the task
+    /// logs the error and terminates.
+    ///
+    /// # Parameters
+    /// - `self`: A reference to the current instance.
+    /// - `write`: The write half of the split WebSocket stream.
+    /// - `uri`: The URI of the WebSocket.
+    ///
+    /// # Returns
+    /// An optional `JoinHandle` for the spawned task. If no message is configured, it returns `None`.
+    ///
+    /// # Errors
+    /// If an error occurs while sending a message to the WebSocket, the task logs the error and
+    /// terminates.
+    async fn spawn_write_task(
+        &self,
+        mut write: SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, WSMessage>,
+        uri: Uri,
+    ) -> Option<JoinHandle<()>> {
+        if let Some(message) = &self.configuration.message {
+            let name = self.name.clone();
+            let socket_msg = message.clone();
+            let sleep_duration = self.configuration.sleep_duration;
+
+            Some(tokio::spawn(async move {
+                loop {
+                    if let Err(e) = write.send(WSMessage::Text(socket_msg.clone())).await {
+                        error!("Failed to send message to WS: [{name}] at [{uri}]. Error: {e}");
+                        return;
+                    }
+                    tokio::time::sleep(Duration::from_millis(sleep_duration)).await;
+                }
+            }))
+        } else {
+            None
+        }
+    }
+
+    /// Spawns a task to read messages from the WebSocket and process them.
+    ///
+    /// This function creates an asynchronous task that reads messages from the WebSocket. For each
+    /// message read, it creates a log message and sends it to a specified channel. If an error occurs
+    /// while reading from the WebSocket, the task logs the error and terminates.
+    ///
+    /// # Parameters
+    /// - `self`: A reference to the current instance.
+    /// - `read`: The read half of the split WebSocket stream.
+    /// - `sender`: A channel sender to which log messages are sent.
+    /// - `uri`: The URI of the WebSocket.
+    ///
+    /// # Returns
+    /// A `JoinHandle` for the spawned task.
+    ///
+    /// # Errors
+    /// If an error occurs while reading a message from the WebSocket or sending a log message to the
+    /// channel, the task logs the error and terminates.
+    async fn spawn_read_task(
+        &self,
+        mut read: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
+        sender: Sender<Message>,
+        uri: Uri,
+    ) -> JoinHandle<()> {
+        let name = self.name.clone();
+        let log_type = self.configuration.log_type.clone();
+        let log_source = LogSource::Generator(Generator::Websocket(name.clone()));
+        let logbacks_allowed = self.configuration.logbacks_allowed.clone();
+
+        tokio::spawn(async move {
+            while let Some(message) = read.next().await {
+                match message {
+                    Ok(msg) => {
+                        let log_message = Message::new(
+                            log_type.clone(),
+                            msg.into_data(),
+                            log_source.clone(),
+                            logbacks_allowed.clone(),
+                        );
+
+                        if sender.send(log_message).is_err() {
+                            error!("Failed to send log to executor");
+                        }
+                    }
+                    Err(e) => {
+                        error!("Failed to read from WebSocket: [{name}] at [{uri}]. Error: {e}");
+                        return;
+                    }
+                }
+            }
+        })
+    }
+
+    /// Waits for the read and write tasks to complete, handling any unexpected terminations.
+    ///
+    /// This function waits for the completion of the read and write tasks. If either task terminates
+    /// unexpectedly, it logs an error message. If no write task is spawned, it only waits for the
+    /// read task.
+    ///
+    /// # Parameters
+    /// - `self`: A reference to the current instance.
+    /// - `write_handle`: An optional `JoinHandle` for the write task.
+    /// - `read_handle`: A `JoinHandle` for the read task.
+    ///
+    /// # Behavior
+    /// - If both write and read tasks are provided, it waits for both tasks to complete.
+    /// - If only the read task is provided, it waits for the read task to complete.
+    /// - Logs an error message if either task finishes unexpectedly.
+    async fn await_tasks(&self, write_handle: Option<JoinHandle<()>>, read_handle: JoinHandle<()>) {
+        match write_handle {
+            Some(write_handle) => {
+                tokio::select! {
+                    _ = write_handle => {
+                        error!("Write task for WebSocket: [{}] finished unexpectedly", &self.name);
+                    },
+                    _ = read_handle => {
+                        error!("Read task for WebSocket: [{}] finished unexpectedly", &self.name);
+                    },
+                }
+            }
+            None => {
+                tokio::select! {
+                    _ = read_handle => {
+                        error!("Read task for WebSocket: [{}] finished unexpectedly", &self.name);
+                    },
+                }
+            }
+        }
+    }
+}
+
+/// Establishes a WebSocket connection to the specified URI with optional custom headers.
+///
+/// This function attempts to establish a WebSocket connection to the given URI using `connect_async`.
+/// If successful, it returns the WebSocket stream. If the connection attempt fails, it logs an error
+/// message and returns `Errors::SocketCreationFailure`. Optionally, custom headers can be provided
+/// to be included in the connection request.
+///
+/// # Parameters
+/// - `uri`: A reference to the URI of the WebSocket.
+/// - `user_configured_headers`: An optional reference to a hashmap containing custom headers to be included in the request.
+///
+/// # Returns
+/// A `Result` containing the WebSocket stream on success, or an `Errors` enum variant on failure.
+///
+/// # Errors
+/// - `Errors::SocketCreationFailure`: Returned if the connection attempt fails.
+/// - `Errors::MisconfiguredHeaders`: Returned if the provided headers are misconfigured.
+///
+/// # Note
+/// If `user_configured_headers` contains headers required for WebSocket connections (e.g., `sec-websocket-key`),
+/// they will be overwritten with the user-provided values, which may cause the request to fail.
+async fn establish_connection(
+    uri: &Uri,
+    user_configured_headers: &Option<HeaderMap>,
+) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, Errors> {
+    let mut request = uri
+        .into_client_request()
+        .map_err(|_| Errors::SocketCreationFailure)?;
+
+    if let Some(headers) = user_configured_headers {
+        let request_headers = request.headers_mut();
+        for (key, value) in headers {
+            request_headers.entry(key).or_insert(value.clone());
+        }
+    }
+
+    let (socket, _) = connect_async(request).await.map_err(|e| {
+        error!("Failed to establish connection to [{uri}]. Error: {e}");
+        Errors::SocketCreationFailure
+    })?;
+
+    Ok(socket)
+}

--- a/plaid/src/data/websocket/mod.rs
+++ b/plaid/src/data/websocket/mod.rs
@@ -298,7 +298,7 @@ impl WebSocketClient {
     ) -> JoinHandle<()> {
         let name = self.name.clone();
         let log_type = self.configuration.log_type.clone();
-        let log_source = LogSource::Generator(Generator::Websocket(name.clone()));
+        let log_source = LogSource::Generator(Generator::WebSocketExternal(name.clone()));
         let logbacks_allowed = self.configuration.logbacks_allowed.clone();
 
         tokio::spawn(async move {

--- a/plaid/src/data/websocket/mod.rs
+++ b/plaid/src/data/websocket/mod.rs
@@ -77,7 +77,18 @@ where
     let uris = uris_raw
         .iter()
         .filter_map(|uri| match Uri::from_str(uri) {
-            Ok(valid_uri) => Some(valid_uri),
+            Ok(valid_uri) => {
+                if let Some(scheme) = valid_uri.scheme() {
+                    if scheme != "wss" {
+                        warn!(
+                            "Insecure protocol detected: [{}] for URI: [{}]. Consider using 'wss' if possible.",
+                            scheme, uri
+                        );
+                    }
+                }
+
+                Some(valid_uri)
+            },
             Err(e) => {
                 error!("Invalid URI provided: {}. Error: {}", uri, e);
                 None

--- a/plaid/src/data/websocket/mod.rs
+++ b/plaid/src/data/websocket/mod.rs
@@ -180,6 +180,7 @@ impl WebsocketGenerator {
         );
 
         for mut client in self.clients {
+            info!("Starting [{}]", client.name);
             let logger = self.logger.clone();
             tokio::spawn(async move {
                 loop {

--- a/plaid/src/data/websocket/mod.rs
+++ b/plaid/src/data/websocket/mod.rs
@@ -24,8 +24,10 @@ enum Errors {
     SocketCreationFailure,
 }
 
+/// Configuration of all WebSocket data generators.
 #[derive(Deserialize)]
-pub struct WebsocketDataGenerator {
+pub struct WebSocketDataGenerator {
+    /// A map of WebSocket configurations, identified by its name.
     websockets: HashMap<String, WebSocket>,
 }
 
@@ -171,7 +173,7 @@ pub struct WebsocketGenerator {
 /// # Returns
 /// A new `WebsocketGenerator` instance.
 impl WebsocketGenerator {
-    pub fn new(config: WebsocketDataGenerator, sender: Sender<Message>, logger: Logger) -> Self {
+    pub fn new(config: WebSocketDataGenerator, sender: Sender<Message>, logger: Logger) -> Self {
         let clients = config
             .websockets
             .into_iter()

--- a/plaid/src/data/websocket/mod.rs
+++ b/plaid/src/data/websocket/mod.rs
@@ -32,8 +32,10 @@ pub struct WebsocketDataGenerator {
 /// Represents the configuration for a WebSocket connection.
 #[derive(Deserialize)]
 pub struct WebSocket {
-    /// The URI(s) of the WebSocket endpoint. The config allows multiple URIs in the event that one fails,
-    /// a new one can be used in its place.
+    /// A map of URIs for the WebSocket endpoint(s). The configuration supports multiple URIs
+    /// to allow for failover scenarios. If a connection fails, the system implements exponential
+    /// backoff, selecting the URI whose retry period has elapsed. If none are available, the URI
+    /// with the shortest remaining retry time is chosen.
     #[serde(deserialize_with = "parse_uris")]
     uris: HashMap<String, Uri>,
     /// A string indicating the type of log associated with the WebSocket.

--- a/plaid/src/data/websocket/selector.rs
+++ b/plaid/src/data/websocket/selector.rs
@@ -107,8 +107,7 @@ impl UriSelector {
 
         // If the next attempt hasn't passed, sleep until the socket is ready
         if uri.next_attempt < now {
-            let sleep_duration = uri.next_attempt - now;
-            sleep_until((now + sleep_duration).into()).await;
+            sleep_until((uri.next_attempt).into()).await;
         }
 
         Some((uri.name.clone(), uri.uri.clone()))

--- a/plaid/src/data/websocket/selector.rs
+++ b/plaid/src/data/websocket/selector.rs
@@ -1,0 +1,117 @@
+use http::Uri;
+use std::time::{Duration, Instant};
+
+/// Represents a single URI entry with backoff duration and next attempt time.
+///
+/// The `UriEntry` struct contains information about a URI, including the duration to wait before
+/// retrying a connection (`backoff_duration`) and the time when the next connection attempt
+/// should be made.
+#[derive(Debug)]
+struct UriEntry {
+    /// The URI to connect to.
+    uri: Uri,
+    /// The duration to wait before retrying a connection.
+    backoff_duration: Duration,
+    /// The time when the next connection attempt should be made.
+    next_attempt: Instant,
+}
+
+/// Manages a list of URI entries and handles the selection and retry logic for connection attempts.
+///
+/// The `UriSelector` struct contains a collection of `UriEntry` instances and manages the logic
+/// for selecting the next URI to attempt a connection to, including backoff and retry mechanisms.
+#[derive(Debug)]
+pub struct UriSelector {
+    /// A list of `UriEntry` instances.
+    uris: Vec<UriEntry>,
+    /// The index of the currently selected URI.
+    current_index: usize,
+    /// The initial duration to wait before retrying a connection.
+    initial_retry_after: Duration,
+    /// The maximum duration to wait before retrying a connection.
+    max_retry_after: Duration,
+}
+
+impl UriSelector {
+    /// Creates a new `UriSelector` with the given list of URIs, initial retry duration, and maximum retry duration.
+    ///
+    /// # Arguments
+    ///
+    /// * `uris` - A vector of `Uri` objects representing the URIs to manage.
+    /// * `initial_retry_after` - A `Duration` specifying the initial time to wait before retrying a failed URI.
+    /// * `max_retry_after` - A `Duration` specifying the maximum time to wait before retrying a failed URI.
+    ///
+    /// # Returns
+    ///
+    /// A `UriSelector` instance with the given URIs and retry durations.
+    pub fn new(uris: Vec<Uri>, initial_retry_after: Duration, max_retry_after: Duration) -> Self {
+        let now = Instant::now();
+        UriSelector {
+            uris: uris
+                .into_iter()
+                .map(|uri| UriEntry {
+                    uri,
+                    backoff_duration: initial_retry_after,
+                    next_attempt: now,
+                })
+                .collect(),
+            current_index: 0,
+            initial_retry_after,
+            max_retry_after,
+        }
+    }
+
+    /// Selects the next URI to use, prioritizing URIs with the shortest backoff duration.
+    ///
+    /// This function sorts the URIs by their next attempt time,
+    /// and returns the URI with the shortest backoff duration that is ready for the next attempt.
+    ///
+    /// # Returns
+    ///
+    /// The `Uri` of the next URI to use.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the URI list is empty, although in practice this should never be possible.
+    pub fn next_uri(&mut self) -> Uri {
+        // Sort URIs by next attempt time
+        self.uris.sort_by_key(|entry| entry.next_attempt);
+
+        // Select the URI with the shortest backoff duration that is ready for the next attempt
+        let now = Instant::now();
+        for (index, entry) in self.uris.iter().enumerate() {
+            if now >= entry.next_attempt {
+                self.current_index = index;
+                return entry.uri.clone();
+            }
+        }
+
+        // If no URIs are ready, select the one with the earliest next attempt time
+        self.current_index = 0;
+        self.uris
+            .first()
+            .expect("URI list should never be empty")
+            .uri
+            .clone()
+    }
+
+    /// Marks the currently selected URI as failed, updating its backoff duration and next attempt time.
+    pub fn mark_failed(&mut self) {
+        if let Some(entry) = self.uris.get_mut(self.current_index) {
+            entry.backoff_duration = (entry.backoff_duration * 2).min(self.max_retry_after);
+            entry.next_attempt = Instant::now() + entry.backoff_duration;
+        }
+    }
+
+    /// Resets the backoff duration and next attempt time for the currently selected URI.
+    ///
+    /// This function resets the backoff duration to the initial value
+    /// and sets the next attempt time to now.
+    /// It can be used after a successful connection to a URI to indicate that it is healthy again.
+    pub fn reset_failure(&mut self) {
+        if let Some(entry) = self.uris.get_mut(self.current_index) {
+            entry.backoff_duration = self.initial_retry_after;
+            entry.next_attempt = Instant::now();
+        }
+    }
+}

--- a/plaid/src/logging/mod.rs
+++ b/plaid/src/logging/mod.rs
@@ -47,6 +47,9 @@ pub enum Log {
         error: String,
         log: String,
     },
+    WebSocketConnectionDropped {
+        socket_name: String,
+    },
     /// Is not used by other components of Plaid. This is created and sent
     /// by the logging system if it has not received a message from the server
     /// module for a period of time.
@@ -160,6 +163,12 @@ impl Logger {
     ) -> Result<(), LoggingError> {
         self.sender
             .send(Log::InternalMessage { severity, message })
+            .map_err(|_| LoggingError::LoggingSystemDead)
+    }
+
+    pub fn log_websocket_dropped(&self, socket_name: String) -> Result<(), LoggingError> {
+        self.sender
+            .send(Log::WebSocketConnectionDropped { socket_name })
             .map_err(|_| LoggingError::LoggingSystemDead)
     }
 

--- a/plaid/src/logging/stdout.rs
+++ b/plaid/src/logging/stdout.rs
@@ -16,15 +16,24 @@ impl StdoutLogger {
 impl PlaidLogger for StdoutLogger {
     fn send_log(&self, log: &WrappedLog) -> Result<(), LoggingError> {
         match &log.log {
-            Log::InternalMessage{severity, message} => match severity {
+            Log::InternalMessage { severity, message } => match severity {
                 Severity::Error => error!("{}", message),
                 Severity::Warning => warn!("{}", message),
                 Severity::Info => info!("{}", message),
             },
-            Log::HostFunctionCall { module, function } => debug!("[{module}] is calling [{function}]"),
-            Log::ModuleExecutionError { module, error, log } => debug!("[{module}] errored with error [{error}]. Provided Log: {log}"),
-            Log::TimeseriesPoint { measurement, value } => trace!("New TS Point: ({measurement}, {value})"),
-            Log::Heartbeat{..} => (),
+            Log::HostFunctionCall { module, function } => {
+                debug!("[{module}] is calling [{function}]")
+            }
+            Log::ModuleExecutionError { module, error, log } => {
+                debug!("[{module}] errored with error [{error}]. Provided Log: {log}")
+            }
+            Log::TimeseriesPoint { measurement, value } => {
+                trace!("New TS Point: ({measurement}, {value})")
+            }
+            Log::WebSocketConnectionDropped { socket_name } => {
+                warn!("Connection to socket: {socket_name} dropped unexpectedly");
+            }
+            Log::Heartbeat { .. } => (),
         }
         Ok(())
     }


### PR DESCRIPTION
This PR implements WebSocket data generators to Plaid. 

The `websocket` module defines an optional `WebsocketDataGenerator` configuration struct that takes map of generator names to socket configuration. This allows us to give names to the generators that will later by passed to rules.

In the example configuration below, we define a generator named `demo_rpc_call`. Its fields are:
- `uris`: A list of URIs that can generate data. We allow for many URIs to add resiliency in the case that a socket becomes disconnected. The generator implements a round-robin strategy with exponential backoff to retry connections to sockets on failure.
    - There are two additional fields for further customization of the retry strategy: (1) `min_retry_duration` and (2) `max_retry_duration`. As their names suggest, these are the minimum and maximum amount of time to wait before retrying connections. If no values are provided for either `min_retry_duration` defaults to 100 milliseconds and `max_retry_duration` defaults to 60000 milliseconds (1 minute).
- `message`: This is the data sent in the message to the socket. This field is `Option` in the event that you only need to read from a socket.
- `sleep_duration`: The time to wait in between sending new messages t the socket
- `headers`: Optional headers to include in the request. _Note: These headers will NOT overwrite headers required for the socket connection (e.g. `sec-websocket-key`)_.

```toml
[data.websocket]
[data.websocket.websockets]
[data.websocket."websockets"."demo_rpc_call"]
uris = ["wss://some_rpc"]
message = "{ \"id\": 1, \"jsonrpc\": \"2.0\", \"method\": \"eth_getBlockByNumber\", \"params\": [ \"finalized\", false ]}"
log_type = "testing"
sleep_duration = 0
[data.websocket."websockets"."demo_rpc_call"."headers"]
"some-custom-header" = "asdf"
"another-custom-header" = "asdf"
```

**Tasks**
Each WebSocket spawns up to two tasks: a read task and a write task. If no message is provided in the configuration, the write task is not spawned. If either of these tasks returns, the connection to the socket has closed and we must restart.
