### PR TITLE
Fix return value for npm token generation

### DIFF
--- a/plaid/src/apis/npm/npm_web_client.rs
+++ b/plaid/src/apis/npm/npm_web_client.rs
@@ -291,7 +291,11 @@ impl Npm {
             .await
             .map_err(|_| ApiError::NpmError(NpmError::TokenGenerationError))?
             .get("newToken")
-            .map(|v| Ok(v.to_string()))
+            .map(|v| {
+                Ok(v.as_str()
+                    .ok_or(ApiError::NpmError(NpmError::TokenGenerationError))?
+                    .to_string())
+            })
             .ok_or(ApiError::NpmError(NpmError::TokenGenerationError))?
     }
 


### PR DESCRIPTION
The problem is that `Value`s are returned in JSON format. This was in turn causing problems downstream.
The temporary solution is for the caller downstream to remove all `"` characters from the result, but this is the permanent fix.