### PR TITLE
Add mechanism to process modules non concurrently

### DIFF
--- a/plaid/src/bin/plaid.rs
+++ b/plaid/src/bin/plaid.rs
@@ -72,11 +72,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // requests for handling some configured get requests.
     let executor = Executor::new(
         log_receiver,
+        log_sender.clone(),
         modules.get_channels(),
         api,
         storage,
         config.execution_threads,
-        els.clone(),
+        els.clone()
     );
 
     let executor = Arc::new(executor);

--- a/plaid/src/bin/plaid.rs
+++ b/plaid/src/bin/plaid.rs
@@ -72,7 +72,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // requests for handling some configured get requests.
     let executor = Executor::new(
         log_receiver,
-        log_sender.clone(),
         modules.get_channels(),
         api,
         storage,

--- a/plaid/src/executor/mod.rs
+++ b/plaid/src/executor/mod.rs
@@ -412,6 +412,11 @@ fn execution_loop(
                 Err(e) => Some(determine_error(e, computation_limit, &instance, &mut store)),
             };
 
+            // Mark the rule as complete
+            if let Some((_, is_locked)) = &plaid_module.concurrency_unsafe {
+                is_locked.store(false, Ordering::SeqCst);
+            }
+
             // If there was an error then log that it happened to the els
             if let Some(error) = error {
                 els.log_module_error(
@@ -426,11 +431,6 @@ fn execution_loop(
 
             // Update the persistent response
             update_persistent_response(&plaid_module, &env, &mut store)?;
-
-            // Mark the rule as complete
-            if let Some((_, is_locked)) = &plaid_module.concurrency_unsafe {
-                is_locked.store(false, Ordering::SeqCst);
-            }
         }
     }
     Err(ExecutorError::IncomingLogError)

--- a/plaid/src/executor/mod.rs
+++ b/plaid/src/executor/mod.rs
@@ -426,6 +426,11 @@ fn execution_loop(
 
             // Update the persistent response
             update_persistent_response(&plaid_module, &env, &mut store)?;
+
+            // Mark the rule as complete
+            if let Some((_, is_locked)) = &plaid_module.concurrency_unsafe {
+                is_locked.store(false, Ordering::SeqCst);
+            }
         }
     }
     Err(ExecutorError::IncomingLogError)

--- a/plaid/src/executor/mod.rs
+++ b/plaid/src/executor/mod.rs
@@ -319,7 +319,7 @@ fn execution_loop(
         };
 
         // If ANY of the modules that operate on this log type cannot be executed in parallel, we need to check
-        // the rules in flight list to see if a rule is already being executed.
+        // to see if any of them are currently being executed
         if execution_modules.iter().any(|module| module.is_locked()) {
             // If this rule is currently being processed, send the message back into the execution queue
             // This allows us to guarantee that the rule will only be executed on 1 thread at any given time

--- a/plaid/src/loader/mod.rs
+++ b/plaid/src/loader/mod.rs
@@ -118,15 +118,6 @@ impl PlaidModule {
             .flatten()
     }
 
-    /// Method to check if the module is currently locked
-    pub fn is_locked(&self) -> bool {
-        if let Some(mutex) = &self.concurrency_unsafe {
-            // Return true if try_lock fails (meaning the mutex is locked), otherwise false
-            return mutex.try_lock().is_err();
-        }
-        false
-    }
-
     /// Configure and compiles a Plaid module with specified computation limits and memory page count.
     ///
     /// This function sets up the computation metering, configures the module tunables, and

--- a/plaid/src/loader/mod.rs
+++ b/plaid/src/loader/mod.rs
@@ -31,7 +31,7 @@ pub struct LimitAmount {
 pub struct Configuration {
     /// Where to load modules from
     pub module_dir: String,
-    /// A list of rules that **cannot** be executed in parallel. We assume that rules can be executed
+    /// A list of case-insensitive rule names that **cannot** be executed in parallel. We assume that rules can be executed
     /// in parallel unless otherwise noted. Rules that cannot execute in parallel wait until the
     /// executor is finished processing a rule before beginning their own execution.
     pub single_threaded_rules: Option<Vec<String>>,
@@ -253,7 +253,10 @@ pub fn load(config: Configuration) -> Result<PlaidModules, ()> {
 
         // Check if this rule can be executed in parallel
         let concurrency_safe = config.single_threaded_rules.as_ref().map_or(None, |rules| {
-            if rules.contains(&filename) {
+            if rules
+                .iter()
+                .any(|rule| rule.eq_ignore_ascii_case(&filename))
+            {
                 Some((Mutex::new(()), AtomicBool::new(false)))
             } else {
                 None

--- a/plaid/src/loader/mod.rs
+++ b/plaid/src/loader/mod.rs
@@ -171,7 +171,7 @@ impl PlaidModule {
         })?;
         module.set_name(&filename);
 
-        info!("Name: [{filename}] Computation Limit: [{computation_limit}] Memory Limit: [{page_limit} pages] Log Type: [{log_type}]. Parallel Execution Enabled: [{}]", concurrency_unsafe.is_some());
+        info!("Name: [{filename}] Computation Limit: [{computation_limit}] Memory Limit: [{page_limit} pages] Log Type: [{log_type}]. Concurrency Safe: [{}]", concurrency_unsafe.is_none());
         for import in module.imports() {
             info!("\tImport: {}", import.name());
         }

--- a/plaid/src/loader/mod.rs
+++ b/plaid/src/loader/mod.rs
@@ -152,7 +152,7 @@ impl PlaidModule {
         })?;
         module.set_name(&filename);
 
-        info!("Name: [{filename}] Computation Limit: [{computation_limit}] Memory Limit: [{page_limit} pages] Log Type: [{log_type}]");
+        info!("Name: [{filename}] Computation Limit: [{computation_limit}] Memory Limit: [{page_limit} pages] Log Type: [{log_type}]. Parallel Execution Enabled: [{parallel_execution_enabled}]");
         for import in module.imports() {
             info!("\tImport: {}", import.name());
         }
@@ -236,7 +236,7 @@ pub fn load(config: Configuration) -> Result<PlaidModules, ()> {
         let parallel_execution_enabled = config
             .single_threaded_rules
             .as_ref()
-            .map_or(true, |rules| rules.contains(&filename));
+            .map_or(true, |rules| !rules.contains(&filename));
 
         // Configure and compile module
         let Ok(mut plaid_module) = PlaidModule::configure_and_compile(


### PR DESCRIPTION
 This PR adds a mechanism to mark rules that cannot be processed in parallel. In the configuration we can define single threaded rules like so:
```toml
[loading]
single_threaded_rules = ["testing_test.wasm"]
```

When one of these rules is seen in the execution loop, we check a list of "in flight" rules to see if it's already being processed. If it is, the message is sent back into the log queue for processing. If it's not, we add the rule name to the list of in flight rules and continue with execution. When execution is finished, we remove the rule from the in flight list.