### PR TITLE
Fix SSL On Linux; Cut Next Major Version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,7 +1644,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1669,6 +1669,12 @@ dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "headers"
@@ -2008,12 +2014,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -2551,6 +2557,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.3.2+3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,6 +2573,7 @@ checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2741,7 +2757,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plaid"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "alkali",
  "async-trait",
@@ -2783,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "paste",
@@ -4139,9 +4155,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -4512,7 +4528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
  "bitflags 2.6.0",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "semver",
 ]
 
@@ -4871,7 +4887,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "memchr",
  "thiserror",
  "zopfli",

--- a/plaid-stl/Cargo.toml
+++ b/plaid-stl/Cargo.toml
@@ -1,8 +1,6 @@
-#
-
 [package]
 name = "plaid_stl"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 #
 

--- a/plaid/Cargo.toml
+++ b/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plaid/Cargo.toml
+++ b/plaid/Cargo.toml
@@ -47,7 +47,7 @@ warp = { version = "0.3", features = ["tls"] }
 wasmer = { version = "4", default-features = false, features = ["cranelift"] }
 wasmer-middlewares = "4"
 jsonwebtoken = { version = "9.2" }
-tokio-tungstenite = { version = "0.23.1", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.23.1", features = ["native-tls-vendored"] }
 futures-util = "0.3.30"
 aws-sdk-kms = { version = "1.41.0", optional = true }
 aws-config = { version = "1.5.5", optional = true }

--- a/plaid/resources/Cargo.toml
+++ b/plaid/resources/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,11 +11,14 @@ quorum = ["quorum-agent"]
 aws = ["aws-sdk-kms", "aws-config"]
 
 [dependencies]
-clap = { version = "4", default-features = false, features = ["std"] }
+alkali = "0.3.0"
 async-trait = "0.1.56"
 base64 = "0.13"
+clap = { version = "4", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5"
 env_logger = "0.8"
+flate2 = "1.0"
+hex = "0.4.3"
 http = "1"
 jwt-simple = "0.12.10"
 log = "0.4"
@@ -29,13 +32,17 @@ ring = "0.17"
 reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",
     "json",
+    "cookies",
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 sled = "0.34.7"
+tar = "0.4.41"
 time = "0.3"
 tokio = { version = "1", features = ["full"] }
 toml = "0.5"
+totp-rs = "5.6.0"
+url = "2.5.2"
 warp = { version = "0.3", features = ["tls"] }
 wasmer = { version = "4", default-features = false, features = ["cranelift"] }
 wasmer-middlewares = "4"

--- a/plaid/resources/Cargo.toml
+++ b/plaid/resources/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "plaid"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["aws"]
 quorum = ["quorum-agent"]
+aws = ["aws-sdk-kms", "aws-config"]
 
 [dependencies]
 clap = { version = "4", default-features = false, features = ["std"] }
@@ -16,6 +17,7 @@ base64 = "0.13"
 crossbeam-channel = "0.5"
 env_logger = "0.8"
 http = "1"
+jwt-simple = "0.12.10"
 log = "0.4"
 lru = "0.12"
 octocrab = "0.37"
@@ -38,6 +40,10 @@ warp = { version = "0.3", features = ["tls"] }
 wasmer = { version = "4", default-features = false, features = ["cranelift"] }
 wasmer-middlewares = "4"
 jsonwebtoken = { version = "9.2" }
+tokio-tungstenite = { version = "0.23.1", features = ["native-tls-vendored"] }
+futures-util = "0.3.30"
+aws-sdk-kms = { version = "1.41.0", optional = true }
+aws-config = { version = "1.5.5", optional = true }
 
 # Uncomment to build with Quorum. This is needed
 # because otherwise cargo will try and find this
@@ -47,3 +53,11 @@ quorum-agent = { path = "../../quorum/quorum-agent", default_features = false, o
 [[example]]
 name = "github-tailer"
 path = "examples/tailers/github.rs"
+
+[[bin]]
+name = "plaid"
+path = "src/bin/plaid.rs"
+
+[[bin]]
+name = "config_check"
+path = "src/bin/config_check.rs"


### PR DESCRIPTION
Mostly this just fixes the build for Linux containers where SSL couldn't be found when linking (because it wasn't there) but it also officially sets the version to 13 now that NPM and new GitHub APIs have been merged.