### PR TITLE
Add npm API to Plaid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base32"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,7 +608,7 @@ checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
 ]
 
 [[package]]
@@ -721,8 +727,10 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -790,9 +798,43 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
+
+[[package]]
+name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "cookie"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387461abbc748185c3a6e1673d826918b450b87ff22639429c694619a83b6cf6"
+dependencies = [
+ "cookie",
+ "idna 0.3.0",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1267,6 +1309,28 @@ checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1861,6 +1925,16 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
@@ -2027,6 +2101,17 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "redox_syscall 0.5.3",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2559,7 +2644,9 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "env_logger",
+ "flate2",
  "futures-util",
+ "hex",
  "http 1.1.0",
  "jsonwebtoken",
  "jwt-simple",
@@ -2575,10 +2662,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sled",
+ "tar",
  "time",
  "tokio",
  "tokio-tungstenite 0.23.1",
  "toml",
+ "totp-rs",
+ "url",
  "warp",
  "wasmer",
  "wasmer-middlewares",
@@ -2588,6 +2678,7 @@ dependencies = [
 name = "plaid_stl"
 version = "0.12.0"
 dependencies = [
+ "chrono",
  "paste",
  "serde",
  "serde_json",
@@ -2651,6 +2742,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2668,6 +2765,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
+dependencies = [
+ "idna 0.3.0",
+ "psl-types",
 ]
 
 [[package]]
@@ -2842,6 +2949,8 @@ checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.7",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -3530,6 +3639,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3732,6 +3852,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "totp-rs"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b2f27dad992486c26b4e7455f38aa487e838d6d61b57e72906ee2b8c287a90"
+dependencies = [
+ "base32",
+ "constant_time_eq 0.2.6",
+ "hmac",
+ "sha1",
+ "sha2",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3917,7 +4050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
  "serde",
 ]
@@ -4521,6 +4654,17 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys",
+ "rustix",
 ]
 
 [[package]]

--- a/plaid-stl/Cargo.toml
+++ b/plaid-stl/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = { version = "0.4", features = ["serde"] }
 paste = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/plaid-stl/src/lib.rs
+++ b/plaid-stl/src/lib.rs
@@ -63,6 +63,7 @@ impl From<PlaidFunctionError> for i32 {
 pub mod aws;
 pub mod github;
 pub mod network;
+pub mod npm;
 pub mod okta;
 pub mod pagerduty;
 pub mod plaid;

--- a/plaid-stl/src/npm/mod.rs
+++ b/plaid-stl/src/npm/mod.rs
@@ -1,0 +1,540 @@
+use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::PlaidFunctionError;
+
+use chrono::{DateTime, Utc};
+
+// All the structs which are also used in the Plaid API
+
+/// Permission that is granted to a team over an npm package
+#[derive(Serialize, Deserialize)]
+pub enum NpmPackagePermission {
+    READ,
+    WRITE,
+}
+
+impl ToString for NpmPackagePermission {
+    fn to_string(&self) -> String {
+        match self {
+            Self::READ => "read".to_string(),
+            Self::WRITE => "write".to_string(),
+        }
+    }
+}
+
+/// Teams in the npm organization
+#[derive(Serialize, Deserialize)]
+pub enum NpmTeam {
+    Admins,
+    Developers,
+}
+
+impl ToString for NpmTeam {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Admins => "Admins".to_string(),
+            Self::Developers => "developers".to_string(),
+        }
+    }
+}
+
+/// Role that a user can have in the npm organization
+#[derive(Debug, Deserialize, Serialize)]
+pub enum NpmUserRole {
+    Member,
+    Admin,
+    Owner,
+}
+
+impl NpmUserRole {
+    // We do not implement the TryFrom trait because of the error type. We do not want to carry the
+    // NpmError struct here in the STL. Also, we don't care about which error we get from here. If
+    // it fails, the caller will know what to do.
+    pub fn try_from(value: String) -> Result<Self, ()> {
+        match value.as_str() {
+            "developer" => Ok(NpmUserRole::Member),
+            "admin" => Ok(NpmUserRole::Admin), // untested: I think we do not have Admins
+            "super-admin" => Ok(NpmUserRole::Owner),
+            _ => Err(()),
+        }
+    }
+}
+
+/// A user in the npm organization
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NpmUser {
+    pub username: String,
+    pub role: NpmUserRole,
+}
+
+/// Org-level permission granted to a granular token.
+///
+/// Note: this is incomplete. Other permission levels are possible, but we never needed to add them.
+#[derive(Clone, Serialize, Deserialize)]
+pub enum GranularTokenOrgsPermission {
+    NoAccess,
+}
+
+impl ToString for GranularTokenOrgsPermission {
+    fn to_string(&self) -> String {
+        match self {
+            GranularTokenOrgsPermission::NoAccess => "No access".to_string(),
+        }
+    }
+}
+
+/// Package-level permission granted to a granular token.
+///
+/// Note: this is incomplete. Other permission levels are possible, but we never needed to add them.
+#[derive(Clone, Serialize, Deserialize)]
+pub enum GranularTokenPackagesAndScopesPermission {
+    ReadAndWrite,
+}
+
+impl ToString for GranularTokenPackagesAndScopesPermission {
+    fn to_string(&self) -> String {
+        match self {
+            GranularTokenPackagesAndScopesPermission::ReadAndWrite => "Read and write".to_string(),
+        }
+    }
+}
+
+/// TODO I don't exactly know what this means
+#[derive(Clone, Serialize, Deserialize)]
+pub enum GranularTokenSelectedPackagesAndScopes {
+    PackagesAndScopesSome,
+}
+
+impl ToString for GranularTokenSelectedPackagesAndScopes {
+    fn to_string(&self) -> String {
+        match self {
+            GranularTokenSelectedPackagesAndScopes::PackagesAndScopesSome => {
+                "packagesAndScopesSome".to_string()
+            }
+        }
+    }
+}
+
+/// Groups together all the input that we expect from a rule that requests
+/// the generation of a granular token. Optional fields will have a default value.
+#[derive(Serialize, Deserialize)]
+pub struct GranularTokenSpecs {
+    pub allowed_ip_ranges: Option<Vec<String>>,
+    pub expiration_days: Option<u16>,
+    pub orgs_permission: Option<GranularTokenOrgsPermission>,
+    pub packages_and_scopes_permission: Option<GranularTokenPackagesAndScopesPermission>,
+    pub selected_orgs: Option<Vec<String>>,
+    pub selected_packages: Option<Vec<String>>,
+    pub selected_packages_and_scopes: Option<GranularTokenSelectedPackagesAndScopes>,
+    pub selected_scopes: Option<Vec<String>>,
+    pub token_name: String,
+    pub token_description: String,
+}
+
+impl GranularTokenSpecs {
+    /// Provide a name and description for the token, and set all other fields to None, which
+    /// will result in default values being used.
+    pub fn with_name_and_description(token_name: &str, token_description: &str) -> Self {
+        // TODO We could check some things about name and description. E.g., the description
+        // should be longer than 8 characters to avoid "test" and "testing".
+        Self {
+            token_name: token_name.to_string(),
+            token_description: token_description.to_string(),
+            allowed_ip_ranges: None,
+            expiration_days: None,
+            orgs_permission: None,
+            packages_and_scopes_permission: None,
+            selected_orgs: None,
+            selected_packages: None,
+            selected_packages_and_scopes: None,
+            selected_scopes: None,
+        }
+    }
+}
+
+/// An npm token configured on the npm website for the current user
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[allow(dead_code)]
+pub struct NpmToken {
+    token: String,
+    token_name: Option<String>,
+    pub token_type: Option<String>,
+    // Deserialize the date field from the ISO 8601 format
+    #[serde(default, deserialize_with = "deserialize_option_timestamp")]
+    expires: Option<DateTime<Utc>>,
+}
+
+// Custom deserializer for an optional DateTime<Utc>
+fn deserialize_option_timestamp<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Try to deserialize as a string (ISO 8601 format) or return None if missing
+    let opt = Option::<String>::deserialize(deserializer)?;
+
+    // Parse the timestamp string into a DateTime<Utc>, if it's present
+    Ok(opt.and_then(|s| {
+        DateTime::parse_from_rfc3339(&s)
+            .ok()
+            .map(|dt| dt.with_timezone(&Utc))
+    }))
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SetTeamPermissionOnPackageParams {
+    pub team: String,
+    pub package: String,
+    pub permission: NpmPackagePermission,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CreateGranularTokenForPackageParams {
+    pub package: String,
+    pub specs: GranularTokenSpecs,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct AddRemoveUserToFromTeamParams {
+    pub user: String,
+    pub team: NpmTeam,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct InviteUserToOrganizationParams {
+    pub user: String,
+    pub team: Option<NpmTeam>,
+}
+
+/// Access level for an npm package
+#[derive(Serialize, Deserialize)]
+pub enum PkgAccessLevel {
+    Restricted,
+    Public,
+}
+
+impl PkgAccessLevel {
+    pub fn to_string(&self) -> String {
+        match self {
+            PkgAccessLevel::Restricted => "restricted".to_string(),
+            PkgAccessLevel::Public => "public".to_string(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PublishEmptyStubParams {
+    pub package_name: String,
+    pub access_level: PkgAccessLevel,
+}
+
+// End of "All the structs which are also used in the Plaid API"
+
+/// Retrieve a list of users in the npm organization
+pub fn get_org_user_list() -> Result<Vec<NpmUser>, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(npm, get_org_user_list);
+    }
+    const RETURN_BUFFER_SIZE: usize = 32 * 1024; // 32 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let params = "".to_string();
+
+    let res = unsafe {
+        npm_get_org_user_list(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    let res = String::from_utf8(return_buffer).unwrap();
+
+    serde_json::from_str::<Vec<NpmUser>>(&res).map_err(|_| PlaidFunctionError::InternalApiError)
+}
+
+/// Retrieve a list of users in the npm organization that do not have 2FA enabled
+pub fn get_org_users_without_2fa() -> Result<Vec<NpmUser>, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(npm, get_org_users_without_2fa);
+    }
+    const RETURN_BUFFER_SIZE: usize = 32 * 1024; // 32 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let params = "".to_string();
+
+    let res = unsafe {
+        npm_get_org_users_without_2fa(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    let res = String::from_utf8(return_buffer).unwrap();
+
+    serde_json::from_str::<Vec<NpmUser>>(&res).map_err(|_| PlaidFunctionError::InternalApiError)
+}
+
+/// Invite a user to join the npm organization. If the user accepts the invite, they will be added
+/// to the default team "developers".
+///
+/// TODO The Plaid API supports specifying another team as the default for the new user. Expose through the STL?
+pub fn invite_user_to_organization(user: &str) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(npm, invite_user_to_organization);
+    }
+
+    let params = serde_json::to_string(&InviteUserToOrganizationParams {
+        user: user.to_string(),
+        team: None,
+    })
+    .map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+
+    let res = unsafe {
+        npm_invite_user_to_organization(params.as_bytes().as_ptr(), params.as_bytes().len())
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    Ok(())
+}
+
+/// Remove a user from the npm organization
+pub fn remove_user_from_organization(user: &str) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(npm, remove_user_from_organization);
+    }
+
+    let params = user.to_string();
+
+    let res = unsafe {
+        npm_remove_user_from_organization(params.as_bytes().as_ptr(), params.as_bytes().len())
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    Ok(())
+}
+
+/// Create a granular npm token for a package. The token can be configured through the token_specs parameter.
+///
+/// If you are not sure about the token configuration, use `create_granular_token_for_package_simple` which only
+/// requires specifying a name and a description.
+pub fn create_granular_token_for_package(
+    package_name: &str,
+    token_specs: GranularTokenSpecs,
+) -> Result<String, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(npm, create_granular_token_for_package);
+    }
+
+    const RETURN_BUFFER_SIZE: usize = 8 * 1024; // 8 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let params = serde_json::to_string(&CreateGranularTokenForPackageParams {
+        package: package_name.to_string(),
+        specs: token_specs,
+    })
+    .map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+
+    let res = unsafe {
+        npm_create_granular_token_for_package(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    Ok(String::from_utf8(return_buffer).unwrap())
+}
+
+/// Create a granular npm token for a package, specifying only the token name and a suitable description.
+/// Other token configurations default to sensible values.
+pub fn create_granular_token_for_package_simple(
+    package_name: &str,
+    token_name: &str,
+    token_description: &str,
+) -> Result<String, PlaidFunctionError> {
+    let token_specs = GranularTokenSpecs::with_name_and_description(token_name, token_description);
+    create_granular_token_for_package(package_name, token_specs)
+}
+
+/// Retrieve a list of all granular tokens configured for the service account
+pub fn list_granular_tokens() -> Result<Vec<NpmToken>, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(npm, list_granular_tokens);
+    }
+
+    const RETURN_BUFFER_SIZE: usize = 32 * 1024; // 32 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let params = "".to_string();
+
+    let res = unsafe {
+        npm_list_granular_tokens(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    let res = String::from_utf8(return_buffer).unwrap();
+
+    serde_json::from_str::<Vec<NpmToken>>(&res).map_err(|_| PlaidFunctionError::InternalApiError)
+}
+
+/// Add a user to an npm team
+pub fn add_user_to_team(user: &str, team: NpmTeam) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(npm, add_user_to_team);
+    }
+
+    let params = serde_json::to_string(&AddRemoveUserToFromTeamParams {
+        user: user.to_string(),
+        team,
+    })
+    .map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+
+    let res = unsafe { npm_add_user_to_team(params.as_bytes().as_ptr(), params.as_bytes().len()) };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    Ok(())
+}
+
+/// Remove a user from an npm team
+pub fn remove_user_from_team(user: &str, team: NpmTeam) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(npm, remove_user_from_team);
+    }
+
+    let params = serde_json::to_string(&AddRemoveUserToFromTeamParams {
+        user: user.to_string(),
+        team,
+    })
+    .map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+
+    let res =
+        unsafe { npm_remove_user_from_team(params.as_bytes().as_ptr(), params.as_bytes().len()) };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    Ok(())
+}
+
+/// Publish an empty npm package, to be later updated.
+/// If an access level is not specified (i.e., None is passed), it defaults to "restricted".
+pub fn publish_empty_stub(
+    package_name: &str,
+    access_level: Option<PkgAccessLevel>,
+) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(npm, publish_empty_stub);
+    }
+
+    let access_level = access_level.unwrap_or(PkgAccessLevel::Restricted);
+
+    let params = serde_json::to_string(&PublishEmptyStubParams {
+        package_name: package_name.to_string(),
+        access_level,
+    })
+    .map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+
+    let res =
+        unsafe { npm_publish_empty_stub(params.as_bytes().as_ptr(), params.as_bytes().len()) };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    Ok(())
+}
+
+/// Set permissions for a team on a specific npm package
+pub fn set_team_permission_on_package(
+    package_name: &str,
+    team: NpmTeam,
+    permission: NpmPackagePermission,
+) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(npm, set_team_permission_on_package);
+    }
+
+    let params = serde_json::to_string(&SetTeamPermissionOnPackageParams {
+        team: team.to_string(),
+        package: package_name.to_string(),
+        permission,
+    })
+    .map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+
+    let res = unsafe {
+        npm_set_team_permission_on_package(params.as_bytes().as_ptr(), params.as_bytes().len())
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    Ok(())
+}
+
+/// Delete a package under the npm organization from the npm registry.
+///
+/// Note: The package name should be unscoped. If you are trying to delete
+/// @scope/package_name, then you should pass only "package_name". The scope is
+/// preconfigured in the client and will be added automatically.
+pub fn delete_package(package_name: &str) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(npm, delete_package);
+    }
+
+    let params = package_name.to_string();
+
+    let res = unsafe { npm_delete_package(params.as_bytes().as_ptr(), params.as_bytes().len()) };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    Ok(())
+}

