### PR TITLE
Support creating a GH environment with protection rules and env secret

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +56,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "alkali"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb2e727d77155f0e96b81253095e40dfbd3a8eb33b5b9a01bb881dbca9f3992"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "libsodium-sys-stable",
+ "rand_core",
+ "serde",
+ "serde-big-array",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,9 +98,18 @@ checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anyhow"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+
+[[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -90,9 +119,9 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -141,13 +170,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -163,15 +192,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.5"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e95816a168520d72c0e7680c405a5a8c1fb6a035b4bc4b9d7b0de8e1a941697"
+checksum = "8191fb3091fa0561d1379ef80333c3c7191c6f0435d986e85821bcf7acbd1126"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -211,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2424565416eef55906f9f8cece2072b6b6a76075e3ff81483ebe938a89a4c05f"
+checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -236,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.42.0"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704ab31904cf70104a3bb023079e201b1353cf132ca674b26ba6f23acbbb53c9"
+checksum = "0caf20b8855dbeb458552e6c8f8f9eb92b95e4a131725b93540ec73d60c38eb3"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -258,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.41.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af0a3f676cba2c079c9563acc9233998c8951cdbe38629a0bef3c8c1b02f3658"
+checksum = "0b90cfe6504115e13c41d3ea90286ede5aa14da294f3fe077027a6e83850843c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -280,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.42.0"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91b6a04495547162cf52b075e3c15a17ab6608bf9c5785d3e5a5509b3f09f5c"
+checksum = "167c0fad1f212952084137308359e8e4c4724d1c643038ce163f06de9662c1d0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -302,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.41.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c56bcd6a56cab7933980a54148b476a5a69a7694e3874d9aa2a566f150447d"
+checksum = "2cb5f98188ec1435b68097daa2a37d74b9d17c9caa799466338a8d1544e71b9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -325,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df1b0fa6be58efe9d4ccc257df0a53b89cd8909e86591a13ca54817c87517be"
+checksum = "cc8db6904450bafe7473c6ca9123f88cc11089e41a025408f992db4e22d3be68"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -442,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03701449087215b5369c7ea17fef0dd5d24cb93439ec5af0c7615f58c3f22605"
+checksum = "147100a7bea70fa20ef224a6bad700358305f5dc0f84649c53769761395b355b"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -552,22 +581,20 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bindgen"
-version = "0.68.1"
+version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
+ "itertools",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -622,22 +649,23 @@ dependencies = [
 
 [[package]]
 name = "boring"
-version = "4.9.1"
+version = "4.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795e8d96c51071a5479717ca96cb9741b7a41ee6469291a2f06a0b5ce80da52b"
+checksum = "07e774b91e8adadd05892dfa300bc297e703a3cea36f094a4f8c155d2b13b770"
 dependencies = [
  "bitflags 2.6.0",
  "boring-sys",
  "foreign-types 0.5.0",
  "libc",
  "once_cell",
+ "openssl-macros",
 ]
 
 [[package]]
 name = "boring-sys"
-version = "4.9.1"
+version = "4.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feba0d697defa95b2fc181e0e37d55a0547df5c1f8a253af2c614d45bb597f80"
+checksum = "49584b157cf568167bfd13c2567a4bc9e1bec9bc2a36216c54ac86925922a903"
 dependencies = [
  "bindgen",
  "cmake",
@@ -681,9 +709,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "bytes-utils"
@@ -697,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
 dependencies = [
  "shlex",
 ]
@@ -747,18 +775,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -851,6 +879,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "corosensei"
@@ -1057,7 +1094,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1068,8 +1105,14 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
 
 [[package]]
 name = "dashmap"
@@ -1137,6 +1180,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,7 +1210,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1257,7 +1311,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1325,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1366,7 +1420,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1478,7 +1532,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1767,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -1876,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1889,16 +1943,15 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1980,12 +2033,21 @@ checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "iri-string"
-version = "0.7.2"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f5f6c2df22c009ac44f6f1499308e7a3ac7ba42cd2378475cc691510e1eef1b"
+checksum = "44bd7eced44cfe2cebc674adb2a7124a754a4b5269288d22e9f39f8fada3562d"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2047,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -2069,12 +2131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,9 +2138,33 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+
+[[package]]
+name = "libflate"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
+dependencies = [
+ "adler32",
+ "core2",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
+dependencies = [
+ "core2",
+ "hashbrown 0.14.5",
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "libloading"
@@ -2110,7 +2190,24 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.7",
+]
+
+[[package]]
+name = "libsodium-sys-stable"
+version = "1.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42631d334de875c636a1aae7adb515653ac2e771e5a2ce74b1053f5a4412df3a"
+dependencies = [
+ "cc",
+ "libc",
+ "libflate",
+ "minisign-verify",
+ "pkg-config",
+ "tar",
+ "ureq",
+ "vcpkg",
+ "zip",
 ]
 
 [[package]]
@@ -2128,6 +2225,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
@@ -2207,6 +2310,12 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a05b5d0594e0cb1ad8cee3373018d2b84e25905dc75b2468114cc9a8e86cfc20"
 
 [[package]]
 name = "miniz_oxide"
@@ -2402,9 +2511,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "openssl"
@@ -2429,7 +2541,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2523,7 +2635,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.7",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -2533,12 +2645,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
@@ -2591,7 +2697,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2629,14 +2735,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plaid"
 version = "0.12.1"
 dependencies = [
+ "alkali",
  "async-trait",
  "aws-config",
  "aws-sdk-kms",
@@ -2683,6 +2790,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "powerfmt"
@@ -2866,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2887,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2899,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2916,9 +3029,9 @@ checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "region"
@@ -3055,6 +3168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
 name = "rsa"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3107,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.36"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3163,7 +3282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -3180,19 +3299,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"
@@ -3296,9 +3414,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3326,6 +3444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-wasm-bindgen"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3344,7 +3471,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3439,10 +3566,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "simdutf8"
-version = "0.1.4"
+name = "simd-adler32"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -3495,23 +3628,23 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snafu"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b835cb902660db3415a672d862905e791e54d306c6e8189168c7f3d9ae1c79d"
+checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d1e02fca405f6280643174a50c942219f0bbf4dbf7d480f1dd864d6f211ae5"
+checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3560,9 +3693,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superboring"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbde97f499e51ef384f585dc8f8fb6a9c3a71b274b8d12469b516758e6540607"
+checksum = "cee25cd9d145d2c1ef92a52720376eeb510c8870dfa0f84edb371901ec6a12ca"
 dependencies = [
  "getrandom",
  "hmac-sha256",
@@ -3584,9 +3717,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3640,9 +3773,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+checksum = "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020"
 dependencies = [
  "filetime",
  "libc",
@@ -3657,9 +3790,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3679,22 +3812,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3769,7 +3902,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3933,7 +4066,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4012,24 +4145,24 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -4042,6 +4175,18 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "once_cell",
+ "url",
+]
 
 [[package]]
 name = "url"
@@ -4118,7 +4263,7 @@ dependencies = [
  "multer",
  "percent-encoding",
  "pin-project",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "scoped-tls",
  "serde",
  "serde_json",
@@ -4168,7 +4313,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -4202,7 +4347,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4706,7 +4851,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4714,3 +4859,34 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zip"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc5e4288ea4057ae23afc69a4472434a87a2495cafce6632fd1c4ec9f5cf3494"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.5.0",
+ "memchr",
+ "thiserror",
+ "zopfli",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
+]

--- a/plaid-stl/src/github/mod.rs
+++ b/plaid-stl/src/github/mod.rs
@@ -317,7 +317,11 @@ pub fn fetch_commit(user: &str, repo: &str, commit: &str) -> Result<String, Plai
     Ok(String::from_utf8(return_buffer).unwrap())
 }
 
-pub fn list_files(organization: &str, repository_name: &str, pull_request: &str) -> Result<String, PlaidFunctionError> {
+pub fn list_files(
+    organization: &str,
+    repository_name: &str,
+    pull_request: &str,
+) -> Result<String, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, list_files);
     }
@@ -330,7 +334,11 @@ pub fn list_files(organization: &str, repository_name: &str, pull_request: &str)
         pull_request: &'a str,
     }
 
-    let request = Request { organization, repository_name, pull_request };
+    let request = Request {
+        organization,
+        repository_name,
+        pull_request,
+    };
 
     let request = serde_json::to_string(&request).unwrap();
 
@@ -357,7 +365,12 @@ pub fn list_files(organization: &str, repository_name: &str, pull_request: &str)
     Ok(String::from_utf8(return_buffer).unwrap())
 }
 
-pub fn fetch_file(organization: &str, repository_name: &str, file_path: &str, reference: &str) -> Result<String, PlaidFunctionError> {
+pub fn fetch_file(
+    organization: &str,
+    repository_name: &str,
+    file_path: &str,
+    reference: &str,
+) -> Result<String, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, fetch_file);
     }
@@ -371,7 +384,12 @@ pub fn fetch_file(organization: &str, repository_name: &str, file_path: &str, re
         reference: &'a str,
     }
 
-    let request = Request { organization, repository_name, file_path, reference };
+    let request = Request {
+        organization,
+        repository_name,
+        file_path,
+        reference,
+    };
 
     let request = serde_json::to_string(&request).unwrap();
 
@@ -668,7 +686,10 @@ pub fn get_all_repository_collaborators(
         if this_page == "[]" {
             break;
         }
-        collaborators.extend(serde_json::from_str::<Vec<RepositoryCollaborator>>(&this_page).map_err(|_| PlaidFunctionError::InternalApiError)?);
+        collaborators.extend(
+            serde_json::from_str::<Vec<RepositoryCollaborator>>(&this_page)
+                .map_err(|_| PlaidFunctionError::InternalApiError)?,
+        );
     }
 
     Ok(collaborators)
@@ -720,13 +741,16 @@ pub fn update_branch_protection_rule(
 }
 
 /// Create a GitHub deployment environment for a given repository.
-/// 
+///
 /// Arguments:
 /// * `owner` - The owner of the repository
 /// * `repo` - The name of the repository
-/// * `branch` - The branch from which a deployment can be triggered. This will be set in the deployment
-/// protection rules
-pub fn create_environment_for_repo(owner: &str, repo: &str, branch: &str) -> Result<(), PlaidFunctionError> {
+/// * `env_name` - The name of the environment to be created
+pub fn create_environment_for_repo(
+    owner: &str,
+    repo: &str,
+    env_name: &str,
+) -> Result<(), PlaidFunctionError> {
     extern "C" {
         new_host_function!(github, create_environment_for_repo);
     }
@@ -734,9 +758,10 @@ pub fn create_environment_for_repo(owner: &str, repo: &str, branch: &str) -> Res
     let mut params: HashMap<&str, String> = HashMap::new();
     params.insert("owner", owner.to_string());
     params.insert("repo", repo.to_string());
-    params.insert("branch", branch.to_string());
+    params.insert("env_name", env_name.to_string());
 
-    let request = serde_json::to_string(&params).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+    let request =
+        serde_json::to_string(&params).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
 
     let res = unsafe {
         github_create_environment_for_repo(request.as_bytes().as_ptr(), request.as_bytes().len())
@@ -748,30 +773,78 @@ pub fn create_environment_for_repo(owner: &str, repo: &str, branch: &str) -> Res
     }
 }
 
-/// Configure an environment secret for a GitHub deployment environment. If a secret with the same name is already present, it will be overwritten.
-/// 
+/// Create a deployment branch protection rule for a GitHub environment.
+///
 /// Arguments:
 /// * `owner` - The owner of the repository
 /// * `repo` - The name of the repository
-/// * `env_name` - The name of the GitHub environment on which to set the secret
-/// * `secret_name` - The name of the secret to set
-/// * `secret` - The plaintext secret to be set
-pub fn configure_environment_secret(owner: &str, repo: &str, env_name: &str, secret_name: &str, secret: &str) -> Result<(), PlaidFunctionError> {
+/// * `env_name` - The name of the environment to be created
+/// * `branch` - The branch from which a deployment can be triggered. This will be set in the deployment protection rules
+pub fn create_deployment_branch_protection_rule(
+    owner: &str,
+    repo: &str,
+    env_name: &str,
+    branch: &str,
+) -> Result<(), PlaidFunctionError> {
     extern "C" {
-        new_host_function!(github, configure_environment_secret);
+        new_host_function!(github, create_deployment_branch_protection_rule);
     }
 
     let mut params: HashMap<&str, String> = HashMap::new();
     params.insert("owner", owner.to_string());
     params.insert("repo", repo.to_string());
     params.insert("env_name", env_name.to_string());
+    params.insert("branch", branch.to_string());
+
+    let request =
+        serde_json::to_string(&params).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+
+    let res = unsafe {
+        github_create_deployment_branch_protection_rule(
+            request.as_bytes().as_ptr(),
+            request.as_bytes().len(),
+        )
+    };
+
+    match res {
+        0 => Ok(()),
+        x => Err(x.into()),
+    }
+}
+
+/// Configure an environment secret for a GitHub deployment environment. If a secret with the same name is already present, it will be overwritten.
+///
+/// Arguments:
+/// * `owner` - The owner of the repository
+/// * `repo` - The name of the repository
+/// * `env_name` - The name of the GitHub environment on which to set the secret. If not set, then a repository-level secret is created
+/// * `secret_name` - The name of the secret to set
+/// * `secret` - The plaintext secret to be set
+pub fn configure_secret(
+    owner: &str,
+    repo: &str,
+    env_name: Option<&str>,
+    secret_name: &str,
+    secret: &str,
+) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(github, configure_secret);
+    }
+
+    let mut params: HashMap<&str, String> = HashMap::new();
+    params.insert("owner", owner.to_string());
+    params.insert("repo", repo.to_string());
+    if let Some(env_name) = env_name {
+        params.insert("env_name", env_name.to_string());
+    }
     params.insert("secret_name", secret_name.to_string());
     params.insert("secret", secret.to_string());
 
-    let request = serde_json::to_string(&params).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+    let request =
+        serde_json::to_string(&params).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
 
     let res = unsafe {
-        github_configure_environment_secret(request.as_bytes().as_ptr(), request.as_bytes().len())
+        github_configure_secret(request.as_bytes().as_ptr(), request.as_bytes().len())
     };
 
     match res {

--- a/plaid/Cargo.toml
+++ b/plaid/Cargo.toml
@@ -11,6 +11,7 @@ default = ["aws"]
 aws = ["aws-sdk-kms", "aws-config"]
 
 [dependencies]
+alkali = "0.3.0"
 async-trait = "0.1.56"
 base64 = "0.13"
 clap = { version = "4", default-features = false, features = ["std"] }

--- a/plaid/resources/plaid.toml
+++ b/plaid/resources/plaid.toml
@@ -39,9 +39,9 @@ okta = 200
 [loading.memory_page_count.module_overrides]
 "example_rule.wasm" = 50
 
-[apis."okta"]
-token = ""
-domain = ""
+# [apis."okta"]
+# token = ""
+# domain = ""
 
 [apis."general"]
 [apis."general".network.web_requests]

--- a/plaid/src/apis/github/environments.rs
+++ b/plaid/src/apis/github/environments.rs
@@ -1,0 +1,213 @@
+use std::collections::HashMap;
+
+use serde::Serialize;
+use serde_json::Value;
+
+use alkali::asymmetric::seal;
+
+use crate::apis::{github::GitHubError, ApiError};
+
+use super::Github;
+
+#[derive(Serialize)]
+struct DeploymentBranchPolicy {
+    protected_branches: bool,
+    custom_branch_policies: bool,
+}
+
+#[derive(Serialize)]
+struct CreateEnvironmentPayload {
+    wait_timer: u16,
+    prevent_self_review: bool,
+    reviewers: Vec<String>, // This is not true (items are not strings) but we will leave it empty, so we don't care
+    deployment_branch_policy: DeploymentBranchPolicy,
+}
+
+#[derive(Serialize)]
+struct CreateDeploymentBranchPolicyPayload {
+    name: String,
+    #[serde(rename = "type")]
+    type_: String,
+}
+
+#[derive(Serialize)]
+struct UploadEnvironmentSecretPayload {
+    encrypted_value: String,
+    key_id: String,
+}
+
+impl Github {
+    /// Create a new GitHub deployment environment for a given repository
+    /// See https://docs.github.com/en/rest/deployments/environments?apiVersion=2022-11-28#create-or-update-an-environment for more detail
+    pub async fn create_environment_for_repo(
+        &self,
+        params: &str,
+        module: &str,
+    ) -> Result<u32, ApiError> {
+        const ENVIRONMENT_NAME: &str = "publish";
+
+        let request: HashMap<&str, &str> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let owner = self.validate_username(request.get("owner").ok_or(ApiError::BadRequest)?)?;
+        let repo =
+            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
+        let branch =
+            self.validate_branch_name(request.get("branch").ok_or(ApiError::BadRequest)?)?;
+
+        info!(
+            "Creating and configuring 'publish' environment in repo [{repo}] owned by [{owner}] on behalf of [{module}]"
+        );
+
+        // 1. Create the environment
+
+        let address = format!("/repos/{owner}/{repo}/environments/{ENVIRONMENT_NAME}");
+
+        let body = CreateEnvironmentPayload {
+            wait_timer: 0,
+            prevent_self_review: false,
+            reviewers: vec![],
+            deployment_branch_policy: DeploymentBranchPolicy {
+                protected_branches: false,
+                custom_branch_policies: true,
+            },
+        };
+
+        match self
+            .make_generic_put_request(address, Some(&body), module)
+            .await
+        {
+            Ok((status, _)) => {
+                if status == 200 {
+                    Ok(())
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Err(e) => Err(e),
+        }?;
+
+        // 2. Create custom deployment protection rule to allow deployments only from the given branch
+        // See https://docs.github.com/en/rest/deployments/branch-policies?apiVersion=2022-11-28#create-a-deployment-branch-policy for more details
+
+        let address = format!(
+            "/repos/{owner}/{repo}/environments/{ENVIRONMENT_NAME}/deployment-branch-policies"
+        );
+
+        let body = CreateDeploymentBranchPolicyPayload {
+            name: branch.to_string(),
+            type_: "branch".to_string(), // it must be a branch, meaning it cannot be a tag that matches the given name
+        };
+
+        match self
+            .make_generic_post_request(address, Some(&body), module)
+            .await
+        {
+            Ok((status, _)) => {
+                if status == 200 {
+                    Ok(0)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Configure a secret in a GitHub deployment environment
+    pub async fn configure_environment_secret(
+        &self,
+        params: &str,
+        module: &str,
+    ) -> Result<u32, ApiError> {
+        let request: HashMap<&str, &str> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let owner = self.validate_username(request.get("owner").ok_or(ApiError::BadRequest)?)?;
+        let repo =
+            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
+        let environment_name = request.get("env_name").ok_or(ApiError::BadRequest)?;
+        let secret_name = request.get("secret_name").ok_or(ApiError::BadRequest)?;
+        let secret = request.get("secret").ok_or(ApiError::BadRequest)?;
+
+        info!("Configuring secret with name [{secret_name}] on environment [{environment_name}] for repository [{owner}/{repo}] on behalf of [{module}]");
+
+        // 1. Get pub key for the environment
+        let address =
+            format!("/repos/{owner}/{repo}/environments/{environment_name}/secrets/public-key");
+        let (status, body) = self.make_generic_get_request(address, module).await?;
+        if status != 200 {
+            return Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                status,
+            )));
+        };
+        let res = serde_json::from_str::<Value>(&body?).map_err(|_| {
+            ApiError::GitHubError(GitHubError::InvalidInput(
+                "Could not deserialize environment's public key".to_string(),
+            ))
+        })?;
+        let env_pub_key = res
+            .get("key")
+            .ok_or(ApiError::GitHubError(GitHubError::InvalidInput(
+                "Invalid response while fetching environment's public key".to_string(),
+            )))?
+            .to_string()
+            .replace("\"", "");
+        let env_key_id = res
+            .get("key_id")
+            .ok_or(ApiError::GitHubError(GitHubError::InvalidInput(
+                "Invalid response while fetching environment's public key".to_string(),
+            )))?
+            .to_string()
+            .replace("\"", "");
+
+        // 2. Encrypt the secret under the environment's pub key
+        let mut ciphertext = vec![0u8; secret.as_bytes().len() + seal::OVERHEAD_LENGTH];
+        seal::encrypt(
+            secret.as_bytes(),
+            base64::decode(env_pub_key)
+                .unwrap()
+                .as_slice()
+                .try_into()
+                .unwrap(),
+            &mut ciphertext,
+        )
+        .map_err(|_| {
+            ApiError::GitHubError(GitHubError::InvalidInput(
+                "Could not encrypt secret under environment's public key".to_string(),
+            ))
+        })?;
+        let ciphertext = base64::encode(ciphertext);
+
+        // 3. Upload the encrypted secret via the REST API
+        let address =
+            format!("/repos/{owner}/{repo}/environments/{environment_name}/secrets/{secret_name}");
+
+        let body = UploadEnvironmentSecretPayload {
+            encrypted_value: ciphertext,
+            key_id: env_key_id,
+        };
+
+        match self
+            .make_generic_put_request(address, Some(&body), module)
+            .await
+        {
+            Ok((status, _)) => {
+                // we are OK with creating or updating
+                if status == 201 || status == 204 {
+                    info!("Secret successfully uploaded");
+                    Ok(0)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/plaid/src/apis/github/mod.rs
+++ b/plaid/src/apis/github/mod.rs
@@ -1,3 +1,4 @@
+mod environments;
 mod graphql;
 mod pats;
 mod repos;
@@ -143,7 +144,7 @@ impl Github {
         body: T,
         module: &str,
     ) -> Result<(u16, Result<String, ApiError>), ApiError> {
-        info!("Making a get request to {uri} on behalf of {module}");
+        info!("Making a post request to {uri} on behalf of {module}");
 
         let request = self.client._post(uri, Some(&body)).await;
 

--- a/plaid/src/apis/github/mod.rs
+++ b/plaid/src/apis/github/mod.rs
@@ -2,6 +2,7 @@ mod environments;
 mod graphql;
 mod pats;
 mod repos;
+mod secrets;
 mod teams;
 mod validators;
 

--- a/plaid/src/apis/github/secrets.rs
+++ b/plaid/src/apis/github/secrets.rs
@@ -1,0 +1,130 @@
+use super::Github;
+use crate::apis::{github::GitHubError, ApiError};
+
+use alkali::asymmetric::seal;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Serialize)]
+struct UploadEnvironmentSecretPayload {
+    encrypted_value: String,
+    key_id: String,
+}
+
+impl Github {
+    /// Configure a secret in a GitHub repository or deployment environment
+    pub async fn configure_secret(&self, params: &str, module: &str) -> Result<u32, ApiError> {
+        let request: HashMap<&str, &str> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let owner = self.validate_username(request.get("owner").ok_or(ApiError::BadRequest)?)?;
+        let repo =
+            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
+        // Validate an env name if present
+        let env_name = match request.get("env_name") {
+            Some(name) => Some(self.validate_environment_name(name)?),
+            None => None,
+        };
+        let secret_name =
+            self.validate_secret_name(request.get("secret_name").ok_or(ApiError::BadRequest)?)?;
+        let secret = request.get("secret").ok_or(ApiError::BadRequest)?;
+
+        match env_name {
+            Some(name) => info!("Configuring secret with name [{secret_name}] on environment [{name}] for repository [{owner}/{repo}] on behalf of [{module}]"),
+            None => info!("Configuring secret with name [{secret_name}] on repository [{owner}/{repo}] on behalf of [{module}]"),
+        }
+
+        // 1. Get pub key
+
+        let address = match env_name {
+            Some(env_name) => {
+                // We are setting an environment secret
+                format!("/repos/{owner}/{repo}/environments/{env_name}/secrets/public-key")
+            }
+            None => {
+                // We are setting a repository secret
+                format!("/repos/{owner}/{repo}/actions/secrets/public-key")
+            }
+        };
+        let (status, body) = self.make_generic_get_request(address, module).await?;
+        if status != 200 {
+            return Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                status,
+            )));
+        };
+        let res = serde_json::from_str::<Value>(&body?).map_err(|_| {
+            ApiError::GitHubError(GitHubError::InvalidInput(
+                "Could not deserialize public key from GitHub".to_string(),
+            ))
+        })?;
+        let pub_key = res
+            .get("key")
+            .ok_or(ApiError::GitHubError(GitHubError::InvalidInput(
+                "Invalid response while fetching public key from GitHub".to_string(),
+            )))?
+            .to_string()
+            .replace("\"", "");
+        let key_id = res
+            .get("key_id")
+            .ok_or(ApiError::GitHubError(GitHubError::InvalidInput(
+                "Invalid response while fetching public key from GitHub".to_string(),
+            )))?
+            .to_string()
+            .replace("\"", "");
+
+        // 2. Encrypt the secret under the pub key
+
+        let mut ciphertext = vec![0u8; secret.as_bytes().len() + seal::OVERHEAD_LENGTH];
+        seal::encrypt(
+            secret.as_bytes(),
+            base64::decode(pub_key)
+                .unwrap()
+                .as_slice()
+                .try_into()
+                .unwrap(),
+            &mut ciphertext,
+        )
+        .map_err(|_| {
+            ApiError::GitHubError(GitHubError::InvalidInput(
+                "Could not encrypt secret under public key".to_string(),
+            ))
+        })?;
+        let ciphertext = base64::encode(ciphertext);
+
+        // 3. Upload the encrypted secret via the REST API
+
+        let address = match env_name {
+            Some(env_name) => {
+                // We are setting an environment secret
+                format!("/repos/{owner}/{repo}/environments/{env_name}/secrets/{secret_name}")
+            }
+            None => {
+                // We are setting a repository secret
+                format!("/repos/{owner}/{repo}/actions/secrets/{secret_name}")
+            }
+        };
+        let body = UploadEnvironmentSecretPayload {
+            encrypted_value: ciphertext,
+            key_id,
+        };
+
+        match self
+            .make_generic_put_request(address, Some(&body), module)
+            .await
+        {
+            Ok((status, _)) => {
+                // we are OK with creating or updating
+                if status == 201 || status == 204 {
+                    info!("Secret successfully uploaded");
+                    Ok(0)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/plaid/src/apis/github/validators.rs
+++ b/plaid/src/apis/github/validators.rs
@@ -64,6 +64,9 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
     // https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names#naming-branches-and-tags
     define_regex_validator!(validators, "branch_name", r"^[a-zA-Z][a-zA-Z0-9./_-]*$");
 
+    define_regex_validator!(validators, "environment_name", r"^[a-zA-Z][a-zA-Z0-9./_-]*$");
+    define_regex_validator!(validators, "secret_name", r"^[A-Z][A-Z0-9_]*$");
+
     validators
 }
 
@@ -74,3 +77,5 @@ create_regex_validator_func!(team_slug);
 create_regex_validator_func!(commit_hash);
 create_regex_validator_func!(pint);
 create_regex_validator_func!(branch_name);
+create_regex_validator_func!(environment_name);
+create_regex_validator_func!(secret_name);

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -229,6 +229,8 @@ impl_new_function!(github, remove_user_from_repo);
 impl_new_function!(github, add_user_to_team);
 impl_new_function!(github, remove_user_from_team);
 impl_new_function!(github, update_branch_protection_rule);
+impl_new_function!(github, create_environment_for_repo);
+impl_new_function!(github, configure_environment_secret);
 
 impl_new_function_with_error_buffer!(github, make_graphql_query);
 impl_new_function_with_error_buffer!(github, make_advanced_graphql_query);
@@ -439,6 +441,13 @@ pub fn to_api_function(
         "github_update_branch_protection_rule" => {
             Function::new_typed_with_env(&mut store, &env, github_update_branch_protection_rule)
         }
+        "github_create_environment_for_repo" => {
+            Function::new_typed_with_env(&mut store, &env, github_create_environment_for_repo)
+        }
+        "github_configure_environment_secret" => {
+            Function::new_typed_with_env(&mut store, &env, github_configure_environment_secret)
+        }
+
         // Slack Calls
         "slack_post_to_named_webhook" => {
             Function::new_typed_with_env(&mut store, &env, slack_post_to_named_webhook)

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -230,7 +230,8 @@ impl_new_function!(github, add_user_to_team);
 impl_new_function!(github, remove_user_from_team);
 impl_new_function!(github, update_branch_protection_rule);
 impl_new_function!(github, create_environment_for_repo);
-impl_new_function!(github, configure_environment_secret);
+impl_new_function!(github, configure_secret);
+impl_new_function!(github, create_deployment_branch_protection_rule);
 
 impl_new_function_with_error_buffer!(github, make_graphql_query);
 impl_new_function_with_error_buffer!(github, make_advanced_graphql_query);
@@ -444,8 +445,11 @@ pub fn to_api_function(
         "github_create_environment_for_repo" => {
             Function::new_typed_with_env(&mut store, &env, github_create_environment_for_repo)
         }
-        "github_configure_environment_secret" => {
-            Function::new_typed_with_env(&mut store, &env, github_configure_environment_secret)
+        "github_configure_secret" => {
+            Function::new_typed_with_env(&mut store, &env, github_configure_secret)
+        }
+        "github_create_deployment_branch_protection_rule" => {
+            Function::new_typed_with_env(&mut store, &env, github_create_deployment_branch_protection_rule)
         }
 
         // Slack Calls


### PR DESCRIPTION
### Added functionality
We expose STL methods to
* Create a GH environment for a given repository, setting up a deployment protection rule that targets a given branch
* Configure a secret on a GH environment. The secret is passed in plaintext and encrypted in the plaid runtime before being sent to GitHub's API

### Breaking changes
None
