### PR TITLE
KMS tweaks

### DIFF
--- a/plaid-stl/src/aws/kms.rs
+++ b/plaid-stl/src/aws/kms.rs
@@ -105,7 +105,7 @@ pub fn sign_arbitrary_message(
     signing_algorithm: SigningAlgorithm,
 ) -> Result<SignRequestResponse, PlaidFunctionError> {
     extern "C" {
-        new_host_function_with_error_buffer!(kms, sign_arbitrary_message);
+        new_host_function_with_error_buffer!(aws_kms, sign_arbitrary_message);
     }
 
     #[derive(Serialize)]
@@ -128,7 +128,7 @@ pub fn sign_arbitrary_message(
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
     let res = unsafe {
-        kms_sign_arbitrary_message(
+        aws_kms_sign_arbitrary_message(
             request.as_ptr(),
             request.len(),
             return_buffer.as_mut_ptr(),
@@ -165,7 +165,7 @@ pub fn sign_arbitrary_message(
 /// - `message`: The message or message digest to be signed by KMS.
 pub fn get_public_key(key_id: &str) -> Result<GetPublicKeyResponse, PlaidFunctionError> {
     extern "C" {
-        new_host_function_with_error_buffer!(kms, get_public_key);
+        new_host_function_with_error_buffer!(aws_kms, get_public_key);
     }
 
     let mut request = HashMap::new();
@@ -176,7 +176,7 @@ pub fn get_public_key(key_id: &str) -> Result<GetPublicKeyResponse, PlaidFunctio
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
     let res = unsafe {
-        kms_get_public_key(
+        aws_kms_get_public_key(
             request.as_ptr(),
             request.len(),
             return_buffer.as_mut_ptr(),

--- a/plaid-stl/src/aws/kms.rs
+++ b/plaid-stl/src/aws/kms.rs
@@ -100,7 +100,7 @@ impl Serialize for SigningAlgorithm {
 /// A `Result` containing either the `SignRequestResponse` with the signing details or a `PlaidFunctionError` if something went wrong.
 pub fn sign_arbitrary_message(
     key_id: &str,
-    message: &str,
+    message: Vec<u8>,
     message_type: MessageType,
     signing_algorithm: SigningAlgorithm,
 ) -> Result<SignRequestResponse, PlaidFunctionError> {
@@ -111,14 +111,14 @@ pub fn sign_arbitrary_message(
     #[derive(Serialize)]
     struct SignRequestRequest {
         key_id: String,
-        message: String,
+        message: Vec<u8>,
         message_type: MessageType,
         signing_algorithm: SigningAlgorithm,
     }
 
     let request = SignRequestRequest {
         key_id: key_id.to_string(),
-        message: message.to_string(),
+        message,
         message_type,
         signing_algorithm,
     };

--- a/plaid/Cargo.toml
+++ b/plaid/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["aws"]
 #quorum = ["quorum-agent"]
 aws = ["aws-sdk-kms", "aws-config"]
 

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -387,12 +387,12 @@ pub fn to_api_function(
 
         // KMS calls
         #[cfg(feature = "aws")]
-        "kms_sign_arbitrary_message" => {
+        "aws_kms_sign_arbitrary_message" => {
             Function::new_typed_with_env(&mut store, &env, aws_kms_sign_arbitrary_message)
         }
 
         #[cfg(feature = "aws")]
-        "kms_get_public_key" => {
+        "aws_kms_get_public_key" => {
             Function::new_typed_with_env(&mut store, &env, aws_kms_get_public_key)
         }
 

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -387,12 +387,12 @@ pub fn to_api_function(
 
         // KMS calls
         #[cfg(feature = "aws")]
-        "aws_kms_sign_arbitrary_message" => {
+        "kms_sign_arbitrary_message" => {
             Function::new_typed_with_env(&mut store, &env, aws_kms_sign_arbitrary_message)
         }
 
         #[cfg(feature = "aws")]
-        "aws_kms_get_public_key" => {
+        "kms_get_public_key" => {
             Function::new_typed_with_env(&mut store, &env, aws_kms_get_public_key)
         }
 


### PR DESCRIPTION
Addresses bugs I've run into when trying to write a rule using the new KMS APIs.

Passing the message from KMS to sign as a `String` was silly of me - have made that a `Vec<u8>` now which allows us to do away with the `parse_message` function. 

I also ran into issues using API key auth with short lived credentials to AWS as I was missing a session token. We now allow for an optional session token in the `Authentication` enum.

Finally, I linked the functions incorrectly and have now fixed that

(Also enables AWS by default)