--- a/plaid-stl/src/npm/mod.rs
+++ b/plaid-stl/src/npm/mod.rs
@@ -1,252 +1,9 @@
-use serde::{Deserialize, Deserializer, Serialize};
+pub mod shared_structs;
 
 use crate::PlaidFunctionError;
+use serde::Deserialize;
 
-use chrono::{DateTime, Utc};
-
-// All the structs which are also used in the Plaid API
-
-/// Permission that is granted to a team over an npm package
-#[derive(Serialize, Deserialize, Clone)]
-pub enum NpmPackagePermission {
-    READ,
-    WRITE,
-}
-
-impl ToString for NpmPackagePermission {
-    fn to_string(&self) -> String {
-        match self {
-            Self::READ => "read".to_string(),
-            Self::WRITE => "write".to_string(),
-        }
-    }
-}
-
-impl NpmPackagePermission {
-    // We do not implement the TryFrom trait because of the error type. We do not want to carry the
-    // NpmError struct here in the STL. Also, we don't care about which error we get from here. If
-    // it fails, the caller will know what to do.
-    pub fn try_from(value: String) -> Result<Self, ()> {
-        match value.as_str() {
-            "read" => Ok(NpmPackagePermission::READ),
-            "write" => Ok(NpmPackagePermission::WRITE),
-            _ => Err(()),
-        }
-    }
-}
-
-/// Teams in the npm organization
-#[derive(Serialize, Deserialize)]
-pub enum NpmTeam {
-    Admins,
-    Developers,
-}
-
-impl ToString for NpmTeam {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Admins => "Admins".to_string(),
-            Self::Developers => "developers".to_string(),
-        }
-    }
-}
-
-/// Role that a user can have in the npm organization
-#[derive(Debug, Deserialize, Serialize)]
-pub enum NpmUserRole {
-    Member,
-    Admin,
-    Owner,
-}
-
-impl NpmUserRole {
-    // We do not implement the TryFrom trait because of the error type. We do not want to carry the
-    // NpmError struct here in the STL. Also, we don't care about which error we get from here. If
-    // it fails, the caller will know what to do.
-    pub fn try_from(value: String) -> Result<Self, ()> {
-        match value.as_str() {
-            "developer" => Ok(NpmUserRole::Member),
-            "admin" => Ok(NpmUserRole::Admin), // untested: I think we do not have Admins
-            "super-admin" => Ok(NpmUserRole::Owner),
-            _ => Err(()),
-        }
-    }
-}
-
-/// A user in the npm organization
-#[derive(Debug, Serialize, Deserialize)]
-pub struct NpmUser {
-    pub username: String,
-    pub role: NpmUserRole,
-}
-
-/// Org-level permission granted to a granular token.
-///
-/// Note: this is incomplete. Other permission levels are possible, but we never needed to add them.
-#[derive(Clone, Serialize, Deserialize)]
-pub enum GranularTokenOrgsPermission {
-    NoAccess,
-}
-
-impl ToString for GranularTokenOrgsPermission {
-    fn to_string(&self) -> String {
-        match self {
-            GranularTokenOrgsPermission::NoAccess => "No access".to_string(),
-        }
-    }
-}
-
-/// Package-level permission granted to a granular token.
-///
-/// Note: this is incomplete. Other permission levels are possible, but we never needed to add them.
-#[derive(Clone, Serialize, Deserialize)]
-pub enum GranularTokenPackagesAndScopesPermission {
-    ReadAndWrite,
-}
-
-impl ToString for GranularTokenPackagesAndScopesPermission {
-    fn to_string(&self) -> String {
-        match self {
-            GranularTokenPackagesAndScopesPermission::ReadAndWrite => "Read and write".to_string(),
-        }
-    }
-}
-
-/// TODO I don't know what this means
-#[derive(Clone, Serialize, Deserialize)]
-pub enum GranularTokenSelectedPackagesAndScopes {
-    PackagesAndScopesSome,
-}
-
-impl ToString for GranularTokenSelectedPackagesAndScopes {
-    fn to_string(&self) -> String {
-        match self {
-            GranularTokenSelectedPackagesAndScopes::PackagesAndScopesSome => {
-                "packagesAndScopesSome".to_string()
-            }
-        }
-    }
-}
-
-/// Groups together all the input that we expect from a rule that requests
-/// the generation of a granular token. Optional fields will have a default value.
-#[derive(Serialize, Deserialize)]
-pub struct GranularTokenSpecs {
-    pub allowed_ip_ranges: Option<Vec<String>>,
-    pub expiration_days: Option<u16>,
-    pub orgs_permission: Option<GranularTokenOrgsPermission>,
-    pub packages_and_scopes_permission: Option<GranularTokenPackagesAndScopesPermission>,
-    pub selected_orgs: Option<Vec<String>>,
-    pub selected_packages: Option<Vec<String>>,
-    pub selected_packages_and_scopes: Option<GranularTokenSelectedPackagesAndScopes>,
-    pub selected_scopes: Option<Vec<String>>,
-    pub token_name: String,
-    pub token_description: String,
-}
-
-impl GranularTokenSpecs {
-    /// Provide a name and description for the token, and set all other fields to None, which
-    /// will result in default values being used.
-    pub fn with_name_and_description(token_name: &str, token_description: &str) -> Self {
-        // TODO We could check some things about name and description. E.g., the description
-        // should be longer than 8 characters to avoid "test" and "testing".
-        Self {
-            token_name: token_name.to_string(),
-            token_description: token_description.to_string(),
-            allowed_ip_ranges: None,
-            expiration_days: None,
-            orgs_permission: None,
-            packages_and_scopes_permission: None,
-            selected_orgs: None,
-            selected_packages: None,
-            selected_packages_and_scopes: None,
-            selected_scopes: None,
-        }
-    }
-}
-
-/// An npm token configured on the npm website for the current user
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[allow(dead_code)]
-pub struct NpmToken {
-    token: String,
-    token_name: Option<String>,
-    pub token_type: Option<String>,
-    // Deserialize the date field from the ISO 8601 format
-    #[serde(default, deserialize_with = "deserialize_option_timestamp")]
-    expires: Option<DateTime<Utc>>,
-}
-
-// Custom deserializer for an optional DateTime<Utc>
-fn deserialize_option_timestamp<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    // Try to deserialize as a string (ISO 8601 format) or return None if missing
-    let opt = Option::<String>::deserialize(deserializer)?;
-
-    // Parse the timestamp string into a DateTime<Utc>, if it's present
-    Ok(opt.and_then(|s| {
-        DateTime::parse_from_rfc3339(&s)
-            .ok()
-            .map(|dt| dt.with_timezone(&Utc))
-    }))
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct SetTeamPermissionOnPackageParams {
-    pub team: String,
-    pub package: String,
-    pub permission: NpmPackagePermission,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct CreateGranularTokenForPackageParams {
-    pub package: String,
-    pub specs: GranularTokenSpecs,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct AddRemoveUserToFromTeamParams {
-    pub user: String,
-    pub team: NpmTeam,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct InviteUserToOrganizationParams {
-    pub user: String,
-    pub team: Option<NpmTeam>,
-}
-
-/// Access level for an npm package
-#[derive(Serialize, Deserialize)]
-pub enum PkgAccessLevel {
-    Restricted,
-    Public,
-}
-
-impl PkgAccessLevel {
-    pub fn to_string(&self) -> String {
-        match self {
-            PkgAccessLevel::Restricted => "restricted".to_string(),
-            PkgAccessLevel::Public => "public".to_string(),
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct PublishEmptyStubParams {
-    pub package_name: String,
-    pub access_level: PkgAccessLevel,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct ListPackagesWithTeamPermissionParams {
-    pub team: NpmTeam,
-    pub permission: NpmPackagePermission,
-}
-
-// End of "All the structs which are also used in the Plaid API"
+use shared_structs::*;
 
 /// Retrieve a list of users in the npm organization
 pub fn get_org_user_list() -> Result<Vec<NpmUser>, PlaidFunctionError> {
@@ -312,16 +69,17 @@ pub fn get_org_users_without_2fa() -> Result<Vec<NpmUser>, PlaidFunctionError> {
 
 /// Invite a user to join the npm organization. If the user accepts the invite, they will be added
 /// to the default team "developers".
-///
-/// TODO The Plaid API supports specifying another team as the default for the new user. Expose through the STL?
-pub fn invite_user_to_organization(user: &str) -> Result<(), PlaidFunctionError> {
+pub fn invite_user_to_organization(
+    user: &str,
+    team: Option<&str>,
+) -> Result<(), PlaidFunctionError> {
     extern "C" {
         new_host_function!(npm, invite_user_to_organization);
     }
 
     let params = serde_json::to_string(&InviteUserToOrganizationParams {
         user: user.to_string(),
-        team: None,
+        team: team.map(|t| t.to_string()),
     })
     .map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
 
@@ -439,14 +197,14 @@ pub fn list_granular_tokens() -> Result<Vec<NpmToken>, PlaidFunctionError> {
 }
 
 /// Add a user to an npm team
-pub fn add_user_to_team(user: &str, team: NpmTeam) -> Result<(), PlaidFunctionError> {
+pub fn add_user_to_team(user: &str, team: &str) -> Result<(), PlaidFunctionError> {
     extern "C" {
         new_host_function!(npm, add_user_to_team);
     }
 
     let params = serde_json::to_string(&AddRemoveUserToFromTeamParams {
         user: user.to_string(),
-        team,
+        team: team.to_string(),
     })
     .map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
 
@@ -460,14 +218,14 @@ pub fn add_user_to_team(user: &str, team: NpmTeam) -> Result<(), PlaidFunctionEr
 }
 
 /// Remove a user from an npm team
-pub fn remove_user_from_team(user: &str, team: NpmTeam) -> Result<(), PlaidFunctionError> {
+pub fn remove_user_from_team(user: &str, team: &str) -> Result<(), PlaidFunctionError> {
     extern "C" {
         new_host_function!(npm, remove_user_from_team);
     }
 
     let params = serde_json::to_string(&AddRemoveUserToFromTeamParams {
         user: user.to_string(),
-        team,
+        team: team.to_string(),
     })
     .map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
 
@@ -512,7 +270,7 @@ pub fn publish_empty_stub(
 /// Set permissions for a team on a specific npm package
 pub fn set_team_permission_on_package(
     package_name: &str,
-    team: NpmTeam,
+    team: &str,
     permission: NpmPackagePermission,
 ) -> Result<(), PlaidFunctionError> {
     extern "C" {
@@ -560,15 +318,18 @@ pub fn delete_package(package_name: &str) -> Result<(), PlaidFunctionError> {
 
 /// Return a list of npm packages over which a team has a certain permission (read or write)
 pub fn list_packages_with_team_permission(
-    team: NpmTeam,
+    team: &str,
     permission: NpmPackagePermission,
 ) -> Result<Vec<String>, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(npm, list_packages_with_team_permission);
     }
 
-    let params = serde_json::to_string(&ListPackagesWithTeamPermissionParams { team, permission })
-        .map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+    let params = serde_json::to_string(&ListPackagesWithTeamPermissionParams {
+        team: team.to_string(),
+        permission,
+    })
+    .map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
 
     const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];

--- a/plaid-stl/src/npm/mod.rs
+++ b/plaid-stl/src/npm/mod.rs
@@ -1,5 +1,7 @@
 pub mod shared_structs;
 
+use std::fmt::Display;
+
 use crate::PlaidFunctionError;
 use serde::Deserialize;
 
@@ -70,8 +72,8 @@ pub fn get_org_users_without_2fa() -> Result<Vec<NpmUser>, PlaidFunctionError> {
 /// Invite a user to join the npm organization. If the user accepts the invite, they will be added
 /// to the default team "developers".
 pub fn invite_user_to_organization(
-    user: &str,
-    team: Option<&str>,
+    user: impl Display,
+    team: Option<impl Display>,
 ) -> Result<(), PlaidFunctionError> {
     extern "C" {
         new_host_function!(npm, invite_user_to_organization);
@@ -95,7 +97,7 @@ pub fn invite_user_to_organization(
 }
 
 /// Remove a user from the npm organization
-pub fn remove_user_from_organization(user: &str) -> Result<(), PlaidFunctionError> {
+pub fn remove_user_from_organization(user: impl Display) -> Result<(), PlaidFunctionError> {
     extern "C" {
         new_host_function!(npm, remove_user_from_organization);
     }
@@ -118,7 +120,7 @@ pub fn remove_user_from_organization(user: &str) -> Result<(), PlaidFunctionErro
 /// If you are not sure about the token configuration, use `create_granular_token_for_package_simple` which only
 /// requires specifying a name and a description.
 pub fn create_granular_token_for_package(
-    package_name: &str,
+    package_name: impl Display,
     token_specs: GranularTokenSpecs,
 ) -> Result<String, PlaidFunctionError> {
     extern "C" {
@@ -156,9 +158,9 @@ pub fn create_granular_token_for_package(
 /// Create a granular npm token for a package, specifying only the token name and a suitable description.
 /// Other token configurations default to sensible values.
 pub fn create_granular_token_for_package_simple(
-    package_name: &str,
-    token_name: &str,
-    token_description: &str,
+    package_name: impl Display,
+    token_name: impl Display,
+    token_description: impl Display,
 ) -> Result<String, PlaidFunctionError> {
     let token_specs = GranularTokenSpecs::with_name_and_description(token_name, token_description);
     create_granular_token_for_package(package_name, token_specs)
@@ -197,7 +199,7 @@ pub fn list_granular_tokens() -> Result<Vec<NpmToken>, PlaidFunctionError> {
 }
 
 /// Add a user to an npm team
-pub fn add_user_to_team(user: &str, team: &str) -> Result<(), PlaidFunctionError> {
+pub fn add_user_to_team(user: impl Display, team: impl Display) -> Result<(), PlaidFunctionError> {
     extern "C" {
         new_host_function!(npm, add_user_to_team);
     }
@@ -218,7 +220,10 @@ pub fn add_user_to_team(user: &str, team: &str) -> Result<(), PlaidFunctionError
 }
 
 /// Remove a user from an npm team
-pub fn remove_user_from_team(user: &str, team: &str) -> Result<(), PlaidFunctionError> {
+pub fn remove_user_from_team(
+    user: impl Display,
+    team: impl Display,
+) -> Result<(), PlaidFunctionError> {
     extern "C" {
         new_host_function!(npm, remove_user_from_team);
     }
@@ -242,7 +247,7 @@ pub fn remove_user_from_team(user: &str, team: &str) -> Result<(), PlaidFunction
 /// Publish an empty npm package, to be later updated.
 /// If an access level is not specified (i.e., None is passed), it defaults to "restricted".
 pub fn publish_empty_stub(
-    package_name: &str,
+    package_name: impl Display,
     access_level: Option<PkgAccessLevel>,
 ) -> Result<(), PlaidFunctionError> {
     extern "C" {
@@ -269,8 +274,8 @@ pub fn publish_empty_stub(
 
 /// Set permissions for a team on a specific npm package
 pub fn set_team_permission_on_package(
-    package_name: &str,
-    team: &str,
+    package_name: impl Display,
+    team: impl Display,
     permission: NpmPackagePermission,
 ) -> Result<(), PlaidFunctionError> {
     extern "C" {
@@ -300,7 +305,7 @@ pub fn set_team_permission_on_package(
 /// Note: The package name should be unscoped. If you are trying to delete
 /// @scope/package_name, then you should pass only "package_name". The scope is
 /// preconfigured in the client and will be added automatically.
-pub fn delete_package(package_name: &str) -> Result<(), PlaidFunctionError> {
+pub fn delete_package(package_name: impl Display) -> Result<(), PlaidFunctionError> {
     extern "C" {
         new_host_function!(npm, delete_package);
     }
@@ -318,7 +323,7 @@ pub fn delete_package(package_name: &str) -> Result<(), PlaidFunctionError> {
 
 /// Return a list of npm packages over which a team has a certain permission (read or write)
 pub fn list_packages_with_team_permission(
-    team: &str,
+    team: impl Display,
     permission: NpmPackagePermission,
 ) -> Result<Vec<String>, PlaidFunctionError> {
     extern "C" {

--- a/plaid-stl/src/npm/shared_structs/mod.rs
+++ b/plaid-stl/src/npm/shared_structs/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt::Display;
 
 /// Permission that is granted to a team over an npm package
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub enum NpmPackagePermission {
     READ,
     WRITE,
@@ -162,12 +162,12 @@ impl GranularTokenSpecs {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[allow(dead_code)]
 pub struct NpmToken {
-    token: String,
-    token_name: Option<String>,
+    pub token: String,
+    pub token_name: Option<String>,
     pub token_type: Option<String>,
     // Deserialize the date field from the ISO 8601 format
     #[serde(default, deserialize_with = "deserialize_option_timestamp")]
-    expires: Option<DateTime<Utc>>,
+    pub expires: Option<DateTime<Utc>>,
 }
 
 // Custom deserializer for an optional DateTime<Utc>

--- a/plaid-stl/src/npm/shared_structs/mod.rs
+++ b/plaid-stl/src/npm/shared_structs/mod.rs
@@ -1,0 +1,238 @@
+//! This module contains all structs which are shared between the STL and the runtime API.
+//! These are used for ensuring consistent serialization / deserialization across the
+//! host / guest boundary.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::fmt::Display;
+
+/// Permission that is granted to a team over an npm package
+#[derive(Serialize, Deserialize, Clone)]
+pub enum NpmPackagePermission {
+    READ,
+    WRITE,
+}
+
+impl Display for NpmPackagePermission {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let out = match self {
+            Self::READ => "read".to_string(),
+            Self::WRITE => "write".to_string(),
+        };
+        write!(f, "{}", out)
+    }
+}
+
+impl TryFrom<String> for NpmPackagePermission {
+    type Error = ();
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            "read" => Ok(NpmPackagePermission::READ),
+            "write" => Ok(NpmPackagePermission::WRITE),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Role that a user can have in the npm organization
+#[derive(Debug, Deserialize, Serialize)]
+pub enum NpmUserRole {
+    Member,
+    Admin,
+    Owner,
+}
+
+impl TryFrom<String> for NpmUserRole {
+    type Error = ();
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            "developer" => Ok(NpmUserRole::Member),
+            "admin" => Ok(NpmUserRole::Admin), // untested: I think we do not have Admins
+            "super-admin" => Ok(NpmUserRole::Owner),
+            _ => Err(()),
+        }
+    }
+}
+
+/// A user in the npm organization
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NpmUser {
+    pub username: String,
+    pub role: NpmUserRole,
+}
+
+/// Org-level permission granted to a granular token.
+#[derive(Clone, Serialize, Deserialize)]
+pub enum GranularTokenOrgsPermission {
+    NoAccess,
+    ReadOnly,
+    ReandAndWrite,
+}
+
+impl Display for GranularTokenOrgsPermission {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let out = match self {
+            GranularTokenOrgsPermission::NoAccess => "No access".to_string(),
+            GranularTokenOrgsPermission::ReadOnly => "Read only".to_string(),
+            GranularTokenOrgsPermission::ReandAndWrite => "Read and write".to_string(),
+        };
+        write!(f, "{}", out)
+    }
+}
+
+/// Package-level permission granted to a granular token.
+#[derive(Clone, Serialize, Deserialize)]
+pub enum GranularTokenPackagesAndScopesPermission {
+    NoAccess,
+    ReadOnly,
+    ReadAndWrite,
+}
+
+impl Display for GranularTokenPackagesAndScopesPermission {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let out = match self {
+            GranularTokenPackagesAndScopesPermission::NoAccess => "No access".to_string(),
+            GranularTokenPackagesAndScopesPermission::ReadOnly => "Read only".to_string(),
+            GranularTokenPackagesAndScopesPermission::ReadAndWrite => "Read and write".to_string(),
+        };
+        write!(f, "{}", out)
+    }
+}
+
+/// Scopes granted to the token
+#[derive(Clone, Serialize, Deserialize)]
+pub enum GranularTokenSelectedPackagesAndScopes {
+    PackagesAll,
+    PackagesAndScopesSome,
+}
+
+impl Display for GranularTokenSelectedPackagesAndScopes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let out = match self {
+            GranularTokenSelectedPackagesAndScopes::PackagesAll => "packagesAll".to_string(),
+            GranularTokenSelectedPackagesAndScopes::PackagesAndScopesSome => {
+                "packagesAndScopesSome".to_string()
+            }
+        };
+        write!(f, "{}", out)
+    }
+}
+
+/// Groups together all the input that we expect from a rule that requests
+/// the generation of a granular token. Optional fields will have a default value.
+#[derive(Serialize, Deserialize)]
+pub struct GranularTokenSpecs {
+    pub allowed_ip_ranges: Option<Vec<String>>,
+    pub expiration_days: Option<u16>,
+    pub orgs_permission: Option<GranularTokenOrgsPermission>,
+    pub packages_and_scopes_permission: Option<GranularTokenPackagesAndScopesPermission>,
+    pub selected_orgs: Option<Vec<String>>,
+    pub selected_packages: Option<Vec<String>>,
+    pub selected_packages_and_scopes: Option<GranularTokenSelectedPackagesAndScopes>,
+    pub selected_scopes: Option<Vec<String>>,
+    pub token_name: String,
+    pub token_description: String,
+}
+
+impl GranularTokenSpecs {
+    /// Provide a name and description for the token, and set all other fields to None, which
+    /// will result in default values being used.
+    pub fn with_name_and_description(token_name: &str, token_description: &str) -> Self {
+        Self {
+            token_name: token_name.to_string(),
+            token_description: token_description.to_string(),
+            allowed_ip_ranges: None,
+            expiration_days: None,
+            orgs_permission: None,
+            packages_and_scopes_permission: None,
+            selected_orgs: None,
+            selected_packages: None,
+            selected_packages_and_scopes: None,
+            selected_scopes: None,
+        }
+    }
+}
+
+/// An npm token configured on the npm website for the current user
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[allow(dead_code)]
+pub struct NpmToken {
+    token: String,
+    token_name: Option<String>,
+    pub token_type: Option<String>,
+    // Deserialize the date field from the ISO 8601 format
+    #[serde(default, deserialize_with = "deserialize_option_timestamp")]
+    expires: Option<DateTime<Utc>>,
+}
+
+// Custom deserializer for an optional DateTime<Utc>
+fn deserialize_option_timestamp<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Try to deserialize as a string (ISO 8601 format) or return None if missing
+    let opt = Option::<String>::deserialize(deserializer)?;
+
+    // Parse the timestamp string into a DateTime<Utc>, if it's present
+    Ok(opt.and_then(|s| {
+        DateTime::parse_from_rfc3339(&s)
+            .ok()
+            .map(|dt| dt.with_timezone(&Utc))
+    }))
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SetTeamPermissionOnPackageParams {
+    pub team: String,
+    pub package: String,
+    pub permission: NpmPackagePermission,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CreateGranularTokenForPackageParams {
+    pub package: String,
+    pub specs: GranularTokenSpecs,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct AddRemoveUserToFromTeamParams {
+    pub user: String,
+    pub team: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct InviteUserToOrganizationParams {
+    pub user: String,
+    pub team: Option<String>,
+}
+
+/// Access level for an npm package
+#[derive(Serialize, Deserialize)]
+pub enum PkgAccessLevel {
+    Restricted,
+    Public,
+}
+
+impl Display for PkgAccessLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let out = match self {
+            PkgAccessLevel::Restricted => "restricted".to_string(),
+            PkgAccessLevel::Public => "public".to_string(),
+        };
+        write!(f, "{}", out)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PublishEmptyStubParams {
+    pub package_name: String,
+    pub access_level: PkgAccessLevel,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ListPackagesWithTeamPermissionParams {
+    pub team: String,
+    pub permission: NpmPackagePermission,
+}

--- a/plaid-stl/src/npm/shared_structs/mod.rs
+++ b/plaid-stl/src/npm/shared_structs/mod.rs
@@ -139,7 +139,10 @@ pub struct GranularTokenSpecs {
 impl GranularTokenSpecs {
     /// Provide a name and description for the token, and set all other fields to None, which
     /// will result in default values being used.
-    pub fn with_name_and_description(token_name: &str, token_description: &str) -> Self {
+    pub fn with_name_and_description(
+        token_name: impl Display,
+        token_description: impl Display,
+    ) -> Self {
         Self {
             token_name: token_name.to_string(),
             token_description: token_description.to_string(),

--- a/plaid/Cargo.toml
+++ b/plaid/Cargo.toml
@@ -11,11 +11,13 @@ default = ["aws"]
 aws = ["aws-sdk-kms", "aws-config"]
 
 [dependencies]
-clap = { version = "4", default-features = false, features = ["std"] }
 async-trait = "0.1.56"
 base64 = "0.13"
+clap = { version = "4", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5"
 env_logger = "0.8"
+flate2 = "1.0"
+hex = "0.4.3"
 http = "1"
 jwt-simple = "0.12.10"
 log = "0.4"
@@ -29,13 +31,17 @@ ring = "0.17"
 reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",
     "json",
+    "cookies",
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 sled = "0.34.7"
+tar = "0.4.41"
 time = "0.3"
 tokio = { version = "1", features = ["full"] }
 toml = "0.5"
+totp-rs = "5.6.0"
+url = "2.5.2"
 warp = { version = "0.3", features = ["tls"] }
 wasmer = { version = "4", default-features = false, features = ["cranelift"] }
 wasmer-middlewares = "4"

--- a/plaid/src/apis/general/random.rs
+++ b/plaid/src/apis/general/random.rs
@@ -1,5 +1,5 @@
 use super::General;
-use crate::{apis::ApiError, data::DelayedMessage, executor::Message};
+use crate::apis::ApiError;
 
 use ring::rand::SecureRandom;
 

--- a/plaid/src/apis/mod.rs
+++ b/plaid/src/apis/mod.rs
@@ -2,6 +2,7 @@
 pub mod aws;
 pub mod general;
 pub mod github;
+pub mod npm;
 pub mod okta;
 pub mod pagerduty;
 pub mod quorum;
@@ -20,6 +21,7 @@ use aws_sdk_kms::{error::SdkError, operation::sign::SignError};
 use crossbeam_channel::Sender;
 use general::{General, GeneralConfig};
 use github::{Github, GithubConfig};
+use npm::{Npm, NpmConfig};
 use okta::{Okta, OktaConfig};
 use pagerduty::{PagerDuty, PagerDutyConfig};
 use quorum::{Quorum, QuorumConfig};
@@ -40,6 +42,7 @@ pub struct Api {
     pub aws: Option<Aws>,
     pub general: Option<General>,
     pub github: Option<Github>,
+    pub npm: Option<Npm>,
     pub okta: Option<Okta>,
     pub pagerduty: Option<PagerDuty>,
     pub quorum: Option<Quorum>,
@@ -56,6 +59,7 @@ pub struct Apis {
     pub aws: Option<AwsConfig>,
     pub general: Option<GeneralConfig>,
     pub github: Option<GithubConfig>,
+    pub npm: Option<NpmConfig>,
     pub okta: Option<OktaConfig>,
     pub pagerduty: Option<PagerDutyConfig>,
     pub quorum: Option<QuorumConfig>,
@@ -78,6 +82,7 @@ pub enum ApiError {
     #[cfg(feature = "aws")]
     KmsGetPublicKeyError(SdkError<GetPublicKeyError>),
     NetworkError(reqwest::Error),
+    NpmError(npm::NpmError),
     OktaError(okta::OktaError),
     PagerDutyError(pagerduty::PagerDutyError),
     QuorumError(quorum::QuorumError),
@@ -108,6 +113,11 @@ impl Api {
         let github = match config.github {
             Some(gh) => Some(Github::new(gh)),
             _ => None,
+        };
+
+        let npm = match config.npm {
+            Some(npm) => Some(Npm::new(npm)),
+            _ => None
         };
 
         let okta = match config.okta {
@@ -159,6 +169,7 @@ impl Api {
             aws,
             general,
             github,
+            npm,
             okta,
             pagerduty,
             quorum,

--- a/plaid/src/apis/mod.rs
+++ b/plaid/src/apis/mod.rs
@@ -116,8 +116,14 @@ impl Api {
         };
 
         let npm = match config.npm {
-            Some(npm) => Some(Npm::new(npm)),
-            _ => None
+            Some(npm) => match Npm::new(npm) {
+                Ok(npm) => Some(npm),
+                Err(_) => {
+                    error!("Something went wrong while initializing the npm API: proceeding without. This should be investigated!");
+                    None
+                }
+            },
+            _ => None,
         };
 
         let okta = match config.okta {

--- a/plaid/src/apis/npm/hashes.rs
+++ b/plaid/src/apis/npm/hashes.rs
@@ -1,0 +1,11 @@
+use ring::digest;
+
+/// Compute the SHA-1 hash of a bytes vector, and return its hex encoding.
+pub fn sha1_hex(data: &Vec<u8>) -> String {
+    hex::encode(digest::digest(&digest::SHA1_FOR_LEGACY_USE_ONLY, &data).as_ref())
+}
+
+/// Compute the SHA-512 hash of a bytes vector, and return its base64 encoding.
+pub fn sha512_base64(data: &Vec<u8>) -> String {
+    base64::encode(digest::digest(&digest::SHA512, &data).as_ref())
+}

--- a/plaid/src/apis/npm/mod.rs
+++ b/plaid/src/apis/npm/mod.rs
@@ -20,24 +20,23 @@ pub struct Npm {
 }
 
 impl Npm {
-    pub fn new(config: NpmConfig) -> Self {
+    pub fn new(config: NpmConfig) -> Result<Self, NpmError> {
         let cookie_jar = Arc::new(Jar::default());
         let client = Client::builder()
             .cookie_provider(cookie_jar.clone())
             .build()
-            .map_err(|_| NpmError::GenericError)
-            .unwrap(); // TODO @obelisk OK to unwrap here? If we cannot build the client, perhaps we should just panic?
+            .map_err(|_| NpmError::GenericError)?;
 
         // Create all the validators and compile all the regexes. If the module contains
         // any invalid regexes it will panic.
         let validators = validators::create_validators();
 
-        Self {
+        Ok(Self {
             config,
             client,
             cookie_jar,
             validators,
-        }
+        })
     }
 }
 

--- a/plaid/src/apis/npm/mod.rs
+++ b/plaid/src/apis/npm/mod.rs
@@ -112,4 +112,6 @@ pub enum NpmError {
     FailedToRetrieveUsersWithout2FA,
     FailedToConvertToNpmUser,
     FailedToGetCsrfTokenFromCookies,
+    FailedToRetrievePaginatedData,
+    FailedToRetrievePackages
 }

--- a/plaid/src/apis/npm/mod.rs
+++ b/plaid/src/apis/npm/mod.rs
@@ -1,0 +1,115 @@
+mod hashes;
+pub mod npm_cli_client;
+pub mod npm_web_client;
+
+use std::sync::Arc;
+
+use regex::Regex;
+use reqwest::{cookie::Jar, Client};
+use serde::{Deserialize, Serialize};
+
+/// Client for interacting with npm that groups a client for CLI operations
+/// and one for web operations
+pub struct Npm {
+    config: NpmConfig,
+    client: Client,
+    cookie_jar: Arc<Jar>,
+}
+
+impl Npm {
+    pub fn new(config: NpmConfig) -> Self {
+        let cookie_jar = Arc::new(Jar::default());
+        let client = Client::builder()
+            .cookie_provider(cookie_jar.clone())
+            .build()
+            .map_err(|_| NpmError::GenericError).unwrap(); // TODO @obelisk OK to unwrap here? If we cannot build the client, perhaps we should just panic?
+        Self {
+            config,
+            client,
+            cookie_jar,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+/// Credentials and secrets for interacting with npm
+pub struct NpmConfig {
+    /// Username for the npm account
+    pub username: String,
+    /// Password for the npm account
+    pub password: String,
+    /// Secret for the TOTP-based 2FA on the npm account
+    pub otp_secret: String,
+    /// Automation (not publish!) token for the npm account. This is a type of token that can
+    /// be created through the npm website and allows this user to publish packages without
+    /// having to complete the 2FA flow. It is used in the CLI client, for publishing a new package
+    pub automation_token: String,
+    /// The scope for npm packages we are managing. This corresponds to the name of the organization
+    pub npm_scope: String,
+    /// The content of the user-agent header to pass when making a request via the CLI client.
+    /// Useful to link logs together
+    pub user_agent: String,
+}
+
+impl NpmConfig {
+    pub fn new(
+        username: String,
+        password: String,
+        otp_secret: String,
+        automation_token: String,
+        npm_scope: String,
+        user_agent: String,
+    ) -> Result<Self, NpmError> {
+        // Check the OTP secret looks OK: it should be 32 alphanumerical characters
+        let otp_regex = Regex::new(r"^[a-zA-Z0-9]{32}$").unwrap();
+        if !otp_regex.is_match(&otp_secret) {
+            return Err(NpmError::WrongConfig(
+                "Wrong format for OTP secret".to_string(),
+            ));
+        }
+
+        // Check the automation_token looks OK: it should be "npm_" followed by 36 alphanum characters
+        let automation_token_regex = Regex::new(r"^npm_[a-zA-Z0-9]{36}$").unwrap();
+        if !automation_token_regex.is_match(&automation_token) {
+            return Err(NpmError::WrongConfig(
+                "Wrong format for automation token".to_string(),
+            ));
+        }
+
+        // TODO Quickly try to do a login and see if the credentials work? Otherwise we will discover
+        // if they do not work only later, when actually trying to use them.
+        // This way we could verify username + password + OTP secret, but the automation token could still be wrong.
+        // If we want to be 100% sure, then we should _generate_ the automation token ourselves via calls to the website.
+
+        Ok(Self {
+            username,
+            password,
+            otp_secret,
+            automation_token,
+            npm_scope,
+            user_agent,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub enum NpmError {
+    RegistryUploadError,
+    FailedToGenerateArchive,
+    PermissionChangeError,
+    GenericError,
+    LoginFlowError,
+    WrongClientStatus,
+    TokenGenerationError,
+    WrongConfig(String),
+    FailedToListGranularTokens,
+    FailedToDeletePackage,
+    FailedToAddUserToTeam,
+    FailedToRemoveUserFromTeam,
+    FailedToRemoveUserFromOrg,
+    FailedToInviteUserToOrg,
+    FailedToRetrieveUserList,
+    FailedToRetrieveUsersWithout2FA,
+    FailedToConvertToNpmUser,
+    FailedToGetCsrfTokenFromCookies,
+}

--- a/plaid/src/apis/npm/npm_cli_client.rs
+++ b/plaid/src/apis/npm/npm_cli_client.rs
@@ -1,0 +1,191 @@
+use crate::apis::ApiError;
+
+use super::{hashes, Npm, NpmError};
+
+use flate2::{write::GzEncoder, Compression};
+use plaid_stl::npm::PublishEmptyStubParams;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tar::{Builder, Header};
+
+const REGISTRY_URL: &str = "https://registry.npmjs.org";
+const NODE_VERSION: &str = "20.16.0";
+const NPM_VERSION: &str = "10.8.3";
+
+#[derive(Serialize)]
+struct PkgAttachment<'a> {
+    content_type: &'a str,
+    data: &'a str,
+    length: u64,
+}
+
+#[derive(Serialize)]
+struct PkgDist<'a> {
+    integrity: &'a str,
+    shasum: &'a str,
+    tarball: &'a str,
+}
+
+#[derive(Serialize)]
+struct PkgVersion<'a> {
+    name: &'a str,
+    version: &'a str,
+    main: &'a str,
+    author: &'a str,
+    license: &'a str,
+    _id: &'a str,
+    readme: &'a str,
+    #[serde(rename = "_nodeVersion")]
+    _node_version: &'a str,
+    #[serde(rename = "_npmVersion")]
+    _npm_version: &'a str,
+    dist: PkgDist<'a>,
+}
+
+#[derive(Serialize)]
+struct PkgMetadata<'a> {
+    _id: &'a str,
+    name: &'a str,
+    #[serde(rename = "dist-tags")]
+    dist_tags: HashMap<&'a str, &'a str>,
+    versions: HashMap<&'a str, PkgVersion<'a>>,
+    access: Option<&'a str>,
+    _attachments: HashMap<&'a str, PkgAttachment<'a>>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PkgManifest<'a> {
+    name: &'a str,
+    version: &'a str,
+    main: &'a str,
+    author: &'a str,
+    license: &'a str,
+    repository: &'a str,
+    description: &'a str,
+}
+
+impl Npm {
+    /// Upload an empty package stub to the npm registry.
+    pub async fn publish_empty_stub(&self, params: &str, module: &str) -> Result<i32, ApiError> {
+        let params: PublishEmptyStubParams =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        
+        info!("Publishing new empty npm package [{}] on behalf of [{module}]", params.package_name);
+        
+        let (package_json, tarball_data) =
+            create_package_tarball(&self.config.npm_scope, &params.package_name)?;
+        let data_length = tarball_data.len();
+        let sha1_digest = hashes::sha1_hex(&tarball_data);
+        let sha512_digest = hashes::sha512_base64(&tarball_data);
+
+        // Safe unwrap: we are hardcoding the json content, so the deserialization will not fail
+        let manifest = serde_json::from_str::<PkgManifest>(&package_json).unwrap();
+
+        let scoped_pkg_name = format!("@{}/{}", self.config.npm_scope, params.package_name);
+
+        // Build the (somewhat complex) data structure that npm expects
+        let pkg_version_obj = PkgVersion {
+            name: &scoped_pkg_name,
+            version: manifest.version,
+            main: manifest.main,
+            author: manifest.author,
+            license: manifest.license,
+            _id: &format!("{}@{}", &scoped_pkg_name, manifest.version),
+            readme: "Empty",
+            _node_version: NODE_VERSION,
+            _npm_version: NPM_VERSION,
+            dist: PkgDist {
+                integrity: &format!("sha512-{}", sha512_digest),
+                shasum: &sha1_digest,
+                tarball: &format!(
+                    "{}/{}/-/{}-{}.tgz",
+                    REGISTRY_URL, &scoped_pkg_name, &scoped_pkg_name, manifest.version
+                ),
+            },
+        };
+
+        let attachment_name = format!("{}-{}.tgz", &scoped_pkg_name, manifest.version);
+        let base64_data = base64::encode(tarball_data);
+        let pkg_access_level = params.access_level.to_string();
+
+        let pkg_metadata = PkgMetadata {
+            _id: &scoped_pkg_name,
+            name: &scoped_pkg_name,
+            dist_tags: [("latest", manifest.version)].into(),
+            versions: [(manifest.version, pkg_version_obj)].into(),
+            access: Some(&pkg_access_level),
+            _attachments: [(
+                attachment_name.as_str(),
+                PkgAttachment {
+                    content_type: "application/octet-stream",
+                    data: &base64_data,
+                    length: data_length
+                        .try_into()
+                        .map_err(|_| ApiError::NpmError(NpmError::RegistryUploadError))?,
+                },
+            )]
+            .into(),
+        };
+
+        // Send everything to the npm registry: this will result in the creation of a new package
+        let client = Client::new();
+        client
+            .put(format!(
+                "{}/{}",
+                REGISTRY_URL,
+                &scoped_pkg_name.replace("/", "%2f")
+            ))
+            .header("Content-Type", "application/json")
+            .header(
+                "Authorization",
+                format!("Bearer {}", self.config.automation_token),
+            )
+            .header("npm-auth-type", "web")
+            .header("npm-command", "publish")
+            .header("user-agent", &self.config.user_agent)
+            .json(&pkg_metadata)
+            .send()
+            .await
+            .map(|_| Ok(0))
+            .map_err(|_| ApiError::NpmError(NpmError::RegistryUploadError))?
+    }
+}
+
+/// Helper function. Return a tuple (manifest, tarball) where
+/// * **manifest** is the string representation of the npm package's package.json
+/// * **tarball** is a bytes vector that encodes a .tar.gz archive that contains the package.json file
+///
+/// The archive is ready to be uploaded to the NPM registry.
+fn create_package_tarball(pkg_scope: &str, pkg_name: &str) -> Result<(String, Vec<u8>), ApiError> {
+    let package_json = format!(
+        r#"{{
+            "name": "@{}/{}",
+            "version": "0.0.0",
+            "main": "",
+            "author": "",
+            "license": "ISC",
+            "repository": "git://github.com/smartcontractkit/{}.git",
+            "description": ""
+            }}"#,
+        pkg_scope, pkg_name, pkg_name
+    );
+
+    let mut header = Header::new_gnu();
+    header.set_size(package_json.as_bytes().len().try_into().unwrap()); // safe unwrap: data is hardcoded
+    header.set_cksum();
+
+    let mut tar_builder = Builder::new(GzEncoder::new(Vec::new(), Compression::default()));
+    tar_builder
+        .append_data(&mut header, "package/package.json", package_json.as_bytes())
+        .map_err(|_| ApiError::NpmError(NpmError::FailedToGenerateArchive))?;
+    tar_builder
+        .finish()
+        .map_err(|_| ApiError::NpmError(NpmError::FailedToGenerateArchive))?;
+    let data = tar_builder
+        .into_inner()
+        .map_err(|_| ApiError::NpmError(NpmError::FailedToGenerateArchive))?
+        .finish()
+        .map_err(|_| ApiError::NpmError(NpmError::FailedToGenerateArchive))?;
+    Ok((package_json, data))
+}

--- a/plaid/src/apis/npm/npm_web_client.rs
+++ b/plaid/src/apis/npm/npm_web_client.rs
@@ -1,0 +1,716 @@
+use regex::Regex;
+use reqwest::cookie::CookieStore;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::HashMap;
+use totp_rs::{Algorithm, Secret, TOTP};
+use url::Url;
+
+use crate::apis::ApiError;
+
+use plaid_stl::npm::{
+    AddRemoveUserToFromTeamParams, CreateGranularTokenForPackageParams,
+    InviteUserToOrganizationParams, NpmToken, NpmUser, NpmUserRole,
+    SetTeamPermissionOnPackageParams,
+};
+
+use super::{Npm, NpmError};
+
+const NPMJS_COM_URL: &str = "https://www.npmjs.com";
+
+#[derive(Serialize)]
+/// Payload sent to npm website to change a team's permissions over a package
+struct PermissionChangePayload<'a> {
+    csrftoken: &'a str,
+    package: &'a str,
+    permissions: &'a str,
+}
+
+#[derive(Serialize)]
+/// Payload sent to npm website to generate a new granular token
+struct GenerateGranularTokenPayload<'a> {
+    #[serde(rename = "allowedIPRanges")]
+    allowed_ip_ranges: Vec<String>,
+    csrftoken: &'a str,
+    #[serde(rename = "expirationDays")]
+    expiration_days: &'a str,
+    #[serde(rename = "orgsPermission")]
+    orgs_permission: &'a str,
+    #[serde(rename = "packagesAndScopesPermission")]
+    packages_and_scopes_permission: &'a str,
+    #[serde(rename = "selectedOrgs")]
+    selected_orgs: Vec<String>,
+    #[serde(rename = "selectedPackages")]
+    selected_packages: Vec<String>,
+    #[serde(rename = "selectedPackagesAndScopes")]
+    selected_packages_and_scopes: &'a str,
+    #[serde(rename = "selectedScopes")]
+    selected_scopes: Vec<String>,
+    #[serde(rename = "tokenDescription")]
+    token_description: &'a str,
+    #[serde(rename = "tokenName")]
+    token_name: &'a str,
+}
+
+impl Npm {
+    /// Retrieve the CSRF token from the client's cookie jar
+    fn get_csrftoken_from_cookies(&self) -> Result<String, NpmError> {
+        let cookies: Vec<String> = self
+            .cookie_jar
+            .as_ref()
+            .cookies(&Url::parse(NPMJS_COM_URL).unwrap())
+            .ok_or(NpmError::FailedToGetCsrfTokenFromCookies)?
+            .to_str()
+            .map_err(|_| NpmError::FailedToGetCsrfTokenFromCookies)?
+            .to_string()
+            .split("; ")
+            .map(|v| v.to_string())
+            .collect();
+        let mut csrf_token: Option<String> = None;
+        for c in cookies {
+            if c.starts_with("cs=") {
+                csrf_token = Some(
+                    c.split("=")
+                        .collect::<Vec<&str>>()
+                        .get(1)
+                        .ok_or(NpmError::FailedToGetCsrfTokenFromCookies)?
+                        .to_string(),
+                );
+                break;
+            }
+        }
+        csrf_token.ok_or(NpmError::FailedToGetCsrfTokenFromCookies)
+    }
+
+    /// Execute the web login flow (with username/password + OTP 2FA). As a side effect, this
+    /// updates the client's cookie jar, from which we can later extract necessary values.
+    async fn login(&self) -> Result<(), NpmError> {
+        let response = self
+            .client
+            .get(format!("{}/login", NPMJS_COM_URL))
+            .send()
+            .await
+            .map_err(|_| NpmError::LoginFlowError)?;
+        // Get the CSRF token (which is in a cookie) because we need to send it back later on
+        let cs_cookie = match response.cookies().find(|c| c.name() == "cs") {
+            None => return Ok(()), // we do not get this cookie if we are _already_ logged in
+            Some(c) => c.value().to_string(),
+        };
+
+        // Login step 1: send the username and password, together with the CSRF token
+        self.client
+            .post(format!("{}/login", NPMJS_COM_URL))
+            .form(&[
+                ("username", &self.config.username),
+                ("password", &self.config.password),
+                ("csrftoken", &cs_cookie),
+            ])
+            .send()
+            .await
+            .map_err(|_| NpmError::LoginFlowError)?;
+
+        // Prepare the TOTP code for the 2FA
+        let otp_token = TOTP::new(
+            Algorithm::SHA1,
+            6,
+            1,
+            30,
+            Secret::Encoded(self.config.otp_secret.to_string())
+                .to_bytes()
+                .map_err(|_| NpmError::LoginFlowError)?,
+        )
+        .map_err(|_| NpmError::LoginFlowError)?
+        .generate_current()
+        .map_err(|_| NpmError::LoginFlowError)?;
+
+        // Login step 2: send the TOTP code to a well-known URL
+        self.client
+            .post(format!("{}/login/otp?next=%2F", NPMJS_COM_URL))
+            .form(&[
+                ("otp", &otp_token),
+                ("formName", &"totp".to_string()),
+                ("originalUrl", &"".to_string()),
+                ("csrftoken", &cs_cookie),
+            ])
+            .send()
+            .await
+            .map(|_| ())
+            .map_err(|_| NpmError::LoginFlowError)
+    }
+
+    /// Set a team's permissions over a package
+    pub async fn set_team_permission_on_package(
+        &self,
+        params: &str,
+        module: &str,
+    ) -> Result<i32, ApiError> {
+        self.login()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::LoginFlowError))?;
+        let params: SetTeamPermissionOnPackageParams =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        info!(
+            "Setting permission [{}] on package [{}] for team [{}] on behalf of [{module}]",
+            params.permission.to_string(),
+            params.package,
+            params.team
+        );
+
+        // Prepare the request body
+        let csrf_token = self
+            .get_csrftoken_from_cookies()
+            .map_err(|_| ApiError::NpmError(NpmError::WrongClientStatus))?;
+        let payload = PermissionChangePayload {
+            package: &format!("@{}/{}", self.config.npm_scope, params.package),
+            permissions: &params.permission.to_string(),
+            csrftoken: &csrf_token,
+        };
+        self.client
+            .post(format!(
+                "{}/settings/{}/teams/team/{}/access",
+                NPMJS_COM_URL, self.config.npm_scope, params.team
+            ))
+            .json(&payload)
+            .send()
+            .await
+            .map(|_| Ok(0))
+            .map_err(|_| ApiError::NpmError(NpmError::PermissionChangeError))?
+    }
+
+    /// Create a granular token for a package, with given name and description.
+    ///
+    /// The token has the following features:
+    /// * read/write permission
+    /// * expires after 365 days
+    /// * scoped to the given package
+    pub async fn create_granular_token_for_package(
+        &self,
+        params: &str,
+        module: &str,
+    ) -> Result<String, ApiError> {
+        self.login()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::LoginFlowError))?;
+        let params: CreateGranularTokenForPackageParams =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        info!(
+            "Creating npm granular token for package [{}] on behalf of [{module}]",
+            params.package
+        );
+
+        let scoped_package = format!("@{}/{}", self.config.npm_scope, params.package);
+        // Prepare the request body
+        let csrf_token = self
+            .get_csrftoken_from_cookies()
+            .map_err(|_| ApiError::NpmError(NpmError::WrongClientStatus))?;
+        let payload = GenerateGranularTokenPayload {
+            allowed_ip_ranges: params
+                .specs
+                .allowed_ip_ranges
+                .clone()
+                .unwrap_or(vec!["".to_string()]),
+            csrftoken: &csrf_token,
+            expiration_days: &params.specs.expiration_days.unwrap_or(365).to_string(),
+            orgs_permission: &params
+                .specs
+                .orgs_permission
+                .clone()
+                .map_or("No access".to_string(), |v| v.to_string()),
+            packages_and_scopes_permission: &params
+                .specs
+                .packages_and_scopes_permission
+                .clone()
+                .map_or("Read and write".to_string(), |v| v.to_string()),
+            selected_orgs: params.specs.selected_orgs.clone().unwrap_or(vec![]),
+            selected_packages: params
+                .specs
+                .selected_packages
+                .clone()
+                .unwrap_or(vec![scoped_package]),
+            selected_packages_and_scopes: &params
+                .specs
+                .selected_packages_and_scopes
+                .clone()
+                .map_or("packagesAndScopesSome".to_string(), |v| v.to_string()),
+            selected_scopes: params.specs.selected_scopes.clone().unwrap_or(vec![]),
+            token_description: &params.specs.token_description,
+            token_name: &params.specs.token_name,
+        };
+        let response = self
+            .client
+            .post(format!(
+                "{}/settings/{}/tokens/new-gat",
+                NPMJS_COM_URL, self.config.username
+            ))
+            .json(&payload)
+            .header("X-Spiferack", "1") // to get JSON instead of HTML
+            .send()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::TokenGenerationError))?;
+
+        // The new token is in the JSON response, under the key "newToken"
+        response
+            .json::<Value>()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::TokenGenerationError))?
+            .get("newToken")
+            .map(|v| Ok(v.to_string()))
+            .ok_or(ApiError::NpmError(NpmError::TokenGenerationError))?
+    }
+
+    /// Retrieve a list of granular tokens for the account whose credentials have been configured for this client.
+    ///
+    /// Note: only granular tokens are returned. Other types of tokens (publish, automation, etc.) are filtered out.
+    pub async fn list_granular_tokens(&self, _: &str, module: &str) -> Result<String, ApiError> {
+        info!("Listing npm granular tokens on behalf of [{module}]");
+        self.login()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::LoginFlowError))?;
+        let response = self
+            .client
+            .get(format!(
+                "{}/settings/{}/tokens",
+                NPMJS_COM_URL, self.config.username
+            ))
+            .header("X-Spiferack", "1") // to get JSON instead of HTML
+            .send()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToListGranularTokens))?;
+
+        // Tokens are returned in a JSON structure under "list > objects". We first deserialize to a
+        // generic Value, then get "list > objects" and convert to a vector of NpmTokens. Finally, we
+        // keep only granular tokens and return the result.
+        let granular_tokens = serde_json::from_value::<Vec<NpmToken>>(
+            response
+                .json::<Value>()
+                .await
+                .map_err(|_| ApiError::NpmError(NpmError::FailedToListGranularTokens))?
+                .get("list")
+                .ok_or(ApiError::NpmError(NpmError::FailedToListGranularTokens))?
+                .get("objects")
+                .ok_or(ApiError::NpmError(NpmError::FailedToListGranularTokens))?
+                .clone(),
+        )
+        .map_err(|_| ApiError::NpmError(NpmError::FailedToListGranularTokens))?
+        .iter()
+        .filter(|v| v.token_type == Some("granular".to_string()))
+        .cloned()
+        .collect::<Vec<NpmToken>>();
+
+        serde_json::to_string(&granular_tokens)
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToListGranularTokens))
+    }
+
+    /// Delete a package from the npm registry.
+    ///
+    /// Note: The package name should be unscoped. If you are trying to delete
+    /// @scope/package_name, then you should pass only "package_name". The scope is
+    /// preconfigured in the client and will be added automatically.
+    pub async fn delete_package(&self, package: &str, module: &str) -> Result<i32, ApiError> {
+        info!("Deleting npm package [{package}] on behalf of [{module}]");
+        self.login()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::LoginFlowError))?;
+        // Step 1. Make a GET request to /delete in order to retrieve the dsrManifestHash.
+        // This will later be sent as form data when actually performing the deletion.
+        let response = self
+            .client
+            .get(format!(
+                "{}/package/%40{}%2F{}/delete",
+                NPMJS_COM_URL, self.config.npm_scope, package
+            ))
+            .send()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToDeletePackage))?;
+        // Safe unwrap: hardcoded data.
+        // TODO best to precompile regex? This is likely an infrequent operation.
+        let dsr_manifest_hash = Regex::new(r#"dsrManifestHash\"\s+?value=\"([a-z0-9]{64})\""#)
+            .unwrap()
+            .captures(
+                &response
+                    .text()
+                    .await
+                    .map_err(|_| ApiError::NpmError(NpmError::FailedToDeletePackage))?,
+            )
+            .ok_or(ApiError::NpmError(NpmError::FailedToDeletePackage))?
+            .get(1) // get the content of the capturing group, which contains the token we need
+            .ok_or(ApiError::NpmError(NpmError::FailedToDeletePackage))?
+            .as_str()
+            .to_string();
+
+        // Step 2. Perform the actual package deletion with a POST request to /delete
+        let scoped_package_name = format!("@{}/{}", self.config.npm_scope, package);
+        let csrf_token = self
+            .get_csrftoken_from_cookies()
+            .map_err(|_| ApiError::NpmError(NpmError::WrongClientStatus))?;
+        let form_data: HashMap<&str, &str> = [
+            ("package", scoped_package_name.as_str()),
+            ("dsrManifestHash", &dsr_manifest_hash),
+            ("csrftoken", &csrf_token),
+        ]
+        .into();
+        self.client
+            .post(format!(
+                "{}/package/%40{}%2F{}/delete",
+                NPMJS_COM_URL, self.config.npm_scope, package
+            ))
+            .form(&form_data)
+            .send()
+            .await
+            .map(|_| Ok(0))
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToDeletePackage))?
+    }
+
+    /// Add a user to an npm team
+    pub async fn add_user_to_team(&self, params: &str, module: &str) -> Result<i32, ApiError> {
+        self.login()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::LoginFlowError))?;
+        let params: AddRemoveUserToFromTeamParams =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        info!(
+            "Adding user [{}] to team [{}] on behalf of [{module}]",
+            params.user,
+            params.team.to_string()
+        );
+
+        let csrf_token = self
+            .get_csrftoken_from_cookies()
+            .map_err(|_| ApiError::NpmError(NpmError::WrongClientStatus))?;
+        let body = format!(
+            r#"{{"csrftoken": "{}", "user": "{}"}}"#,
+            &csrf_token, params.user
+        );
+        self.client
+            .post(format!(
+                "{}/settings/{}/teams/team/{}/users",
+                NPMJS_COM_URL,
+                self.config.npm_scope,
+                params.team.to_string()
+            ))
+            .header("Content-Type", "text/plain;charset=UTF-8")
+            .body(body)
+            .send()
+            .await
+            .map(|_| Ok(0))
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToAddUserToTeam))?
+    }
+
+    /// Remove a user from an npm team
+    pub async fn remove_user_from_team(&self, params: &str, module: &str) -> Result<i32, ApiError> {
+        self.login()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::LoginFlowError))?;
+        let params: AddRemoveUserToFromTeamParams =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        info!(
+            "Removing user [{}] from team [{}] on behalf of [{module}]",
+            params.user,
+            params.team.to_string()
+        );
+
+        let body = format!(
+            r#"{{"csrftoken": "{}"}}"#,
+            self.get_csrftoken_from_cookies()
+                .map_err(|_| ApiError::NpmError(NpmError::WrongClientStatus))?
+        );
+        self.client
+            .post(format!(
+                "{}/settings/{}/teams/team/{}/users/{}/delete",
+                NPMJS_COM_URL,
+                self.config.npm_scope,
+                params.team.to_string(),
+                params.user
+            ))
+            .header("Content-Type", "text/plain;charset=UTF-8")
+            .body(body)
+            .send()
+            .await
+            .map(|_| Ok(0))
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToRemoveUserFromTeam))?
+    }
+
+    /// Remove a user from the npm organization
+    pub async fn remove_user_from_organization(
+        &self,
+        user: &str,
+        module: &str,
+    ) -> Result<i32, ApiError> {
+        #[derive(Serialize)]
+        struct RemoveUserPayload<'a> {
+            csrftoken: &'a str,
+        }
+
+        info!("Removing user [{user}] from npm organization on behalf of [{module}]");
+
+        self.login()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::LoginFlowError))?;
+        let csrf_token = self
+            .get_csrftoken_from_cookies()
+            .map_err(|_| ApiError::NpmError(NpmError::WrongClientStatus))?;
+        let payload = RemoveUserPayload {
+            csrftoken: &csrf_token,
+        };
+
+        self.client
+            .post(format!(
+                "{}/settings/{}/members/{}/delete",
+                NPMJS_COM_URL, self.config.npm_scope, user
+            ))
+            .json(&payload)
+            .send()
+            .await
+            .map(|_| Ok(0))
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToRemoveUserFromOrg))?
+    }
+
+    /// Invite a user to the npm organization.
+    ///
+    /// If `team` is specified then the user is added to that team upon accepting the invite.
+    /// If `team` is `None`, then the user is added to the default "developers" team.
+    pub async fn invite_user_to_organization(
+        &self,
+        params: &str,
+        module: &str,
+    ) -> Result<i32, ApiError> {
+        self.login()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::LoginFlowError))?;
+        let params: InviteUserToOrganizationParams =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        let team = params.team.unwrap_or(plaid_stl::npm::NpmTeam::Developers);
+
+        info!(
+            "Inviting user [{}] to npm organization and team [{}] on behalf of [{module}]",
+            params.user,
+            team.to_string()
+        );
+
+        let body = format!(
+            r#"{{
+  "csrftoken": "{}",
+  "user": {{
+    "name": "{}"
+    }},
+  "team": "{}"
+    }}"#,
+            self.get_csrftoken_from_cookies()
+                .map_err(|_| ApiError::NpmError(NpmError::WrongClientStatus))?,
+            params.user,
+            team.to_string()
+        );
+
+        self.client
+            .post(format!(
+                "{}/settings/{}/invite/create",
+                NPMJS_COM_URL, self.config.npm_scope
+            ))
+            .header("Content-Type", "text/plain;charset=UTF-8")
+            .body(body)
+            .send()
+            .await
+            .map(|_| Ok(0))
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToInviteUserToOrg))?
+    }
+
+    /// Return all users in the npm organization
+    pub async fn get_org_user_list(&self, _: &str, module: &str) -> Result<String, ApiError> {
+        info!("Listing all members of npm organization on behalf of [{module}]");
+        self.login()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::LoginFlowError))?;
+        let response = self
+            .client
+            .get(format!(
+                "{}/settings/{}/members",
+                NPMJS_COM_URL, self.config.npm_scope
+            ))
+            .header("X-Spiferack", "1")
+            .send()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToRetrieveUserList))?
+            .json::<Value>()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToRetrieveUserList))?;
+
+        // Get total number of users that we will need to retrieve
+        let total_users: u16 = serde_json::from_value(
+            response
+                .get("list")
+                .ok_or(ApiError::NpmError(NpmError::FailedToRetrieveUserList))?
+                .get("total")
+                .ok_or(ApiError::NpmError(NpmError::FailedToRetrieveUserList))?
+                .clone(),
+        )
+        .map_err(|_| ApiError::NpmError(NpmError::FailedToRetrieveUserList))?;
+
+        let users = self
+            .get_users_from_npm_website(
+                &format!(
+                    "{}/settings/{}/members",
+                    NPMJS_COM_URL, self.config.npm_scope
+                ),
+                total_users,
+            )
+            .await?;
+
+        serde_json::to_string(&users)
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToRetrieveUserList))
+    }
+
+    /// Utility function that retrieves users from a certain URL under the npm website.
+    /// The function keeps querying more pages until it has retrieved the target number of users.
+    async fn get_users_from_npm_website(
+        &self,
+        url: &str,
+        target_num_users: u16,
+    ) -> Result<Vec<NpmUser>, ApiError> {
+        // Get the first page, which contains the first users (max 10)
+        let response = self
+            .client
+            .get(url)
+            .header("X-Spiferack", "1")
+            .send()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToRetrieveUserList))?
+            .json::<Value>()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToRetrieveUserList))?;
+
+        let mut all_users = json_value_to_user_vec(response)
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToConvertToNpmUser))?;
+
+        if target_num_users <= 10 {
+            // We should have already got 10 users from the first page
+            if all_users.len() == target_num_users as usize {
+                // OK we got them all and we are done
+                return Ok(all_users);
+            }
+            // We _should_ have got all the users but something went wrong. Not good.
+            return Err(ApiError::NpmError(NpmError::FailedToRetrieveUserList));
+        }
+
+        // If we are here, then there are more than 10 users, so we make more requests
+        let mut page_num = 1; // pages start from 0
+
+        loop {
+            let response = self
+                .client
+                .get(url)
+                .header("X-Spiferack", "1") // to get JSON instead of HTML
+                .query(&[("page", page_num.to_string().as_str()), ("perPage", "10")])
+                .send()
+                .await
+                .map_err(|_| ApiError::NpmError(NpmError::FailedToRetrieveUserList))?
+                .json::<Value>()
+                .await
+                .map_err(|_| ApiError::NpmError(NpmError::FailedToRetrieveUserList))?;
+
+            all_users.extend(
+                json_value_to_user_vec(response)
+                    .map_err(|_| ApiError::NpmError(NpmError::FailedToConvertToNpmUser))?,
+            );
+
+            if all_users.len() == target_num_users as usize {
+                // We got all the users
+                return Ok(all_users);
+            }
+
+            // There are more users
+            page_num += 1;
+        }
+    }
+
+    /// Retrieve all users in the npm org that do not have 2FA enabled
+    pub async fn get_org_users_without_2fa(
+        &self,
+        _: &str,
+        module: &str,
+    ) -> Result<String, ApiError> {
+        info!("Listing all members of npm organization without 2FA on behalf of [{module}]");
+        self.login()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::LoginFlowError))?;
+        let response = self
+            .client
+            .get(format!(
+                "{}/settings/{}/members",
+                NPMJS_COM_URL, self.config.npm_scope
+            ))
+            .query(&[("selectedTab", "tfa_disabled")])
+            .header("X-Spiferack", "1")
+            .send()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToRetrieveUserList))?
+            .json::<Value>()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToRetrieveUserList))?;
+
+        // Get total number of users that we will need to retrieve
+        let total_users: u16 = serde_json::from_value(
+            response
+                .get("memberCounts")
+                .ok_or(ApiError::NpmError(NpmError::FailedToRetrieveUserList))?
+                .get("tfa_disabled")
+                .ok_or(ApiError::NpmError(NpmError::FailedToRetrieveUserList))?
+                .clone(),
+        )
+        .map_err(|_| ApiError::NpmError(NpmError::FailedToRetrieveUserList))?;
+
+        let users = self
+            .get_users_from_npm_website(
+                &format!(
+                    "{}/settings/{}/members?selectedTab=tfa_disabled",
+                    NPMJS_COM_URL, self.config.npm_scope
+                ),
+                total_users,
+            )
+            .await?;
+
+        serde_json::to_string(&users)
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToRetrieveUserList))
+    }
+}
+
+/// Convert a JSON value received from npm website into a list of `NpmUser` objects.
+/// Users are in a JSON array under "list > objects".
+fn json_value_to_user_vec(value: Value) -> Result<Vec<NpmUser>, NpmError> {
+    let users = serde_json::from_value::<Vec<Value>>(
+        value
+            .get("list")
+            .ok_or(NpmError::FailedToConvertToNpmUser)?
+            .get("objects")
+            .ok_or(NpmError::FailedToConvertToNpmUser)?
+            .clone(),
+    )
+    .map_err(|_| NpmError::FailedToConvertToNpmUser)?;
+
+    let mut all_users: Vec<NpmUser> = vec![];
+
+    for u in users {
+        all_users.push(NpmUser {
+            username: serde_json::from_value::<String>(
+                u.get("user")
+                    .ok_or(NpmError::FailedToConvertToNpmUser)?
+                    .get("name")
+                    .ok_or(NpmError::FailedToConvertToNpmUser)?
+                    .clone(),
+            )
+            .map_err(|_| NpmError::FailedToConvertToNpmUser)?,
+            role: NpmUserRole::try_from(
+                u.get("role")
+                    .ok_or(NpmError::FailedToConvertToNpmUser)?
+                    .to_string()
+                    .replace("\"", ""),
+            )
+            .map_err(|_| NpmError::FailedToConvertToNpmUser)?,
+        });
+    }
+
+    Ok(all_users)
+}

