### PR TITLE
Return number of seats changed for Copilot API

### DIFF
--- a/plaid-stl/src/github/mod.rs
+++ b/plaid-stl/src/github/mod.rs
@@ -416,6 +416,8 @@ pub fn add_user_to_copilot_subscription(org: &str, user: &str) -> Result<u32, Pl
         return Err(res.into());
     }
 
+    return_buffer.truncate(res as usize);
+
     // This should be safe because unless the Plaid runtime is expressly trying
     // to mess with us, this came from a String in the API module.
     let seats_created = String::from_utf8(return_buffer)

--- a/plaid-stl/src/github/mod.rs
+++ b/plaid-stl/src/github/mod.rs
@@ -397,7 +397,7 @@ pub fn add_user_to_copilot_subscription(org: &str, user: &str) -> Result<u32, Pl
         selected_usernames: vec![user],
     };
 
-    const RETURN_BUFFER_SIZE: usize = 32; // 32 bytes
+    const RETURN_BUFFER_SIZE: usize = 1024; // 1 KiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
     let params = serde_json::to_string(&params).unwrap();
@@ -446,7 +446,7 @@ pub fn remove_user_from_copilot_subscription(org: &str, user: &str) -> Result<u3
         selected_usernames: vec![user],
     };
 
-    const RETURN_BUFFER_SIZE: usize = 32; // 32 bytes
+    const RETURN_BUFFER_SIZE: usize = 1024; // 1 KiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
     let params = serde_json::to_string(&params).unwrap();

--- a/plaid-stl/src/github/mod.rs
+++ b/plaid-stl/src/github/mod.rs
@@ -383,7 +383,7 @@ pub fn list_all_copilot_subscription_seats(org: &str) -> Result<Vec<CopilotSeat>
 ///
 /// * `org` - The org owning the subscription
 /// * `user` - The user to add to Copilot subscription
-pub fn add_user_to_copilot_subscription(org: &str, user: &str) -> Result<u32, PlaidFunctionError> {
+pub fn add_user_to_copilot_subscription(org: &str, user: &str) -> Result<String, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, add_users_to_org_copilot);
     }
@@ -420,12 +420,10 @@ pub fn add_user_to_copilot_subscription(org: &str, user: &str) -> Result<u32, Pl
 
     // This should be safe because unless the Plaid runtime is expressly trying
     // to mess with us, this came from a String in the API module.
-    let seats_created = String::from_utf8(return_buffer)
-        .map_err(|_| PlaidFunctionError::InternalApiError)?;
-    let seats_created: u32 = seats_created.parse()
+    let response_body = String::from_utf8(return_buffer)
         .map_err(|_| PlaidFunctionError::InternalApiError)?;
 
-    Ok(seats_created)
+    Ok(response_body)
 }
 
 /// Remove a user from the org's Copilot subscription
@@ -433,7 +431,7 @@ pub fn add_user_to_copilot_subscription(org: &str, user: &str) -> Result<u32, Pl
 ///
 /// * `org` - The org owning the subscription
 /// * `user` - The user to remove from Copilot subscription
-pub fn remove_user_from_copilot_subscription(org: &str, user: &str) -> Result<u32, PlaidFunctionError> {
+pub fn remove_user_from_copilot_subscription(org: &str, user: &str) -> Result<String, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, remove_users_from_org_copilot);
     }
@@ -471,12 +469,10 @@ pub fn remove_user_from_copilot_subscription(org: &str, user: &str) -> Result<u3
 
     // This should be safe because unless the Plaid runtime is expressly trying
     // to mess with us, this came from a String in the API module.
-    let seats_cancelled = String::from_utf8(return_buffer)
-        .map_err(|_| PlaidFunctionError::InternalApiError)?;
-    let seats_cancelled: u32 = seats_cancelled.parse()
+    let response_body = String::from_utf8(return_buffer)
         .map_err(|_| PlaidFunctionError::InternalApiError)?;
 
-    Ok(seats_cancelled)
+    Ok(response_body)
 }
 
 /// TODO: Do not use this function, it is deprecated and will be removed soon

