### PR TITLE
Implement benchmarking system to measure and compare rule execution data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /target
 plaid-stl/target
 /plaid/private-resources
+/plaid/benchmark_results

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /target
 plaid-stl/target
 /plaid/private-resources
-/plaid/benchmark_results
+*benchmark-results

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.64",
  "time 0.3.36",
 ]
 
@@ -154,7 +154,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -176,7 +176,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -530,7 +530,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -580,24 +580,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags 2.6.0",
- "cexpr",
- "clang-sys",
- "itertools",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.79",
-]
-
-[[package]]
 name = "binstring"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,32 +627,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "boring"
-version = "4.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e774b91e8adadd05892dfa300bc297e703a3cea36f094a4f8c155d2b13b770"
-dependencies = [
- "bitflags 2.6.0",
- "boring-sys",
- "foreign-types 0.5.0",
- "libc",
- "once_cell",
- "openssl-macros",
-]
-
-[[package]]
-name = "boring-sys"
-version = "4.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49584b157cf568167bfd13c2567a4bc9e1bec9bc2a36216c54ac86925922a903"
-dependencies = [
- "bindgen",
- "cmake",
- "fs_extra",
- "fslock",
 ]
 
 [[package]]
@@ -733,19 +689,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -759,18 +712,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
+ "windows-targets",
 ]
 
 [[package]]
@@ -797,15 +739,6 @@ name = "clap_lex"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
-
-[[package]]
-name = "cmake"
-version = "0.1.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "coarsetime"
@@ -838,9 +771,9 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cookie"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "percent-encoding",
  "time 0.3.36",