--- a/plaid/src/apis/npm/npm_web_client.rs
+++ b/plaid/src/apis/npm/npm_web_client.rs
@@ -419,10 +419,7 @@ impl Npm {
         let user = self.validate_npm_username(&params.user)?;
         let team = self.validate_npm_team_name(&params.team)?;
 
-        info!(
-            "Removing user [{}] from team [{}] on behalf of [{module}]",
-            user, team
-        );
+        info!("Removing [{user}] from [{team}] on behalf of [{module}]");
 
         let body = format!(
             r#"{{"csrftoken": "{}"}}"#,
@@ -492,6 +489,9 @@ impl Npm {
         let params: InviteUserToOrganizationParams =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
         let user = self.validate_npm_username(&params.user)?;
+        
+        // See https://docs.npmjs.com/about-developers-team
+        // We use "developers" as default since all organizations have a "developers" team
         let team = params.team.unwrap_or("developers".to_string());
         let team = self.validate_npm_team_name(&team)?;
 

--- a/plaid/src/apis/npm/validators.rs
+++ b/plaid/src/apis/npm/validators.rs
@@ -1,0 +1,141 @@
+use std::collections::HashMap;
+
+use plaid_stl::npm::shared_structs::GranularTokenSpecs;
+
+use super::{Npm, NpmError};
+use crate::apis::ApiError;
+
+macro_rules! define_regex_validator {
+    ($validators:expr,$validator:tt,$regex: tt) => {
+        $validators.insert(
+            $validator,
+            regex::Regex::new($regex)
+                .expect(format!("Failed to create {} validator", stringify!($validator)).as_str()),
+        );
+    };
+}
+
+macro_rules! create_regex_validator_func {
+    ($validator:ident) => {
+        paste::item! {
+            impl Npm {
+                pub fn [< validate_ $validator>]<'a> (&self, value_to_validate: &'a str) -> Result<&'a str, ApiError> {
+                    let validator = if let Some(validator) = self.validators.get(stringify!($validator)) {
+                        validator
+                    } else {
+                        error!("Validator {} not found in npm API. This should be impossible.", stringify!($validator));
+                        return Err(ApiError::ImpossibleError);
+                    };
+
+                    validator.is_match(value_to_validate)
+                        .then(|| value_to_validate)
+                        .ok_or(ApiError::NpmError(NpmError::InvalidInput(value_to_validate.to_string())))
+                }
+            }
+        }
+    }
+}
+
+pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
+    let mut validators = HashMap::new();
+
+    // Validate an _unscoped_ package name. The scope is added later
+    define_regex_validator!(
+        validators,
+        "npm_package_name",
+        r"^[a-z0-9-_]+(?:\.[a-z0-9-_]+)*$"
+    );
+
+    // Validate a team's name for npm: it is possible more combinations are allowed, but we choose to be rather strict
+    define_regex_validator!(validators, "npm_team_name", r"^[a-zA-Z0-9-_]+$");
+
+    // Validate an npm username. This is probably stricter than necessary
+    define_regex_validator!(validators, "npm_username", r"^[a-zA-Z0-9-_]+$");
+
+    define_regex_validator!(
+        validators,
+        "ipv4",
+        r"^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9]).){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])$"
+    );
+    define_regex_validator!(validators, "npm_org_name", r"^[a-z0-9]+(-[a-z0-9]+)*$");
+    define_regex_validator!(validators, "npm_at_org_name", r"^@[a-z0-9]+(-[a-z0-9]+)*$");
+    define_regex_validator!(
+        validators,
+        "npm_scoped_package",
+        r"^@[a-z0-9]+(-[a-z0-9]+)*\/[a-z0-9-_]+(?:\.[a-z0-9-_]+)*$"
+    );
+
+    // probably more strict than necessary
+    define_regex_validator!(validators, "npm_token_name", r"^[a-z0-9._-]+$");
+
+    validators
+}
+
+create_regex_validator_func!(npm_package_name);
+create_regex_validator_func!(npm_team_name);
+create_regex_validator_func!(npm_username);
+create_regex_validator_func!(ipv4);
+create_regex_validator_func!(npm_org_name);
+create_regex_validator_func!(npm_at_org_name);
+create_regex_validator_func!(npm_scoped_package);
+create_regex_validator_func!(npm_token_name);
+
+// Special validator for GranularTokenSpecs
+impl Npm {
+    pub fn validate_granular_token_specs<'a>(
+        &self,
+        value_to_validate: &'a GranularTokenSpecs,
+    ) -> Result<&'a GranularTokenSpecs, ApiError> {
+        // Validate each field of the struct
+
+        // pub allowed_ip_ranges: Option<Vec<String>>,
+        if let Some(ref ips) = value_to_validate.allowed_ip_ranges {
+            ips.iter()
+                .try_for_each(|v| self.validate_ipv4(v).map(|_| ()))?;
+        }
+
+        // pub expiration_days: Option<u16>,
+        // No validation necessary: if it deserializes to u16, it's fine
+
+        // pub orgs_permission: Option<GranularTokenOrgsPermission>,
+        // No validation necessary: if it deserializes to the enum, it's fine
+
+        // pub packages_and_scopes_permission: Option<GranularTokenPackagesAndScopesPermission>,
+        // No validation necessary: if it deserializes to the enum, it's fine
+
+        // pub selected_orgs: Option<Vec<String>>,
+        if let Some(ref orgs) = value_to_validate.selected_orgs {
+            orgs.iter()
+                .try_for_each(|v| self.validate_npm_org_name(v).map(|_| ()))?;
+        }
+
+        // pub selected_packages: Option<Vec<String>>,
+        if let Some(ref pkgs) = value_to_validate.selected_packages {
+            pkgs.iter()
+                .try_for_each(|v| self.validate_npm_scoped_package(v).map(|_| ()))?;
+        }
+
+        // pub selected_packages_and_scopes: Option<GranularTokenSelectedPackagesAndScopes>,
+        // No validation necessary: if it deserializes to the enum, it's fine
+
+        // pub selected_scopes: Option<Vec<String>>,
+        if let Some(ref scopes) = value_to_validate.selected_scopes {
+            scopes
+                .iter()
+                .try_for_each(|v| self.validate_npm_at_org_name(v).map(|_| ()))?;
+        }
+
+        // pub token_name: String,
+        self.validate_npm_token_name(&value_to_validate.token_name)?;
+
+        // pub token_description: String,
+        // Impose it's at least 8 characters to avoid things like "test" or "testing"
+        if value_to_validate.token_description.len() < 8 {
+            return Err(ApiError::NpmError(NpmError::InvalidInput(
+                value_to_validate.token_description.clone(),
+            )));
+        }
+
+        Ok(value_to_validate)
+    }
+}

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -261,6 +261,7 @@ impl_new_function!(npm, remove_user_from_organization);
 impl_new_function!(npm, invite_user_to_organization);
 impl_new_function_with_error_buffer!(npm, get_org_user_list);
 impl_new_function_with_error_buffer!(npm, get_org_users_without_2fa);