--- a/plaid/src/apis/github/copilot.rs
+++ b/plaid/src/apis/github/copilot.rs
@@ -39,7 +39,7 @@ impl Github {
     // Add users to the Copilot subscription for an organization
     // See https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#add-users-to-the-copilot-subscription-for-an-organization for more details
     // Returns the number of users successfully added to the subscription if the API call succeeds
-    pub async fn add_users_to_org_copilot(&self, params: &str, module: &str) -> Result<u32, ApiError> {
+    pub async fn add_users_to_org_copilot(&self, params: &str, module: &str) -> Result<String, ApiError> {
         #[derive(Deserialize, Serialize)]
         struct Request {
             #[serde(skip_serializing)]
@@ -69,7 +69,7 @@ impl Github {
                     let response: Response = serde_json::from_str(&body)
                         .map_err(|_| ApiError::GitHubError(GitHubError::BadResponse))?;
 
-                    Ok(response.seats_created)
+                    Ok(response.seats_created.to_string())
                 } else {
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
                         status,
@@ -84,7 +84,7 @@ impl Github {
     // Remove users from the Copilot subscription for an organization
     // See https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#remove-users-from-the-copilot-subscription-for-an-organization for more details
     // Returns the number of users successfully removed from the subscription if the API call succeeds
-    pub async fn remove_users_from_org_copilot(&self, params: &str, module: &str) -> Result<u32, ApiError> {
+    pub async fn remove_users_from_org_copilot(&self, params: &str, module: &str) -> Result<String, ApiError> {
         #[derive(Deserialize, Serialize)]
         struct Request {
             #[serde(skip_serializing)]
@@ -114,7 +114,7 @@ impl Github {
                     let response: Response = serde_json::from_str(&body)
                         .map_err(|_| ApiError::GitHubError(GitHubError::BadResponse))?;
 
-                    Ok(response.seats_cancelled)
+                    Ok(response.seats_cancelled.to_string())
                 } else {
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
                         status,

--- a/plaid/src/apis/github/copilot.rs
+++ b/plaid/src/apis/github/copilot.rs
@@ -38,7 +38,6 @@ impl Github {
 
     // Add users to the Copilot subscription for an organization
     // See https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#add-users-to-the-copilot-subscription-for-an-organization for more details
-    // Returns the number of users successfully added to the subscription if the API call succeeds
     pub async fn add_users_to_org_copilot(&self, params: &str, module: &str) -> Result<String, ApiError> {
         #[derive(Deserialize, Serialize)]
         struct Request {
@@ -58,18 +57,10 @@ impl Github {
 
         let address = format!("/orgs/{organization}/copilot/billing/selected_users");
 
-        #[derive(Deserialize, Serialize)]
-        struct Response {
-            seats_created: u32,
-        }
-
         match self.make_generic_post_request(address, &request, &module).await {
             Ok((status, Ok(body))) => {
                 if status == 201 {
-                    let response: Response = serde_json::from_str(&body)
-                        .map_err(|_| ApiError::GitHubError(GitHubError::BadResponse))?;
-
-                    Ok(response.seats_created.to_string())
+                    Ok(body)
                 } else {
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
                         status,
@@ -83,7 +74,6 @@ impl Github {
 
     // Remove users from the Copilot subscription for an organization
     // See https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#remove-users-from-the-copilot-subscription-for-an-organization for more details
-    // Returns the number of users successfully removed from the subscription if the API call succeeds
     pub async fn remove_users_from_org_copilot(&self, params: &str, module: &str) -> Result<String, ApiError> {
         #[derive(Deserialize, Serialize)]
         struct Request {
@@ -103,18 +93,10 @@ impl Github {
 
         let address = format!("/orgs/{organization}/copilot/billing/selected_users");
 
-        #[derive(Deserialize, Serialize)]
-        struct Response {
-            seats_cancelled: u32,
-        }
-
         match self.make_generic_delete_request(address, Some(&request), &module).await {
             Ok((status, Ok(body))) => {
                 if status == 200 {
-                    let response: Response = serde_json::from_str(&body)
-                        .map_err(|_| ApiError::GitHubError(GitHubError::BadResponse))?;
-
-                    Ok(response.seats_cancelled.to_string())
+                    Ok(body)
                 } else {
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
                         status,

--- a/plaid/src/apis/github/mod.rs
+++ b/plaid/src/apis/github/mod.rs
@@ -65,6 +65,7 @@ pub enum GitHubError {
     GraphQLRequestError(String),
     ClientError(octocrab::Error),
     InvalidInput(String),
+    BadResponse,
 }
 
 impl Github {

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -232,8 +232,6 @@ impl_new_function!(github, update_branch_protection_rule);
 impl_new_function!(github, create_environment_for_repo);
 impl_new_function!(github, configure_secret);
 impl_new_function!(github, create_deployment_branch_protection_rule);
-impl_new_function!(github, add_users_to_org_copilot);
-impl_new_function!(github, remove_users_from_org_copilot);
 
 impl_new_function_with_error_buffer!(github, make_graphql_query);
 impl_new_function_with_error_buffer!(github, make_advanced_graphql_query);
@@ -244,6 +242,8 @@ impl_new_function_with_error_buffer!(github, get_branch_protection_rules);
 impl_new_function_with_error_buffer!(github, get_repository_collaborators);
 impl_new_function_with_error_buffer!(github, search_for_file);
 impl_new_function_with_error_buffer!(github, list_seats_in_org_copilot);
+impl_new_function_with_error_buffer!(github, add_users_to_org_copilot);
+impl_new_function_with_error_buffer!(github, remove_users_from_org_copilot);
 
 // GitHub Functions only available with GitHub App authentication
 impl_new_function!(github, review_fpat_requests_for_org);


### PR DESCRIPTION
Upon a successful Copilot API call, we'll return the response body from Github. This will include the number of modifications (seats removed/seats added).

This will allow the rules to handle cases where the API call returns a success status code but no modification took place due to various reasons like the person already subscribed or already removed.