@@ -849,12 +782,13 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387461abbc748185c3a6e1673d826918b450b87ff22639429c694619a83b6cf6"
+checksum = "2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9"
 dependencies = [
  "cookie",
- "idna 0.3.0",
+ "document-features",
+ "idna 1.0.3",
  "log",
  "publicsuffix",
  "serde",
@@ -1103,7 +1037,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1114,7 +1048,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1196,7 +1130,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1219,7 +1153,16 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1320,7 +1263,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1414,28 +1357,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared 0.3.1",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1443,12 +1365,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1464,22 +1380,6 @@ name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fslock"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
 dependencies = [
  "libc",
  "winapi",
@@ -1547,7 +1447,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1629,12 +1529,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "group"
@@ -1942,6 +1836,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.5.0",
+ "hyper-util",
+ "rustls 0.23.17",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,6 +1909,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,6 +2050,27 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -2068,15 +2119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,7 +2157,6 @@ dependencies = [
  "anyhow",
  "binstring",
  "blake2b_simd",
- "boring",
  "coarsetime",
  "ct-codecs",
  "ed25519-compact",
@@ -2129,7 +2170,7 @@ dependencies = [
  "serde",
  "serde_json",
  "superboring",
- "thiserror",
+ "thiserror 1.0.64",
  "zeroize",
 ]
 
@@ -2193,16 +2234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libloading"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,6 +2272,18 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -2540,7 +2583,7 @@ checksum = "7b8cefcf97f41316955f9294cd61f639bdcfa9f2f230faac6cb896aa8ab64704"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
- "foreign-types 0.3.2",
+ "foreign-types",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -2555,7 +2598,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2661,7 +2704,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.7",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2730,7 +2773,7 @@ checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2798,6 +2841,7 @@ dependencies = [
  "rcgen",
  "regex",
  "reqwest",
+ "reqwest_cookie_store",
  "ring 0.17.8",
  "serde",
  "serde_json",
@@ -2918,6 +2962,58 @@ checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
 dependencies = [
  "idna 0.3.0",
  "psl-types",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.17",
+ "socket2",
+ "thiserror 2.0.3",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+dependencies = [
+ "bytes",
+ "getrandom",
+ "rand",
+ "ring 0.17.8",
+ "rustc-hash",
+ "rustls 0.23.17",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.3",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3086,22 +3182,22 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "cookie",
  "cookie_store",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.31",
- "hyper-rustls 0.24.2",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.0",
+ "hyper-rustls 0.27.3",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -3109,22 +3205,35 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "quinn",
+ "rustls 0.23.17",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.26.0",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "windows-registry",
+]
+
+[[package]]
+name = "reqwest_cookie_store"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b36498c7452f11b1833900f31fbb01fc46be20992a50269c88cf59d79f54e9"
+dependencies = [
+ "bytes",
+ "cookie_store",
+ "reqwest",
+ "url",
 ]
 
 [[package]]
@@ -3232,9 +3341,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"
@@ -3294,6 +3403,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
+dependencies = [
+ "once_cell",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3341,6 +3464,9 @@ name = "rustls-pki-types"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+dependencies = [
+ "web-time",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -3501,7 +3627,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3615,7 +3741,7 @@ checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.64",
  "time 0.3.36",
 ]
 
@@ -3674,7 +3800,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3770,9 +3896,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3781,9 +3907,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3798,24 +3927,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.5.1"
+name = "synstructure"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3869,7 +3988,16 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.64",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -3880,7 +4008,18 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3924,6 +4063,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3964,7 +4113,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3994,6 +4143,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.17",
  "rustls-pki-types",
  "tokio",
 ]
@@ -4128,7 +4288,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4160,7 +4320,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.64",
  "url",
  "utf-8",
 ]
@@ -4180,7 +4340,7 @@ dependencies = [
  "native-tls",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.64",
  "utf-8",
 ]
 
@@ -4273,6 +4433,18 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -4375,7 +4547,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -4409,7 +4581,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4437,7 +4609,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "shared-buffer",
  "target-lexicon",
- "thiserror",
+ "thiserror 1.0.64",
  "tracing",
  "wasm-bindgen",
  "wasmer-compiler",
@@ -4469,7 +4641,7 @@ dependencies = [
  "self_cell",
  "shared-buffer",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.64",
  "wasmer-types",
  "wasmer-vm",
  "wasmparser",
@@ -4535,7 +4707,7 @@ dependencies = [
  "rkyv",
  "sha2",
  "target-lexicon",
- "thiserror",
+ "thiserror 1.0.64",
  "xxhash-rust",
 ]
 
@@ -4562,7 +4734,7 @@ dependencies = [
  "more-asserts",
  "region",
  "scopeguard",
- "thiserror",
+ "thiserror 1.0.64",
  "wasmer-types",
  "windows-sys 0.59.0",
 ]
@@ -4589,10 +4761,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.25.4"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -4631,7 +4816,37 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4649,20 +4864,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4671,22 +4877,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4695,21 +4886,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_gnullvm",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_gnullvm",
  "windows_x86_64_msvc 0.52.6",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4725,12 +4910,6 @@ checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4740,12 +4919,6 @@ name = "windows_i686_gnu"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4767,12 +4940,6 @@ checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4785,21 +4952,9 @@ checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4815,25 +4970,21 @@ checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
+name = "write16"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wyz"
@@ -4859,7 +5010,7 @@ dependencies = [
  "oid-registry",
  "ring 0.16.20",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.64",
  "time 0.3.36",
 ]
 
@@ -4896,6 +5047,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure 0.13.1",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4913,7 +5088,28 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -4933,7 +5129,29 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4949,7 +5167,7 @@ dependencies = [
  "flate2",
  "indexmap 2.6.0",
  "memchr",
- "thiserror",
+ "thiserror 1.0.64",
  "zopfli",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2850,6 +2850,7 @@ dependencies = [
  "time 0.3.36",
  "tokio",
  "tokio-tungstenite 0.23.1",
+ "tokio-util",
  "toml",
  "totp-rs",
  "url",

--- a/plaid-stl/src/lib.rs
+++ b/plaid-stl/src/lib.rs
@@ -154,12 +154,11 @@ macro_rules! entrypoint_with_source {
         #[no_mangle]
         pub unsafe extern "C" fn entrypoint() -> i32 {
             extern "C" {
-                fn fetch_data(data_buffer: *mut u8, buffer_size: u32) -> i32;
-                fn fetch_source(data_buffer: *mut u8, buffer_size: u32) -> i32;
+                fn fetch_data_and_source(data_buffer: *mut u8, buffer_size: u32) -> i32;
             }
 
-            let buffer_size = fetch_data(vec![].as_mut_ptr(), 0);
-            let buffer_size = if buffer_size < 0 {
+            let buffer_size = fetch_data_and_source(vec![].as_mut_ptr(), 0);
+            let buffer_size = if buffer_size < 4 {
                 return buffer_size;
             } else {
                 buffer_size as u32
@@ -167,8 +166,8 @@ macro_rules! entrypoint_with_source {
 
             let mut data_buffer = vec![0; buffer_size as usize];
 
-            let copied_size = fetch_data(data_buffer.as_mut_ptr(), buffer_size);
-            let copied_size = if copied_size < 0 {
+            let copied_size = fetch_data_and_source(data_buffer.as_mut_ptr(), buffer_size);
+            let copied_size = if copied_size < 4 {
                 return copied_size;
             } else {
                 copied_size as u32
@@ -178,31 +177,16 @@ macro_rules! entrypoint_with_source {
                 return -1;
             }
 
-            let log = match String::from_utf8(data_buffer) {
+            let log_length = u32::from_le_bytes(data_buffer[0..4].try_into().unwrap()) as usize;
+
+            let log = &data_buffer[4..4 + log_length];
+            let log = match String::from_utf8(log.to_vec()) {
                 Ok(s) => s,
                 Err(_) => return -2,
             };
 
-            let buffer_size = fetch_source(vec![].as_mut_ptr(), 0);
-            let buffer_size = if buffer_size < 0 {
-                return buffer_size;
-            } else {
-                buffer_size as u32
-            };
-
-            let mut data_buffer = vec![0; buffer_size as usize];
-            let copied_size = fetch_source(data_buffer.as_mut_ptr(), buffer_size);
-            let copied_size = if copied_size < 0 {
-                return copied_size;
-            } else {
-                copied_size as u32
-            };
-
-            if copied_size != buffer_size {
-                return -1;
-            }
-
-            let source = match serde_json::from_slice::<LogSource>(&data_buffer) {
+            let log_source = &data_buffer[4 + log_length..];
+            let source = match serde_json::from_slice::<LogSource>(log_source) {
                 Ok(s) => s,
                 Err(_) => return -2,
             };
@@ -228,13 +212,12 @@ macro_rules! entrypoint_with_source_and_response {
         #[no_mangle]
         pub unsafe extern "C" fn entrypoint() -> i32 {
             extern "C" {
-                fn fetch_data(data_buffer: *mut u8, buffer_size: u32) -> i32;
-                fn fetch_source(data_buffer: *mut u8, buffer_size: u32) -> i32;
+                fn fetch_data_and_source(data_buffer: *mut u8, buffer_size: u32) -> i32;
                 fn set_response(data_buffer: *const u8, buffer_size: u32);
             }
 
-            let buffer_size = fetch_data(vec![].as_mut_ptr(), 0);
-            let buffer_size = if buffer_size < 0 {
+            let buffer_size = fetch_data_and_source(vec![].as_mut_ptr(), 0);
+            let buffer_size = if buffer_size < 4 {
                 return buffer_size;
             } else {
                 buffer_size as u32
@@ -242,8 +225,8 @@ macro_rules! entrypoint_with_source_and_response {
 
             let mut data_buffer = vec![0; buffer_size as usize];
 
-            let copied_size = fetch_data(data_buffer.as_mut_ptr(), buffer_size);
-            let copied_size = if copied_size < 0 {
+            let copied_size = fetch_data_and_source(data_buffer.as_mut_ptr(), buffer_size);
+            let copied_size = if copied_size < 4 {
                 return copied_size;
             } else {
                 copied_size as u32
@@ -253,31 +236,16 @@ macro_rules! entrypoint_with_source_and_response {
                 return -1;
             }
 
-            let log = match String::from_utf8(data_buffer) {
+            let log_length = u32::from_le_bytes(data_buffer[0..4].try_into().unwrap()) as usize;
+
+            let log = &data_buffer[4..4 + log_length];
+            let log = match String::from_utf8(log.to_vec()) {
                 Ok(s) => s,
                 Err(_) => return -2,
             };
 
-            let buffer_size = fetch_source(vec![].as_mut_ptr(), 0);
-            let buffer_size = if buffer_size < 0 {
-                return buffer_size;
-            } else {
-                buffer_size as u32
-            };
-
-            let mut data_buffer = vec![0; buffer_size as usize];
-            let copied_size = fetch_source(data_buffer.as_mut_ptr(), buffer_size);
-            let copied_size = if copied_size < 0 {
-                return copied_size;
-            } else {
-                copied_size as u32
-            };
-
-            if copied_size != buffer_size {
-                return -1;
-            }
-
-            let source = match serde_json::from_slice::<LogSource>(&data_buffer) {
+            let log_source = &data_buffer[4 + log_length..];
+            let source = match serde_json::from_slice::<LogSource>(log_source) {
                 Ok(s) => s,
                 Err(_) => return -2,
             };

--- a/plaid/Cargo.toml
+++ b/plaid/Cargo.toml
@@ -52,6 +52,7 @@ tokio-tungstenite = { version = "0.23.1", features = ["native-tls-vendored"] }
 futures-util = "0.3.30"
 aws-sdk-kms = { version = "1.41.0", optional = true }
 aws-config = { version = "1.5.5", optional = true }
+tokio-util = "0.7.12"
 
 [[example]]
 name = "github-tailer"

--- a/plaid/src/benchmark/mod.rs
+++ b/plaid/src/benchmark/mod.rs
@@ -1,0 +1,168 @@
+use std::collections::HashMap;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+
+use crossbeam_channel::Receiver;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct Benchmarking {
+    /// The full path to the output file where benchmarking metrics should be written
+    #[serde(default = "default_results_file_path")]
+    output_file_path: String,
+}
+
+/// Default file path for benchmarking results if none is provided in the config
+fn default_results_file_path() -> String {
+    format!(
+        "{}/benchmark_results/metrics.txt",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
+/// Metadata about a rule's execution
+pub struct ModulePerformanceMetadata {
+    /// The name of the module
+    pub module: String,
+    /// Time (in microseconds) for execution to complete
+    pub execution_time: u128,
+    /// The amount of computation used by the rule
+    pub computation_used: u64,
+}
+
+/// Represents a module's aggregate performance
+struct AggregatePerformanceData {
+    /// The number of times the module has been executed
+    runs: u64,
+    /// The total time (in microseconds) the module has spent in the execution loop
+    total_execution_time: u128,
+    /// The total computation used by the module
+    total_computation_used: u64,
+    /// Denotes whether the system should continue collecting performance metadata
+    maxed_out: bool,
+}
+
+impl AggregatePerformanceData {
+    /// Creates a new `AggregatePerformanceData` with initial execution time and computation used.
+    fn new(execution_time: u128, computation_used: u64) -> Self {
+        Self {
+            runs: 1,
+            total_execution_time: execution_time,
+            total_computation_used: computation_used,
+            maxed_out: false,
+        }
+    }
+
+    /// Updates the aggregate data atomically with the latest execution time and computation used.
+    /// If overflow occurs, the update is rolled back and none of the fields are modified.
+    fn update(&mut self, message: &ModulePerformanceMetadata) {
+        if self.maxed_out {
+            return;
+        }
+
+        // Check if the additions would overflow before proceeding
+        if let (Some(new_total_execution_time), Some(new_total_computation_used)) = (
+            self.total_execution_time
+                .checked_add(message.execution_time),
+            self.total_computation_used
+                .checked_add(message.computation_used),
+        ) {
+            // Atomic update
+            self.runs += 1;
+            self.total_execution_time = new_total_execution_time;
+            self.total_computation_used = new_total_computation_used;
+        } else {
+            error!("Overflow occurred updating execution data for [{}]. No further execution data will be collected.", message.module);
+            self.maxed_out = true;
+        }
+    }
+}
+
+impl Benchmarking {
+    pub async fn benchmark_loop(
+        &self,
+        receiver: Receiver<ModulePerformanceMetadata>,
+        shutdown_initiated: Arc<AtomicBool>,
+    ) {
+        let mut aggregate_performance_metadata = HashMap::new();
+
+        // Benchmarking loop runs until shutdown_initiated is set to true
+        while !shutdown_initiated.load(Ordering::SeqCst) {
+            match receiver.try_recv() {
+                Ok(message) => {
+                    aggregate_performance_metadata
+                        .entry(message.module.clone())
+                        .and_modify(|aggregate: &mut AggregatePerformanceData| {
+                            aggregate.update(&message);
+                        })
+                        .or_insert_with(|| {
+                            AggregatePerformanceData::new(
+                                message.execution_time,
+                                message.computation_used,
+                            )
+                        });
+                }
+                Err(_) => {
+                    // Sleep for a short period to avoid busy looping when no data is received
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+
+        if let Err(e) =
+            generate_report(&aggregate_performance_metadata, &self.output_file_path).await
+        {
+            error!("Failed to generate benchmark report. Error: {e}")
+        }
+    }
+}
+
+/// Generates a performance report based on the given aggregate performance data
+/// and writes the results to the specified file.
+async fn generate_report(
+    aggregate_performance_metadata: &HashMap<String, AggregatePerformanceData>,
+    file_path: &str,
+) -> Result<(), tokio::io::Error> {
+    debug!("Writing benchmarking results file to {file_path}...");
+
+    // Open a file in write mode asynchronously. If the file doesn't exist, it will be created.
+    let mut file = File::create(file_path).await?;
+
+    // Write the report header
+    file.write_all(b"Performance Report:\n").await?;
+
+    // Write the data for each module
+    for (module, data) in aggregate_performance_metadata {
+        file.write_all(format!("Module: {}\n", module).as_bytes())
+            .await?;
+        file.write_all(format!("\tRuns: {}\n", data.runs).as_bytes())
+            .await?;
+        file.write_all(
+            format!(
+                "\tAverage Computation Used: {}\n",
+                data.total_computation_used / data.runs
+            )
+            .as_bytes(),
+        )
+        .await?;
+        file.write_all(
+            format!(
+                "\tAverage Execution Time (microseconds): {}\n",
+                data.total_execution_time / data.runs as u128
+            )
+            .as_bytes(),
+        )
+        .await?;
+        file.write_all(b"\n").await?;
+    }
+
+    // Ensure the file is flushed and fully written
+    file.flush().await?;
+
+    Ok(())
+}

--- a/plaid/src/benchmark/mod.rs
+++ b/plaid/src/benchmark/mod.rs
@@ -20,7 +20,7 @@ pub struct Benchmarking {
 /// Default file path for benchmarking results if none is provided in the config
 fn default_results_file_path() -> String {
     format!(
-        "{}/benchmark_results/metrics.txt",
+        "{}/../benchmark-results/metrics.txt",
         env!("CARGO_MANIFEST_DIR")
     )
 }
@@ -129,6 +129,16 @@ async fn generate_report(
     file_path: &str,
 ) -> Result<(), tokio::io::Error> {
     debug!("Writing benchmarking results file to {file_path}...");
+
+    // Check if benchmark_results directory exists
+    // Extract the directory path from the file path
+    if let Some(dir_path) = std::path::Path::new(file_path).parent() {
+        // Check if the directory exists
+        if !dir_path.exists() {
+            // Create the directory if it doesn't exist
+            tokio::fs::create_dir_all(dir_path).await?;
+        }
+    }
 
     // Open a file in write mode asynchronously. If the file doesn't exist, it will be created.
     let mut file = File::create(file_path).await?;

--- a/plaid/src/config.rs
+++ b/plaid/src/config.rs
@@ -6,6 +6,8 @@ use serde::{de, Deserialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
+use crate::benchmark::Benchmarking;
+
 use super::apis::Apis;
 use super::data::DataConfig;
 use super::loader::Configuration as LoaderConfiguration;
@@ -114,6 +116,10 @@ pub struct Configuration {
     /// The maximum number of logs in the queue to be processed at once
     #[serde(default = "default_log_queue_size")]
     pub log_queue_size: usize,
+    /// Configuration for how Plaid benchmarks rules. When enabled,
+    /// Plaid outputs a metrics file with performance metadata for all
+    /// rules than have been run at least once.
+    pub benchmark_mode: Option<Benchmarking>,
     /// Configuration for persistent data. This allows modules to store data between
     /// invocations
     pub storage: Option<StorageConfig>,

--- a/plaid/src/executor/mod.rs
+++ b/plaid/src/executor/mod.rs
@@ -8,7 +8,8 @@ use crate::loader::PlaidModule;
 use crate::logging::{Logger, LoggingError};
 use crate::storage::Storage;
 
-use crossbeam_channel::{Receiver, Sender};
+use crossbeam_channel::Receiver;
+use tokio::sync::mpsc::Sender;
 use tokio::sync::oneshot::Sender as OneShotSender;
 
 use plaid_stl::messages::{LogSource, LogbacksAllowed};
@@ -453,7 +454,7 @@ fn process_message_with_module(
 
                     // If benchmarking is enabled, log data to the benchmarking system
                     if let Some(ref sender) = benchmark_mode {
-                        if let Err(e) = sender.send(ModulePerformanceMetadata {
+                        if let Err(e) = sender.blocking_send(ModulePerformanceMetadata {
                             module: module.name.clone(),
                             execution_time: begin.elapsed().as_micros(),
                             computation_used: computation_limit - remaining,

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -311,6 +311,9 @@ pub fn to_api_function(
         "fetch_source" => {
             Function::new_typed_with_env(&mut store, &env, super::message::fetch_source)
         }
+        "fetch_data_and_source" => {
+            Function::new_typed_with_env(&mut store, &env, super::message::fetch_data_and_source)
+        }
         "fetch_accessory_data_by_name" => Function::new_typed_with_env(
             &mut store,
             &env,
@@ -350,8 +353,9 @@ pub fn to_api_function(
         }
         "cache_get" => Function::new_typed_with_env(&mut store, &env, super::cache::get),
         "log_back" => Function::new_typed_with_env(&mut store, &env, super::internal::log_back),
-        "log_back_unlimited" => Function::new_typed_with_env(&mut store, &env, super::internal::log_back_unlimited),
-        
+        "log_back_unlimited" => {
+            Function::new_typed_with_env(&mut store, &env, super::internal::log_back_unlimited)
+        }
         // Npm Calls
         "npm_publish_empty_stub" => {
             Function::new_typed_with_env(&mut store, &env, npm_publish_empty_stub)
@@ -373,9 +377,7 @@ pub fn to_api_function(
             Function::new_typed_with_env(&mut store, &env, npm_list_granular_tokens)
         }
 
-        "npm_delete_package" => {
-            Function::new_typed_with_env(&mut store, &env, npm_delete_package)
-        }
+        "npm_delete_package" => Function::new_typed_with_env(&mut store, &env, npm_delete_package),
 
         "npm_add_user_to_team" => {
             Function::new_typed_with_env(&mut store, &env, npm_add_user_to_team)
@@ -408,7 +410,7 @@ pub fn to_api_function(
         "npm_get_token_details" => {
             Function::new_typed_with_env(&mut store, &env, npm_get_token_details)
         }
-        
+
         // Okta Calls
         "okta_remove_user_from_group" => {
             Function::new_typed_with_env(&mut store, &env, okta_remove_user_from_group)
@@ -437,12 +439,8 @@ pub fn to_api_function(
         "github_fetch_commit" => {
             Function::new_typed_with_env(&mut store, &env, github_fetch_commit)
         }
-        "github_list_files" => {
-            Function::new_typed_with_env(&mut store, &env, github_list_files)
-        }
-        "github_fetch_file" => {
-            Function::new_typed_with_env(&mut store, &env, github_fetch_file)
-        }
+        "github_list_files" => Function::new_typed_with_env(&mut store, &env, github_list_files),
+        "github_fetch_file" => Function::new_typed_with_env(&mut store, &env, github_fetch_file),
         "github_list_fpat_requests_for_org" => {
             Function::new_typed_with_env(&mut store, &env, github_list_fpat_requests_for_org)
         }
@@ -467,9 +465,11 @@ pub fn to_api_function(
         "github_configure_secret" => {
             Function::new_typed_with_env(&mut store, &env, github_configure_secret)
         }
-        "github_create_deployment_branch_protection_rule" => {
-            Function::new_typed_with_env(&mut store, &env, github_create_deployment_branch_protection_rule)
-        }
+        "github_create_deployment_branch_protection_rule" => Function::new_typed_with_env(
+            &mut store,
+            &env,
+            github_create_deployment_branch_protection_rule,
+        ),
         "github_search_for_file" => {
             Function::new_typed_with_env(&mut store, &env, github_search_for_file)
         }
@@ -495,7 +495,9 @@ pub fn to_api_function(
         }
         "slack_post_message" => Function::new_typed_with_env(&mut store, &env, slack_post_message),
         "slack_views_open" => Function::new_typed_with_env(&mut store, &env, slack_views_open),
-        "slack_get_id_from_email" => Function::new_typed_with_env(&mut store, &env, slack_get_id_from_email),
+        "slack_get_id_from_email" => {
+            Function::new_typed_with_env(&mut store, &env, slack_get_id_from_email)
+        }
 
         // General Calls
         "general_simple_json_post_request" => {

--- a/plaid/src/functions/message.rs
+++ b/plaid/src/functions/message.rs
@@ -3,6 +3,64 @@ use crate::executor::Env;
 
 use wasmer::{AsStoreRef, FunctionEnvMut, WasmPtr};
 
+pub fn fetch_data_and_source(
+    env: FunctionEnvMut<Env>,
+    data_buffer: WasmPtr<u8>,
+    buffer_size: u32,
+) -> i32 {
+    let store = env.as_store_ref();
+    let memory_view = match get_memory(&env, &store) {
+        Ok(memory_view) => memory_view,
+        Err(e) => {
+            error!(
+                "{}: Memory error in fetch_from_module: {:?}",
+                env.data().name,
+                e
+            );
+            return e as i32;
+        }
+    };
+
+    let log_data = &env.data().message.data;
+
+    // Get the from_module if it exists (which it won't if this is from a data generator
+    // like GitHub, Okta, or a Webhook)
+    let source = &env.data().message.source;
+
+    // I really think this is overkill and we could just unwrap() this but
+    // in the future we may run modules that are completely untrusted allowing things
+    // like names to sneak in and perhaps cause issues. That is still a problem here
+    // because this would then not succeed and the module will not know where a log came
+    // from, but at least we can handle that.
+    let source = match serde_json::to_vec(source) {
+        Ok(s) => s,
+        Err(e) => {
+            error!(
+                "{}: Could not serialize the source: {}. Error: {e}",
+                env.data().name,
+                env.data().message.source,
+            );
+            return -4;
+        }
+    };
+
+    // Get the length of the log and convert it to a byte representation
+    let log_length = (log_data.len() as u32).to_le_bytes();
+
+    let mut rule_data = Vec::new();
+    rule_data.extend_from_slice(&log_length);
+    rule_data.extend_from_slice(log_data);
+    rule_data.extend_from_slice(&source);
+
+    match safely_write_data_back(&memory_view, &rule_data, data_buffer, buffer_size) {
+        Ok(x) => x,
+        Err(e) => {
+            error!("{}: Error in fetch_data: {:?}", env.data().name, e);
+            e as i32
+        }
+    }
+}
+
 /// Wrap the fetch_data call in a native WASM function.
 pub fn fetch_data(env: FunctionEnvMut<Env>, data_buffer: WasmPtr<u8>, buffer_size: u32) -> i32 {
     let store = env.as_store_ref();

--- a/plaid/src/lib.rs
+++ b/plaid/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate log;
 
 pub mod apis;
+pub mod benchmark;
 pub mod config;
 pub mod data;
 pub mod executor;


### PR DESCRIPTION
Currently, we're unable to quantify how subtle changes to a rule or the Plaid runtime affect performance. This PR implements a mechanism to benchmark and compare Plaid rules, enabling developers and plaidmins to maximize their instance's performance. When enabled, it logs rule execution metadata (rule name, execution time, computation used) to a task that aggregates this data based on rule name. On shutdown, the benchmarking system writes this data out to a file.

Triggering shutdown of the server is done with `CTRL+C` or by sending a `SIGTERM` signal. Plaid is configured to listen for this signal and begin a graceful shutdown. Right now, graceful shutdown means waiting for the `benchmark_loop` task to exit. This allows us to guarantee that our benchmarking data will be written to a file prior to exiting. However, graceful shutdown allows us to do more in the future. We could extend this idea to the execution loop and only shutdown once the message queue is empty, therefore guaranteeing that all logs will be processed.

### Output
The benchmarking system outputs a file like:
```
Performance Report:
Module: testing_test_release_default.wasm
	Runs: 3510
	Average Computation Used: 4752.00
	Average Execution Time (microseconds): 2012

Module: testing_test.wasm
	Runs: 3510
	Average Computation Used: 31317.00
	Average Execution Time (microseconds): 1967
```

In this simple example, we can see that when we compile the `testing_test.wasm` rule with the `--release` flag, we reduce the computation used by about 85%! That's a big difference. 