### PR TITLE
Add log_back_unlimited API

### DIFF
--- a/plaid-stl/src/plaid/mod.rs
+++ b/plaid-stl/src/plaid/mod.rs
@@ -23,6 +23,35 @@ pub fn log_back(type_: &str, log: &[u8], delay: u32) -> Result<(), i32> {
     log_back_with_budget(type_, log, delay, 0)
 }
 
+/// Send a log to the logback system with unlimited extra budget to trigger
+/// further invocations. Whoever will pick up the message will also have an
+/// unlimited budget for future invocations.
+pub fn log_back_unlimited(type_: &str, log: &[u8], delay: u32) -> Result<(), i32> {
+    extern "C" {
+        /// Send a log to the logback system
+        fn log_back_unlimited(
+            type_: *const u8,
+            type_len: usize,
+            log: *const u8,
+            log_len: usize,
+            delay: u32,
+        ) -> u32;
+    }
+
+    let type_bytes = type_.as_bytes().to_vec();
+    unsafe {
+        log_back_unlimited(
+            type_bytes.as_ptr(),
+            type_bytes.len(),
+            log.as_ptr(),
+            log.len(),
+            delay,
+        );
+    };
+
+    Ok(())
+}
+
 /// Send a log to the logback system with a budget to trigger further
 /// invoations. The requested budget will be substracted from this invocation's
 /// budget and the call will fail if it is exceeded. Calling this function itself

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -346,6 +346,7 @@ pub fn to_api_function(
         }
         "cache_get" => Function::new_typed_with_env(&mut store, &env, super::internal::cache_get),
         "log_back" => Function::new_typed_with_env(&mut store, &env, super::internal::log_back),
+        "log_back_unlimited" => Function::new_typed_with_env(&mut store, &env, super::internal::log_back_unlimited),
         
         // Npm Calls
         "npm_publish_empty_stub" => {


### PR DESCRIPTION
This PR adds an API for rules to log back with unlimited budget.

Until now, rules could log back either with 0 budget for further invocations, or with a fixed budget. This would not allow one to implement a use case where something needs to continue forever at regular intervals.

Instead, with this change, a rule that picks up a message with unlimited budget can trigger further invocations with unlimited budget.

### Backward compatibility
The change is backward compatible: existing APIs are left untouched and a new API is added.

### Security considerations
Malicious rules could use this feature to try and mount a DOS attack against the runtime, by triggering an endless sequence of log backs. In the future, the problem might be addressed by allowing one to specify which rules are trusted to use this feature.

### Extra notes
There is no API for a rule to query the number of invocations left. If there was, one could approximate the use case above by starting with a high budget and, each time, logging back with budget `what_we_had_before - 1`. Such an API might be added in the future.