### PR TITLE
Add Github API to manage Copilot membership

### DIFF
--- a/plaid-stl/src/github/mod.rs
+++ b/plaid-stl/src/github/mod.rs
@@ -277,7 +277,7 @@ pub fn list_copilot_subscription_seats_by_page(
     page: Option<u64>,
 ) -> Result<Vec<CopilotSeat>, PlaidFunctionError> {
     extern "C" {
-        new_host_function_with_error_buffer!(github, list_copilot_subscription_seats_by_page);
+        new_host_function_with_error_buffer!(github, list_seats_in_org_copilot);
     }
 
     let mut params: HashMap<&'static str, String> = HashMap::new();
@@ -295,7 +295,7 @@ pub fn list_copilot_subscription_seats_by_page(
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
     let res = unsafe {
-        github_list_copilot_subscription_seats_by_page(
+        github_list_seats_in_org_copilot(
             request.as_bytes().as_ptr(),
             request.as_bytes().len(),
             return_buffer.as_mut_ptr(),
@@ -324,7 +324,7 @@ pub fn list_copilot_subscription_seats_by_page(
 /// * `org` - The org owning the subscription
 pub fn list_all_copilot_subscription_seats(org: &str) -> Result<Vec<CopilotSeat>, PlaidFunctionError> {
     extern "C" {
-        new_host_function_with_error_buffer!(github, list_all_copilot_subscription_seats);
+        new_host_function_with_error_buffer!(github, list_seats_in_org_copilot);
     }
 
     let mut params: HashMap<&'static str, String> = HashMap::new();
@@ -344,7 +344,7 @@ pub fn list_all_copilot_subscription_seats(org: &str) -> Result<Vec<CopilotSeat>
         let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
         let res = unsafe {
-            github_list_all_copilot_subscription_seats(
+            github_list_seats_in_org_copilot(
                 request.as_bytes().as_ptr(),
                 request.as_bytes().len(),
                 return_buffer.as_mut_ptr(),

--- a/plaid-stl/src/github/mod.rs
+++ b/plaid-stl/src/github/mod.rs
@@ -391,7 +391,7 @@ pub fn add_user_to_copilot_subscription(org: &str, user: &str) -> Result<(), Pla
     Ok(())
 }
 
-/// Remove a user to the org's Copilot subscription
+/// Remove a user from the org's Copilot subscription
 /// ## Arguments
 ///
 /// * `org` - The org owning the subscription

--- a/plaid-stl/src/github/mod.rs
+++ b/plaid-stl/src/github/mod.rs
@@ -33,8 +33,9 @@ pub struct RepositoryCollaborator {
 
 #[derive(Debug, Deserialize)]
 /// A person assigned to a seat in a Github Org Copilot subscription
-pub struct CopilotAsignee {
+pub struct CopilotAssignee {
     pub login: String,
+    // type of assignee, such as "User"
     #[serde(rename = "type")]
     pub type_: String,
 }
@@ -42,7 +43,7 @@ pub struct CopilotAsignee {
 #[derive(Debug, Deserialize)]
 /// A seat in a Github Org Copilot subscription
 pub struct CopilotSeat {
-    pub assignee: CopilotAsignee,
+    pub assignee: CopilotAssignee,
     pub last_activity_at: Option<String>,
     pub plan_type: String,
 }

--- a/plaid-stl/src/github/mod.rs
+++ b/plaid-stl/src/github/mod.rs
@@ -384,18 +384,21 @@ pub fn list_all_copilot_subscription_seats(org: &str) -> Result<Vec<CopilotSeat>
 /// * `user` - The user to add to Copilot subscription
 pub fn add_user_to_copilot_subscription(org: &str, user: &str) -> Result<(), PlaidFunctionError> {
     extern "C" {
-        new_host_function!(github, add_user_to_copilot_subscription);
+        new_host_function!(github, add_users_to_org_copilot);
     }
-
-    let mut params: HashMap<&'static str, &str> = HashMap::new();
-    params.insert("org", org);
-    let selected_users: Vec<String> = vec![user.to_owned()];
-    let selected_users = serde_json::to_string(&selected_users).unwrap();
-    params.insert("selected_usernames", &selected_users);
+    #[derive(Serialize)]
+    struct Params<'a> {
+        org: &'a str,
+        selected_usernames: Vec<&'a str>,
+    }
+    let params = Params {
+        org,
+        selected_usernames: vec![user],
+    };
 
     let params = serde_json::to_string(&params).unwrap();
     let res = unsafe {
-        github_add_user_to_copilot_subscription(params.as_bytes().as_ptr(), params.as_bytes().len())
+        github_add_users_to_org_copilot(params.as_bytes().as_ptr(), params.as_bytes().len())
     };
 
     // There was an error with the Plaid system. Maybe the API is not
@@ -414,18 +417,22 @@ pub fn add_user_to_copilot_subscription(org: &str, user: &str) -> Result<(), Pla
 /// * `user` - The user to remove from Copilot subscription
 pub fn remove_user_from_copilot_subscription(org: &str, user: &str) -> Result<(), PlaidFunctionError> {
     extern "C" {
-        new_host_function!(github, remove_user_from_copilot_subscription);
+        new_host_function!(github, remove_users_from_org_copilot);
     }
 
-    let mut params: HashMap<&'static str, &str> = HashMap::new();
-    params.insert("org", org);
-    let selected_users: Vec<String> = vec![user.to_owned()];
-    let selected_users = serde_json::to_string(&selected_users).unwrap();
-    params.insert("selected_usernames", &selected_users);
+    #[derive(Serialize)]
+    struct Params<'a> {
+        org: &'a str,
+        selected_usernames: Vec<&'a str>,
+    }
+    let params = Params {
+        org,
+        selected_usernames: vec![user],
+    };
 
     let params = serde_json::to_string(&params).unwrap();
     let res = unsafe {
-        github_remove_user_from_copilot_subscription(params.as_bytes().as_ptr(), params.as_bytes().len())
+        github_remove_users_from_org_copilot(params.as_bytes().as_ptr(), params.as_bytes().len())
     };
 
     // There was an error with the Plaid system. Maybe the API is not

--- a/plaid/src/apis/github/copilot.rs
+++ b/plaid/src/apis/github/copilot.rs
@@ -13,9 +13,9 @@ impl Github {
 
         let organization = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
 
-        info!("List all seats in Copilot subscription for org {organization}");
+        info!("List seats in Copilot subscription for org {organization}");
 
-        let address = format!("/org/{organization}/copilot/billing/seats");
+        let address = format!("/orgs/{organization}/copilot/billing/seats");
 
         match self.make_generic_get_request(address, &module).await {
             Ok((status, Ok(body))) => {
@@ -50,7 +50,7 @@ impl Github {
 
         info!("Adding users {:?} to Copilot subscription for org {organization} as module {module}", request.selected_usernames);
 
-        let address = format!("/org/{organization}/copilot/billing/selected_users");
+        let address = format!("/orgs/{organization}/copilot/billing/selected_users");
 
         match self.make_generic_post_request(address, &request, &module).await {
             Ok((status, Ok(_))) => {
@@ -85,7 +85,7 @@ impl Github {
 
         info!("Remove users {:?} from Copilot subscription for org {organization}", request.selected_usernames);
 
-        let address = format!("/org/{organization}/copilot/billing/selected_users");
+        let address = format!("/orgs/{organization}/copilot/billing/selected_users");
 
         match self.make_generic_delete_request(address, Some(&request), &module).await {
             Ok((status, Ok(_))) => {

--- a/plaid/src/apis/github/copilot.rs
+++ b/plaid/src/apis/github/copilot.rs
@@ -41,6 +41,7 @@ impl Github {
     pub async fn add_users_to_org_copilot(&self, params: &str, module: &str) -> Result<u32, ApiError> {
         #[derive(Deserialize, Serialize)]
         struct Request {
+            #[serde(skip_serializing)]
             org: String,
             selected_usernames: Vec<String>,
         }
@@ -76,6 +77,7 @@ impl Github {
     pub async fn remove_users_from_org_copilot(&self, params: &str, module: &str) -> Result<u32, ApiError> {
         #[derive(Deserialize, Serialize)]
         struct Request {
+            #[serde(skip_serializing)]
             org: String,
             selected_usernames: Vec<String>,
         }

--- a/plaid/src/apis/github/copilot.rs
+++ b/plaid/src/apis/github/copilot.rs
@@ -44,11 +44,11 @@ impl Github {
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         let organization = self.validate_org(&request.org)?;
-        for username in request.selected_usernames.iter() {
+        for username in &request.selected_usernames {
             self.validate_username(&username)?;
         }
 
-        info!("Adding users {:?} to Copilot subscription for org {organization}", request.selected_usernames);
+        info!("Adding users {:?} to Copilot subscription for org {organization} as module {module}", request.selected_usernames);
 
         let address = format!("/org/{organization}/copilot/billing/selected_users");
 
@@ -83,7 +83,7 @@ impl Github {
             self.validate_username(&username)?;
         }
 
-        info!("Remove users {:?} from Copilot subscription for org {organization}", request.selected_usernames.clone());
+        info!("Remove users {:?} from Copilot subscription for org {organization}", request.selected_usernames);
 
         let address = format!("/org/{organization}/copilot/billing/selected_users");
 

--- a/plaid/src/apis/github/copilot.rs
+++ b/plaid/src/apis/github/copilot.rs
@@ -1,0 +1,104 @@
+use super::Github;
+use crate::apis::{github::GitHubError, ApiError};
+use serde::{Deserialize, Serialize};
+
+use std::collections::HashMap;
+
+impl Github {
+    // List all seats in the Copilot subscription for an organization
+    // See https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#list-all-copilot-seat-assignments-for-an-organization for more details
+    pub async fn list_seats_in_org_copilot(&self, params: &str, module: &str) -> Result<String, ApiError> {
+        let request: HashMap<&str, &str> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let organization = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
+
+        info!("List all seats in Copilot subscription for org {organization}");
+
+        let address = format!("/org/{organization}/copilot/billing/seats");
+
+        match self.make_generic_get_request(address, &module).await {
+            Ok((status, Ok(body))) => {
+                if status == 200 {
+                    Ok(body)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
+    }
+
+    // Add users to the Copilot subscription for an organization
+    // See https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#add-users-to-the-copilot-subscription-for-an-organization for more details
+    pub async fn add_users_to_org_copilot(&self, params: &str, module: &str) -> Result<u32, ApiError> {
+        #[derive(Deserialize, Serialize)]
+        struct Request {
+            org: String,
+            selected_usernames: Vec<String>,
+        }
+        let request: Request =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let organization = self.validate_org(&request.org)?;
+        for username in request.selected_usernames.iter() {
+            self.validate_username(&username)?;
+        }
+
+        info!("Adding users {:?} to Copilot subscription for org {organization}", request.selected_usernames);
+
+        let address = format!("/org/{organization}/copilot/billing/selected_users");
+
+        match self.make_generic_post_request(address, &request, &module).await {
+            Ok((status, Ok(_))) => {
+                if status == 201 {
+                    Ok(0)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
+    }
+
+    // Remove users from the Copilot subscription for an organization
+    // See https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#remove-users-from-the-copilot-subscription-for-an-organization for more details
+    pub async fn remove_users_from_org_copilot(&self, params: &str, module: &str) -> Result<u32, ApiError> {
+        #[derive(Deserialize, Serialize)]
+        struct Request {
+            org: String,
+            selected_usernames: Vec<String>,
+        }
+        let request: Request =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let organization = self.validate_org(&request.org)?;
+        for username in request.selected_usernames.iter() {
+            self.validate_username(&username)?;
+        }
+
+        info!("Remove users {:?} from Copilot subscription for org {organization}", request.selected_usernames.clone());
+
+        let address = format!("/org/{organization}/copilot/billing/selected_users");
+
+        match self.make_generic_delete_request(address, Some(&request), &module).await {
+            Ok((status, Ok(_))) => {
+                if status == 200 {
+                    Ok(0)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/plaid/src/apis/github/copilot.rs
+++ b/plaid/src/apis/github/copilot.rs
@@ -12,10 +12,14 @@ impl Github {
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         let organization = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
+        let per_page: u8 = request.get("per_page").unwrap_or(&"50")
+            .parse::<u8>().map_err(|_| ApiError::BadRequest)?;
+        let page: u16 = request.get("page").unwrap_or(&"1")
+            .parse::<u16>().map_err(|_| ApiError::BadRequest)?;
 
         info!("List seats in Copilot subscription for org {organization}");
 
-        let address = format!("/orgs/{organization}/copilot/billing/seats");
+        let address = format!("/orgs/{organization}/copilot/billing/seats?page={page}&per_page={per_page}");
 
         match self.make_generic_get_request(address, &module).await {
             Ok((status, Ok(body))) => {

--- a/plaid/src/apis/github/mod.rs
+++ b/plaid/src/apis/github/mod.rs
@@ -1,3 +1,4 @@
+mod copilot;
 mod environments;
 mod graphql;
 mod pats;
@@ -191,10 +192,10 @@ impl Github {
     /// to help facilitate the conversion from a token usage to GitHub app. It also means that
     /// extra parsing can be avoided since we need to re-serialize anyway to pass back to the rules
     /// (at least currently).
-    async fn make_generic_delete_request(
+    async fn make_generic_delete_request<T: Serialize> (
         &self,
         uri: String,
-        body: Option<&str>,
+        body: Option<&T>,
         module: &str,
     ) -> Result<(u16, Result<String, ApiError>), ApiError> {
         info!("Making a delete request to {uri} on behalf of {module}");

--- a/plaid/src/apis/github/repos.rs
+++ b/plaid/src/apis/github/repos.rs
@@ -23,7 +23,7 @@ impl Github {
         info!("Removing user [{user}] from [{repo}] on behalf of {module}");
 
         match self
-            .make_generic_delete_request(address, None, module)
+            .make_generic_delete_request::<&str>(address, None, module)
             .await
         {
             Ok((status, _)) => {

--- a/plaid/src/apis/github/teams.rs
+++ b/plaid/src/apis/github/teams.rs
@@ -20,7 +20,7 @@ impl Github {
         let address = format!("/orgs/{org}/teams/{team_slug}/memberships/{user}");
 
         match self
-            .make_generic_delete_request(address, None, module)
+            .make_generic_delete_request::<&str>(address, None, module)
             .await
         {
             Ok((status, _)) => {

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -232,6 +232,8 @@ impl_new_function!(github, update_branch_protection_rule);
 impl_new_function!(github, create_environment_for_repo);
 impl_new_function!(github, configure_secret);
 impl_new_function!(github, create_deployment_branch_protection_rule);
+impl_new_function!(github, add_users_to_org_copilot);
+impl_new_function!(github, remove_users_from_org_copilot);
 
 impl_new_function_with_error_buffer!(github, make_graphql_query);
 impl_new_function_with_error_buffer!(github, make_advanced_graphql_query);
@@ -240,6 +242,7 @@ impl_new_function_with_error_buffer!(github, list_files);
 impl_new_function_with_error_buffer!(github, fetch_file);
 impl_new_function_with_error_buffer!(github, get_branch_protection_rules);
 impl_new_function_with_error_buffer!(github, get_repository_collaborators);
+impl_new_function_with_error_buffer!(github, list_seats_in_org_copilot);
 
 // GitHub Functions only available with GitHub App authentication
 impl_new_function!(github, review_fpat_requests_for_org);
@@ -450,6 +453,15 @@ pub fn to_api_function(
         }
         "github_create_deployment_branch_protection_rule" => {
             Function::new_typed_with_env(&mut store, &env, github_create_deployment_branch_protection_rule)
+        }
+        "github_add_users_to_org_copilot" => {
+            Function::new_typed_with_env(&mut store, &env, github_add_users_to_org_copilot)
+        }
+        "github_remove_users_to_org_copilot" => {
+            Function::new_typed_with_env(&mut store, &env, github_remove_users_from_org_copilot)
+        }
+        "github_list_seats_in_org_copilot" => {
+            Function::new_typed_with_env(&mut store, &env, github_list_seats_in_org_copilot)
         }
 
         // Slack Calls

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -471,7 +471,7 @@ pub fn to_api_function(
         "github_add_users_to_org_copilot" => {
             Function::new_typed_with_env(&mut store, &env, github_add_users_to_org_copilot)
         }
-        "github_remove_users_to_org_copilot" => {
+        "github_remove_users_from_org_copilot" => {
             Function::new_typed_with_env(&mut store, &env, github_remove_users_from_org_copilot)
         }
         "github_list_seats_in_org_copilot" => {


### PR DESCRIPTION
- Add 3 Github APIs to manage Copilot membership: list, add and remove.