### PR TITLE
Rewrite logging system to be asynchronous

### DIFF
--- a/plaid/src/data/websocket/mod.rs
+++ b/plaid/src/data/websocket/mod.rs
@@ -220,7 +220,9 @@ impl WebsocketGenerator {
                         return;
                     };
 
-                    logger.log_websocket_dropped(socket_name).unwrap();
+                    if let Err(e) = logger.log_websocket_dropped(socket_name).await {
+                        error!("Failed to send to logging system. Error: {e}")
+                    }
 
                     client.uri_selector.mark_failed();
                 }

--- a/plaid/src/executor/mod.rs
+++ b/plaid/src/executor/mod.rs
@@ -194,7 +194,7 @@ fn prepare_for_execution(
     let exports = match link_functions_to_module(&plaid_module.module, &mut store, env.clone()) {
         Ok(exports) => exports,
         Err(e) => {
-            els.log_module_error(
+            els.log_module_error_sync(
                 plaid_module.name.clone(),
                 format!("Failed to link functions to module: {:?}", e),
                 message.data.clone(),
@@ -216,7 +216,7 @@ fn prepare_for_execution(
     let instance = match Instance::new(&mut store, &plaid_module.module, &imports) {
         Ok(i) => i,
         Err(e) => {
-            els.log_module_error(
+            els.log_module_error_sync(
                 plaid_module.name.clone(),
                 format!("Failed to instantiate module: {e}"),
                 message.data.clone(),
@@ -232,7 +232,7 @@ fn prepare_for_execution(
     data_mut.memory = match instance.exports.get_memory("memory") {
         Ok(memory) => Some(memory.clone()),
         Err(e) => {
-            els.log_module_error(
+            els.log_module_error_sync(
                 plaid_module.name.clone(),
                 format!("Failed to get memory from module: {e}"),
                 message.data.clone(),
@@ -355,7 +355,7 @@ fn execution_loop(
             ) {
                 Ok((store, instance, ep, env)) => (store, instance, ep, env),
                 Err(e) => {
-                    els.log_module_error(
+                    els.log_module_error_sync(
                         plaid_module.name.clone(),
                         format!("Failed to prepare for execution: {e}"),
                         message.data.clone(),
@@ -379,7 +379,7 @@ fn execution_loop(
                             let computation_remaining_percentage =
                                 (remaining as f32 / computation_limit as f32) * 100.;
                             let computation_used = 100. - computation_remaining_percentage;
-                            els.log_ts(
+                            els.log_ts_sync(
                                 format!("{}_computation_percentage_used", plaid_module.name),
                                 computation_used as i64,
                             )?;
@@ -392,7 +392,7 @@ fn execution_loop(
 
             // If there was an error then log that it happened to the els
             if let Some(error) = error {
-                els.log_module_error(
+                els.log_module_error_sync(
                     plaid_module.name.clone(),
                     format!("{error}"),
                     message.data.clone(),
@@ -494,7 +494,7 @@ impl Executor {
                         let computation_remaining_percentage =
                             (remaining as f32 / computation_limit as f32) * 100.;
                         let computation_used = 100. - computation_remaining_percentage;
-                        self.els.log_ts(
+                        self.els.log_ts_sync(
                             format!("{}_immediate_computation_percentage_used", name),
                             computation_used as i64,
                         )?;

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -10,7 +10,7 @@ macro_rules! impl_new_function {
                 let store = env.as_store_ref();
                 let env_data = env.data();
 
-                if let Err(e) = env_data.external_logging_system.log_function_call(env_data.name.clone(), stringify!([< $api _ $function_name >]).to_string()) {
+                if let Err(e) = env_data.external_logging_system.log_function_call_sync(env_data.name.clone(), stringify!([< $api _ $function_name >]).to_string()) {
                     error!("Logging system is not working!!: {:?}", e);
                     return Err(FunctionErrors::InternalApiError);
                 }
@@ -70,7 +70,7 @@ macro_rules! impl_new_function_with_error_buffer {
                 let store = env.as_store_ref();
                 let env_data = env.data();
 
-                if let Err(e) = env_data.external_logging_system.log_function_call(env_data.name.clone(), stringify!([< $api _ $function_name >]).to_string()) {
+                if let Err(e) = env_data.external_logging_system.log_function_call_sync(env_data.name.clone(), stringify!([< $api _ $function_name >]).to_string()) {
                     error!("Logging system is not working!!: {:?}", e);
                     return Err(FunctionErrors::InternalApiError);
                 }
@@ -158,7 +158,7 @@ macro_rules! impl_new_sub_module_function_with_error_buffer {
                 let env_data = env.data();
 
                 // Log function call by module
-                if let Err(e) = env_data.external_logging_system.log_function_call(env_data.name.clone(), stringify!([< $api _ $sub_module _ $function_name >]).to_string()) {
+                if let Err(e) = env_data.external_logging_system.log_function_call_sync(env_data.name.clone(), stringify!([< $api _ $sub_module _ $function_name >]).to_string()) {
                     error!("Logging system is not working!!: {:?}", e);
                     return Err(FunctionErrors::InternalApiError);
                 }
@@ -346,7 +346,7 @@ pub fn to_api_function(
         }
         "cache_get" => Function::new_typed_with_env(&mut store, &env, super::internal::cache_get),
         "log_back" => Function::new_typed_with_env(&mut store, &env, super::internal::log_back),
-        
+
         // Npm Calls
         "npm_publish_empty_stub" => {
             Function::new_typed_with_env(&mut store, &env, npm_publish_empty_stub)
@@ -368,9 +368,7 @@ pub fn to_api_function(
             Function::new_typed_with_env(&mut store, &env, npm_list_granular_tokens)
         }
 
-        "npm_delete_package" => {
-            Function::new_typed_with_env(&mut store, &env, npm_delete_package)
-        }
+        "npm_delete_package" => Function::new_typed_with_env(&mut store, &env, npm_delete_package),
 
         "npm_add_user_to_team" => {
             Function::new_typed_with_env(&mut store, &env, npm_add_user_to_team)
@@ -403,7 +401,7 @@ pub fn to_api_function(
         "npm_get_token_details" => {
             Function::new_typed_with_env(&mut store, &env, npm_get_token_details)
         }
-        
+
         // Okta Calls
         "okta_remove_user_from_group" => {
             Function::new_typed_with_env(&mut store, &env, okta_remove_user_from_group)
@@ -432,12 +430,8 @@ pub fn to_api_function(
         "github_fetch_commit" => {
             Function::new_typed_with_env(&mut store, &env, github_fetch_commit)
         }
-        "github_list_files" => {
-            Function::new_typed_with_env(&mut store, &env, github_list_files)
-        }
-        "github_fetch_file" => {
-            Function::new_typed_with_env(&mut store, &env, github_fetch_file)
-        }
+        "github_list_files" => Function::new_typed_with_env(&mut store, &env, github_list_files),
+        "github_fetch_file" => Function::new_typed_with_env(&mut store, &env, github_fetch_file),
         "github_list_fpat_requests_for_org" => {
             Function::new_typed_with_env(&mut store, &env, github_list_fpat_requests_for_org)
         }
@@ -462,9 +456,11 @@ pub fn to_api_function(
         "github_configure_secret" => {
             Function::new_typed_with_env(&mut store, &env, github_configure_secret)
         }
-        "github_create_deployment_branch_protection_rule" => {
-            Function::new_typed_with_env(&mut store, &env, github_create_deployment_branch_protection_rule)
-        }
+        "github_create_deployment_branch_protection_rule" => Function::new_typed_with_env(
+            &mut store,
+            &env,
+            github_create_deployment_branch_protection_rule,
+        ),
         "github_search_for_file" => {
             Function::new_typed_with_env(&mut store, &env, github_search_for_file)
         }

--- a/plaid/src/functions/internal.rs
+++ b/plaid/src/functions/internal.rs
@@ -419,7 +419,7 @@ pub fn cache_insert(
         }
         Ok(None) => 0,
         Err(e) => {
-            if let Err(e) = env_data.external_logging_system.log_internal_message(
+            if let Err(e) = env_data.external_logging_system.log_internal_message_sync(
                 crate::logging::Severity::Error,
                 format!("Cache system error in [{}]: {:?}", env_data.name, e),
             ) {
@@ -480,7 +480,7 @@ pub fn cache_get(
         }
         Ok(None) => 0,
         Err(e) => {
-            if let Err(e) = env_data.external_logging_system.log_internal_message(
+            if let Err(e) = env_data.external_logging_system.log_internal_message_sync(
                 crate::logging::Severity::Error,
                 format!("Cache system error in [{}]: {:?}", env_data.name, e),
             ) {

--- a/plaid/src/logging/mod.rs
+++ b/plaid/src/logging/mod.rs
@@ -106,7 +106,7 @@ where
 /// Default value for `hearbeat_interval` in `LoggingConfiguration` in the event
 /// that one is not provided
 fn default_log_heartbeat_interval() -> Duration {
-    Duration::from_secs(3)
+    Duration::from_secs(300)
 }
 
 #[derive(Debug)]

--- a/plaid/src/logging/stdout.rs
+++ b/plaid/src/logging/stdout.rs
@@ -1,4 +1,4 @@
-use super::{Log, LoggingError, PlaidLogger, Severity, WrappedLog};
+use super::{Log, Severity, WrappedLog};
 
 use serde::Deserialize;
 
@@ -13,8 +13,8 @@ impl StdoutLogger {
     }
 }
 
-impl PlaidLogger for StdoutLogger {
-    fn send_log(&self, log: &WrappedLog) -> Result<(), LoggingError> {
+impl StdoutLogger {
+    pub fn send_log(&self, log: &WrappedLog) {
         match &log.log {
             Log::InternalMessage { severity, message } => match severity {
                 Severity::Error => error!("{}", message),
@@ -35,6 +35,5 @@ impl PlaidLogger for StdoutLogger {
             }
             Log::Heartbeat { .. } => (),
         }
-        Ok(())
     }
 }

--- a/plaid/src/logging/webhook.rs
+++ b/plaid/src/logging/webhook.rs
@@ -3,8 +3,6 @@ use super::{LoggingError, PlaidLogger, WrappedLog};
 use serde::Deserialize;
 use std::time::Duration;
 
-use tokio::runtime::Handle;
-
 /// The struct that defines the Webhook specific configuration of the logging
 /// service.
 #[derive(Deserialize)]
@@ -16,30 +14,24 @@ pub struct Config {
 
 /// The specific logger that is configured from the `Config` struct.
 pub struct WebhookLogger {
-    /// A tokio runtime to send logs on
-    runtime: Handle,
     /// A reqwest client configured with the Splunk endpoint and authentication
     client: reqwest::Client,
     /// The configuration struct
     config: Config,
 }
 
-
 impl WebhookLogger {
     /// Implement the new function for the Splunk logger. This converts
     /// the configuration struct into a type that can handle sending
     /// logs directly to a Splunk HEC endpoint.
-    pub fn new(config: Config, handle: Handle) -> Self {
+    pub fn new(config: Config) -> Self {
         // I don't think this can fail with our settings so we do an unwrap
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(config.timeout.into()))
-            .build().unwrap();
+            .build()
+            .unwrap();
 
-        Self {
-            runtime: handle,
-            client,
-            config,
-        }
+        Self { client, config }
     }
 }
 
@@ -48,28 +40,29 @@ impl PlaidLogger for WebhookLogger {
     /// will not block sending logs to other services (like stdout) but it
     /// does mean we cannot return a proper LoggingError to the caller since
     /// we cannot wait for it to complete.
-    fn send_log(&self, log: &WrappedLog) -> Result<(), LoggingError> {
+    async fn send_log(&self, log: &WrappedLog) -> Result<(), LoggingError> {
         let data = match serde_json::to_string(&log) {
             Ok(json) => json,
-            Err(e) => return Err(LoggingError::SerializationError(e.to_string()))
+            Err(e) => return Err(LoggingError::SerializationError(e.to_string())),
         };
 
-        let res = self.client.post(&self.config.url)
+        let res = self
+            .client
+            .post(&self.config.url)
             .header("Content-Type", "application/x-www-form-urlencoded")
             .header("Content-Length", data.len())
             .body(data);
-        
+
         let res = if let Some(auth) = &self.config.auth_header {
             res.header("Authorization", auth)
         } else {
             res
         };
 
-        self.runtime.spawn(async move {
-            match res.send().await {
-                Ok(_) => (),
-                Err(e) => error!("Could not log to webhook: {}", e.to_string()),
-            };
+        tokio::task::spawn(async {
+            if let Err(e) = res.send().await {
+                error!("Could not log to webhook: {}", e.to_string());
+            }
         });
 
         Ok(())


### PR DESCRIPTION
I have a theory that the logging system is more resource intensive than we need it to be. Given that the logging loop is synchronous, we spend a lot of CPU time busy waiting for logs to come in, effectively pinning an entire thread that could be better utilized for rule execution. To mitigate this, I refactored the logging system to make it async. This comes with a few changes, notably:
- Replacing `crossbeam_channel` (synchronous) with `tokio::sync::mpsc` (asynchronous). This allows us to call `channel.recv().await` in the logging loop (with a timeout so we can still heartbeat log) instead of `recv_timeout`, freeing up the logging thread for use by other parts of the runtime
- The need for async and sync `log_xyz` functions
  - There's places in the runtime (executor for example) that are synchronous and cannot await an async logging call. A synchronous log_xyz calls blocking_send instead of send on the logging channel
- Removing the `PlaidLogger` trait on the stdout logger - making the logger async means the `send_log` method in the trait must be async as well. stdout logging is obviously not async and shouldn't implement this trait. Right now `send_log` is just an impl of `StdoutLogger`