### PR TITLE
Cut 13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2757,7 +2757,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plaid"
-version = "0.13.0"
+version = "0.13.2"
 dependencies = [
  "alkali",
  "async-trait",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.13.0"
+version = "0.13.2"
 dependencies = [
  "chrono",
  "paste",

--- a/plaid-stl/Cargo.toml
+++ b/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.13.0"
+version = "0.13.2"
 edition = "2021"
 #
 

--- a/plaid/Cargo.toml
+++ b/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.13.0"
+version = "0.13.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plaid/resources/Cargo.toml
+++ b/plaid/resources/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.13.0"
+version = "0.13.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Cuts version 13.2.

Notably this adds the ability to mark modules as non-concurrent. When a module is configured as such it is guaranteed to only run one instance of the module at once. This is useful if you need to ensure the LRU or database does not change out from under you (due to other running instances of your rule) for the duration of the run.

This does come with performance penalties so should only be used if there are no other options to make your module run safely.