### PR TITLE
Add npm APIs for retrieving details about / deleting / renewing a granular token

### DIFF
--- a/plaid-stl/src/npm/mod.rs
+++ b/plaid-stl/src/npm/mod.rs
@@ -484,4 +484,13 @@ impl NpmToken {
         serde_json::from_str::<GranularTokenDetails>(&res)
             .map_err(|_| PlaidFunctionError::InternalApiError)
     }
+
+    /// Renew this token, keeping the same publish scope
+    pub fn renew(&self) -> Result<String, PlaidFunctionError> {
+        renew_granular_token(
+            self.token_name
+                .as_ref()
+                .ok_or(PlaidFunctionError::InternalApiError)?,
+        )
+    }
 }

--- a/plaid-stl/src/npm/shared_structs/mod.rs
+++ b/plaid-stl/src/npm/shared_structs/mod.rs
@@ -244,6 +244,21 @@ pub struct ListPackagesWithTeamPermissionParams {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct GetTokenPublishScopeParams {
+pub struct GetTokenDetailsParams {
     pub token_id: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct GranularTokenDetails {
+    #[serde(rename = "packagesAndScopesPermission")]
+    pub packages_and_scopes_permission: String,
+    #[serde(rename = "selectedPackagesAndScopes")]
+    pub selected_packages_and_scopes: String,
+    #[serde(rename = "selectedPackages")]
+    pub selected_packages: Vec<String>,
+    expired: bool,
+    #[serde(rename = "selectedScopes")]
+    pub selected_scopes: Vec<String>,
+    #[serde(rename = "selectedOrgs")]
+    pub selected_orgs: Vec<String>,
 }

--- a/plaid-stl/src/npm/shared_structs/mod.rs
+++ b/plaid-stl/src/npm/shared_structs/mod.rs
@@ -202,6 +202,11 @@ pub struct CreateGranularTokenForPackagesParams {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct DeleteTokenParams {
+    pub token_id: String
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct AddRemoveUserToFromTeamParams {
     pub user: String,
     pub team: String,
@@ -250,8 +255,12 @@ pub struct GetTokenDetailsParams {
 
 #[derive(Serialize, Deserialize)]
 pub struct GranularTokenDetails {
+    #[serde(rename = "tokenName")]
+    pub token_name: Option<String>,
+    #[serde(rename = "tokenID")]
+    pub token_id: Option<String>,
     #[serde(rename = "tokenDescription")]
-    pub token_description: String,
+    pub token_description: Option<String>,
     #[serde(rename = "packagesAndScopesPermission")]
     pub packages_and_scopes_permission: String,
     #[serde(rename = "selectedPackagesAndScopes")]

--- a/plaid-stl/src/npm/shared_structs/mod.rs
+++ b/plaid-stl/src/npm/shared_structs/mod.rs
@@ -160,8 +160,10 @@ impl GranularTokenSpecs {
 
 /// An npm token configured on the npm website for the current user
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[allow(dead_code)]
 pub struct NpmToken {
+    /// ID assigned by npm to the token.
+    /// Note: only granular tokens have this.
+    pub id: Option<String>,
     pub token: String,
     pub token_name: Option<String>,
     pub token_type: Option<String>,
@@ -239,4 +241,9 @@ pub struct PublishEmptyStubParams {
 pub struct ListPackagesWithTeamPermissionParams {
     pub team: String,
     pub permission: NpmPackagePermission,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct GetTokenPublishScopeParams {
+    pub token_id: String,
 }

--- a/plaid-stl/src/npm/shared_structs/mod.rs
+++ b/plaid-stl/src/npm/shared_structs/mod.rs
@@ -250,6 +250,8 @@ pub struct GetTokenDetailsParams {
 
 #[derive(Serialize, Deserialize)]
 pub struct GranularTokenDetails {
+    #[serde(rename = "tokenDescription")]
+    pub token_description: String,
     #[serde(rename = "packagesAndScopesPermission")]
     pub packages_and_scopes_permission: String,
     #[serde(rename = "selectedPackagesAndScopes")]

--- a/plaid/src/apis/npm/mod.rs
+++ b/plaid/src/apis/npm/mod.rs
@@ -122,4 +122,5 @@ pub enum NpmError {
     FailedToGetCsrfTokenFromCookies,
     FailedToRetrievePaginatedData,
     FailedToRetrievePackages,
+    FailedToGetTokenPublishScope,
 }

--- a/plaid/src/apis/npm/mod.rs
+++ b/plaid/src/apis/npm/mod.rs
@@ -109,6 +109,7 @@ pub enum NpmError {
     LoginFlowError,
     WrongClientStatus,
     TokenGenerationError,
+    TokenDeletionError,
     WrongConfig(String),
     FailedToListGranularTokens,
     FailedToDeletePackage,

--- a/plaid/src/apis/npm/mod.rs
+++ b/plaid/src/apis/npm/mod.rs
@@ -122,5 +122,5 @@ pub enum NpmError {
     FailedToGetCsrfTokenFromCookies,
     FailedToRetrievePaginatedData,
     FailedToRetrievePackages,
-    FailedToGetTokenPublishScope,
+    FailedToGetTokenDetails,
 }

--- a/plaid/src/apis/npm/npm_web_client.rs
+++ b/plaid/src/apis/npm/npm_web_client.rs
@@ -1,5 +1,5 @@
 use reqwest::cookie::CookieStore;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use totp_rs::{Algorithm, Secret, TOTP};
@@ -9,8 +9,10 @@ use crate::apis::ApiError;
 
 use plaid_stl::npm::shared_structs::{
     AddRemoveUserToFromTeamParams, CreateGranularTokenForPackagesParams,
-    InviteUserToOrganizationParams, ListPackagesWithTeamPermissionParams, NpmPackagePermission,
-    NpmToken, NpmUser, NpmUserRole, SetTeamPermissionOnPackageParams,
+    GetTokenPublishScopeParams, GranularTokenPackagesAndScopesPermission,
+    GranularTokenSelectedPackagesAndScopes, InviteUserToOrganizationParams,
+    ListPackagesWithTeamPermissionParams, NpmPackagePermission, NpmToken, NpmUser, NpmUserRole,
+    SetTeamPermissionOnPackageParams,
 };
 
 use super::{Npm, NpmError};
@@ -67,6 +69,21 @@ struct AddUserToTeamPayload<'a> {
 #[derive(Serialize)]
 struct RemoveUserPayload<'a> {
     csrftoken: &'a str,
+}
+
+#[derive(Deserialize)]
+struct GranularTokenDetails {
+    #[serde(rename = "packagesAndScopesPermission")]
+    packages_and_scopes_permission: String,
+    #[serde(rename = "selectedPackagesAndScopes")]
+    selected_packages_and_scopes: String,
+    #[serde(rename = "selectedPackages")]
+    selected_packages: Vec<String>,
+    expired: bool,
+    #[serde(rename = "selectedScopes")]
+    selected_scopes: Vec<String>,
+    #[serde(rename = "selectedOrgs")]
+    selected_orgs: Vec<String>,
 }
 
 impl Npm {
@@ -760,6 +777,69 @@ impl Npm {
             // There are more items
             page_num += 1;
         }
+    }
+
+    /// Return a JSON-encoded list of packages that a granular token can publish
+    pub async fn get_token_publish_scope(
+        &self,
+        params: &str,
+        module: &str,
+    ) -> Result<String, ApiError> {
+        let params: GetTokenPublishScopeParams =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        let token_id = self.validate_token_id(&params.token_id)?;
+
+        info!("Retrieving publish scope for token [{token_id}] on behalf of [{module}]");
+
+        self.login()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::LoginFlowError))?;
+        let response = self
+            .client
+            .get(format!(
+                "{}/settings/{}/tokens/granular-access-tokens/{}",
+                NPMJS_COM_URL, self.config.username, token_id
+            ))
+            .header("X-Spiferack", "1") // to get JSON instead of HTML
+            .send()
+            .await
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToGetTokenPublishScope))?;
+
+        // Information on the token is returned in an object under "tokenDetails"
+        let token_details = serde_json::from_value::<GranularTokenDetails>(
+            response
+                .json::<Value>()
+                .await
+                .map_err(|_| ApiError::NpmError(NpmError::FailedToGetTokenPublishScope))?
+                .get("tokenDetails")
+                .ok_or(ApiError::NpmError(NpmError::FailedToGetTokenPublishScope))?
+                .clone(),
+        )
+        .map_err(|_| ApiError::NpmError(NpmError::FailedToGetTokenPublishScope))?;
+
+        // Check a few things about the token before returning its publish scope
+
+        if token_details.expired
+            || token_details.packages_and_scopes_permission
+                != GranularTokenPackagesAndScopesPermission::ReadAndWrite.to_string()
+        {
+            // The token cannot publish
+            return Ok("[]".to_string());
+        }
+        if token_details.selected_packages_and_scopes
+            != GranularTokenSelectedPackagesAndScopes::PackagesAndScopesSome.to_string()
+        {
+            // This should not happen
+            return Err(ApiError::NpmError(NpmError::FailedToGetTokenPublishScope));
+        }
+        if !token_details.selected_scopes.is_empty() || !token_details.selected_orgs.is_empty() {
+            // This token has a list of scopes or organizations. Currently, we support only tokens
+            // without scopes and organizations, that simply have a list of selected packages
+            return Err(ApiError::NpmError(NpmError::FailedToGetTokenPublishScope));
+        }
+
+        serde_json::to_string(&token_details.selected_packages)
+            .map_err(|_| ApiError::NpmError(NpmError::FailedToGetTokenPublishScope))
     }
 }
 

--- a/plaid/src/apis/npm/validators.rs
+++ b/plaid/src/apis/npm/validators.rs
@@ -75,6 +75,9 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
     );
 
     define_regex_validator!(validators, "repository_name", r"^[\w\-\./]+$");
+    
+    // The token ID is actually a UUID
+    define_regex_validator!(validators, "token_id", r"^[a-f0-9-]{36}$");
 
     validators
 }
@@ -88,6 +91,7 @@ create_regex_validator_func!(npm_at_org_name);
 create_regex_validator_func!(npm_scoped_package);
 create_regex_validator_func!(npm_token_name);
 create_regex_validator_func!(repository_name);
+create_regex_validator_func!(token_id);
 
 impl Npm {
     /// Look for a valid `dsrManifestHash` in an HTML page and extract it

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -256,6 +256,7 @@ impl_new_sub_module_function_with_error_buffer!(aws, kms, get_public_key);
 impl_new_function!(npm, publish_empty_stub);
 impl_new_function!(npm, set_team_permission_on_package);
 impl_new_function_with_error_buffer!(npm, create_granular_token_for_packages);
+impl_new_function!(npm, delete_granular_token);
 impl_new_function_with_error_buffer!(npm, list_granular_tokens);
 impl_new_function!(npm, delete_package);
 impl_new_function!(npm, add_user_to_team);
@@ -353,6 +354,10 @@ pub fn to_api_function(
 
         "npm_create_granular_token_for_packages" => {
             Function::new_typed_with_env(&mut store, &env, npm_create_granular_token_for_packages)
+        }
+
+        "npm_delete_granular_token" => {
+            Function::new_typed_with_env(&mut store, &env, npm_delete_granular_token)
         }
 
         "npm_list_granular_tokens" => {

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -265,6 +265,7 @@ impl_new_function!(npm, invite_user_to_organization);
 impl_new_function_with_error_buffer!(npm, get_org_user_list);
 impl_new_function_with_error_buffer!(npm, get_org_users_without_2fa);
 impl_new_function_with_error_buffer!(npm, list_packages_with_team_permission);
+impl_new_function_with_error_buffer!(npm, get_token_publish_scope);
 
 // Okta Functions
 impl_new_function!(okta, remove_user_from_group);
@@ -388,6 +389,10 @@ pub fn to_api_function(
 
         "npm_list_packages_with_team_permission" => {
             Function::new_typed_with_env(&mut store, &env, npm_list_packages_with_team_permission)
+        }
+
+        "npm_get_token_publish_scope" => {
+            Function::new_typed_with_env(&mut store, &env, npm_get_token_publish_scope)
         }
         
         // Okta Calls

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -265,7 +265,7 @@ impl_new_function!(npm, invite_user_to_organization);
 impl_new_function_with_error_buffer!(npm, get_org_user_list);
 impl_new_function_with_error_buffer!(npm, get_org_users_without_2fa);
 impl_new_function_with_error_buffer!(npm, list_packages_with_team_permission);
-impl_new_function_with_error_buffer!(npm, get_token_publish_scope);
+impl_new_function_with_error_buffer!(npm, get_token_details);
 
 // Okta Functions
 impl_new_function!(okta, remove_user_from_group);
@@ -391,8 +391,8 @@ pub fn to_api_function(
             Function::new_typed_with_env(&mut store, &env, npm_list_packages_with_team_permission)
         }
 
-        "npm_get_token_publish_scope" => {
-            Function::new_typed_with_env(&mut store, &env, npm_get_token_publish_scope)
+        "npm_get_token_details" => {
+            Function::new_typed_with_env(&mut store, &env, npm_get_token_details)
         }
         
         // Okta Calls


### PR DESCRIPTION
This PR adds
* An API to retrieve some details about an npm granular token (including the packages it can publish). Further processing is left to the calling rule.
* An API to delete npm granular tokens
* An API to renew an npm granular token "in place", i.e., overwrite it with a token that has the same name and same publish scope