### PR TITLE
[npm] Support creating tokens for multiple packages at once

### DIFF
--- a/plaid-stl/src/npm/shared_structs/mod.rs
+++ b/plaid-stl/src/npm/shared_structs/mod.rs
@@ -194,8 +194,8 @@ pub struct SetTeamPermissionOnPackageParams {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct CreateGranularTokenForPackageParams {
-    pub package: String,
+pub struct CreateGranularTokenForPackagesParams {
+    pub packages: Vec<String>,
     pub specs: GranularTokenSpecs,
 }
 
@@ -232,6 +232,7 @@ impl Display for PkgAccessLevel {
 pub struct PublishEmptyStubParams {
     pub package_name: String,
     pub access_level: PkgAccessLevel,
+    pub repo_name: String,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/plaid/src/apis/npm/validators.rs
+++ b/plaid/src/apis/npm/validators.rs
@@ -74,6 +74,8 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
         r#"dsrManifestHash\"\s+?value=\"([a-z0-9]{64})\""#
     );
 
+    define_regex_validator!(validators, "repository_name", r"^[\w\-\./]+$");
+
     validators
 }
 
@@ -85,6 +87,7 @@ create_regex_validator_func!(npm_org_name);
 create_regex_validator_func!(npm_at_org_name);
 create_regex_validator_func!(npm_scoped_package);
 create_regex_validator_func!(npm_token_name);
+create_regex_validator_func!(repository_name);
 
 impl Npm {
     /// Look for a valid `dsrManifestHash` in an HTML page and extract it

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -255,7 +255,7 @@ impl_new_sub_module_function_with_error_buffer!(aws, kms, get_public_key);
 // Npm Functions
 impl_new_function!(npm, publish_empty_stub);
 impl_new_function!(npm, set_team_permission_on_package);
-impl_new_function_with_error_buffer!(npm, create_granular_token_for_package);
+impl_new_function_with_error_buffer!(npm, create_granular_token_for_packages);
 impl_new_function_with_error_buffer!(npm, list_granular_tokens);
 impl_new_function!(npm, delete_package);
 impl_new_function!(npm, add_user_to_team);
@@ -350,8 +350,8 @@ pub fn to_api_function(
             Function::new_typed_with_env(&mut store, &env, npm_set_team_permission_on_package)
         }
 
-        "npm_create_granular_token_for_package" => {
-            Function::new_typed_with_env(&mut store, &env, npm_create_granular_token_for_package)
+        "npm_create_granular_token_for_packages" => {
+            Function::new_typed_with_env(&mut store, &env, npm_create_granular_token_for_packages)
         }
 
         "npm_list_granular_tokens" => {


### PR DESCRIPTION
Instead of taking a single package name, take a vector of package names. They are all validated and used to define the scope of the token.

Also allow callers to specify the GH repo linked to the package, instead of assuming it is the same as package_name.