### PR TITLE
Shorten default npm token expiration to 30 days

### DIFF
--- a/plaid/src/apis/npm/npm_web_client.rs
+++ b/plaid/src/apis/npm/npm_web_client.rs
@@ -251,7 +251,7 @@ impl Npm {
                 .clone()
                 .unwrap_or(vec!["".to_string()]),
             csrftoken: &csrf_token,
-            expiration_days: &specs.expiration_days.unwrap_or(365).to_string(),
+            expiration_days: &specs.expiration_days.unwrap_or(30).to_string(),
             orgs_permission: &params
                 .specs
                 .orgs_permission


### PR DESCRIPTION
Since the STL supports automatically renewing tokens, tokens can be rotated more frequently without disruption.

We now choose a default duration of 30 days. Rules can still override this value, if they decide to pass detailed token specs.