+impl_new_function_with_error_buffer!(npm, list_packages_with_team_permission);
 
 // Okta Functions
 impl_new_function!(okta, remove_user_from_group);
@@ -380,6 +381,10 @@ pub fn to_api_function(
 
         "npm_get_org_users_without_2fa" => {
             Function::new_typed_with_env(&mut store, &env, npm_get_org_users_without_2fa)
+        }
+
+        "npm_list_packages_with_team_permission" => {
+            Function::new_typed_with_env(&mut store, &env, npm_list_packages_with_team_permission)
         }
         
         // Okta Calls

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -249,6 +249,19 @@ impl_new_sub_module_function_with_error_buffer!(aws, kms, sign_arbitrary_message
 #[cfg(feature = "aws")]
 impl_new_sub_module_function_with_error_buffer!(aws, kms, get_public_key);
 
+// Npm Functions
+impl_new_function!(npm, publish_empty_stub);
+impl_new_function!(npm, set_team_permission_on_package);
+impl_new_function_with_error_buffer!(npm, create_granular_token_for_package);
+impl_new_function_with_error_buffer!(npm, list_granular_tokens);
+impl_new_function!(npm, delete_package);
+impl_new_function!(npm, add_user_to_team);
+impl_new_function!(npm, remove_user_from_team);
+impl_new_function!(npm, remove_user_from_organization);
+impl_new_function!(npm, invite_user_to_organization);
+impl_new_function_with_error_buffer!(npm, get_org_user_list);
+impl_new_function_with_error_buffer!(npm, get_org_users_without_2fa);
+
 // Okta Functions
 impl_new_function!(okta, remove_user_from_group);
 impl_new_function_with_error_buffer!(okta, get_user_data);
@@ -323,6 +336,52 @@ pub fn to_api_function(
         }
         "cache_get" => Function::new_typed_with_env(&mut store, &env, super::internal::cache_get),
         "log_back" => Function::new_typed_with_env(&mut store, &env, super::internal::log_back),
+        
+        // Npm Calls
+        "npm_publish_empty_stub" => {
+            Function::new_typed_with_env(&mut store, &env, npm_publish_empty_stub)
+        }
+
+        "npm_set_team_permission_on_package" => {
+            Function::new_typed_with_env(&mut store, &env, npm_set_team_permission_on_package)
+        }
+
+        "npm_create_granular_token_for_package" => {
+            Function::new_typed_with_env(&mut store, &env, npm_create_granular_token_for_package)
+        }
+
+        "npm_list_granular_tokens" => {
+            Function::new_typed_with_env(&mut store, &env, npm_list_granular_tokens)
+        }
+
+        "npm_delete_package" => {
+            Function::new_typed_with_env(&mut store, &env, npm_delete_package)
+        }
+
+        "npm_add_user_to_team" => {
+            Function::new_typed_with_env(&mut store, &env, npm_add_user_to_team)
+        }
+
+        "npm_remove_user_from_team" => {
+            Function::new_typed_with_env(&mut store, &env, npm_remove_user_from_team)
+        }
+
+        "npm_remove_user_from_organization" => {
+            Function::new_typed_with_env(&mut store, &env, npm_remove_user_from_organization)
+        }
+
+        "npm_invite_user_to_organization" => {
+            Function::new_typed_with_env(&mut store, &env, npm_invite_user_to_organization)
+        }
+
+        "npm_get_org_user_list" => {
+            Function::new_typed_with_env(&mut store, &env, npm_get_org_user_list)
+        }
+
+        "npm_get_org_users_without_2fa" => {
+            Function::new_typed_with_env(&mut store, &env, npm_get_org_users_without_2fa)
+        }
+        
         // Okta Calls
         "okta_remove_user_from_group" => {
             Function::new_typed_with_env(&mut store, &env, okta_remove_user_from_group)


### PR DESCRIPTION
### Supported functionality
1. Publish empty package stub
2. Invite user to organization
3. Remove user from organization
4. Add user to team
5. Remove user from team
6. Get list of users in the organization
7. Get list of users in the organization without 2FA enabled
8. Set team permissions on a package
9. Create granular token for package
10. List all granular tokens (with expiration date)
11. Delete a package (TBC if we want to expose this)
12. List packages over which a team has certain permissions (useful to spot misconfigured packages)

### Design choices
* Shared structs are all defined in the STL, since `plaid` depends on `plaid-stl`. Therefore, the code can serialize and deserialize using the same types across the host/guest boundary.
* The TOTP functionality is embedded in the code that uses it. TBD if we want to separate it out.
* The generation of a tarball (for uploading a new package stub) is currently part of the plaid runtime.

### Backward compatibility
Changes are purely additive, so backward compatibility is maintained.

### New configuration for npm API

```
[apis.npm]
username = ""
password = ""
otp_secret = ""
automation_token = ""
npm_scope = ""
user_agent = ""
```
