### PR TITLE
Add Slack API to retrieve ID from email

### DIFF
--- a/plaid-stl/src/slack/mod.rs
+++ b/plaid-stl/src/slack/mod.rs
@@ -160,3 +160,38 @@ pub fn views_open(bot: &str, view: &str) -> Result<(), PlaidFunctionError> {
 
     Ok(())
 }
+
+/// Get a Slack user's ID from their email address
+pub fn get_id_from_email(bot: &str, email: &str) -> Result<String, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(slack, get_id_from_email);
+    }
+    const RETURN_BUFFER_SIZE: usize = 32 * 1024; // 32 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let mut params: HashMap<&'static str, &str> = HashMap::new();
+    params.insert("bot", bot);
+    params.insert("email", email);
+
+    let params = serde_json::to_string(&params).unwrap();
+
+    let res = unsafe {
+        slack_get_id_from_email(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    let res = String::from_utf8(return_buffer).unwrap();
+
+    Ok(res)
+}

--- a/plaid/src/apis/slack/api.rs
+++ b/plaid/src/apis/slack/api.rs
@@ -1,12 +1,15 @@
 use std::collections::HashMap;
 
-use crate::apis::{ApiError, slack::SlackError};
+use serde::{Deserialize, Serialize};
+
+use crate::apis::{slack::SlackError, ApiError};
 
 use super::Slack;
 
 enum Apis {
     PostMessage,
     ViewsOpen,
+    LookupByEmail,
 }
 
 impl std::fmt::Display for Apis {
@@ -14,60 +17,123 @@ impl std::fmt::Display for Apis {
         match &self {
             Self::PostMessage => write!(f, "chat.postMessage"),
             Self::ViewsOpen => write!(f, "views.open"),
+            Self::LookupByEmail => write!(f, "users.lookupByEmail"),
         }
     }
 }
 
+/// Slack user profile as returned by https://api.slack.com/methods/users.lookupByEmail
+#[derive(Serialize, Deserialize)]
+struct SlackUserProfile {
+    user: SlackUser,
+}
+
+#[derive(Serialize, Deserialize)]
+struct SlackUser {
+    id: String,
+}
+
 impl Slack {
-    async fn call_slack(&self, params: &str, api: Apis) -> Result<u32, ApiError> {
-        let request: HashMap<String, String> = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+    /// Get token for a bot, if present
+    fn get_token(&self, bot: &str) -> Result<String, ()> {
+        let token = self.config.bot_tokens.get(bot).ok_or(())?;
+        Ok(format!("Bearer {token}"))
+    }
 
-        // GitHub says this is only valid on Organization repositories. Not sure if it's ignored
-        // on others? This may not work on standard accounts. Also, pull is the lowest permission level
-        let bot = request.get("bot").ok_or(ApiError::MissingParameter("bot".to_string()))?.to_string();
-        let body = request.get("body").ok_or(ApiError::MissingParameter("body".to_string()))?.to_string();
+    async fn call_slack(&self, params: &str, api: Apis) -> Result<String, ApiError> {
+        let request: HashMap<String, String> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let token = match self.config.bot_tokens.get(&bot) {
-            Some(h) => format!("Bearer {h}"),
-            None => {
-                error!("A module tried to call api {api} for a bot that didn't exist: {bot}");
-                return Err(ApiError::SlackError(SlackError::UnknownBot(bot.to_string())));
-            }
-        };
+        let bot = request
+            .get("bot")
+            .ok_or(ApiError::MissingParameter("bot".to_string()))?
+            .to_string();
+
+        let token = self.get_token(&bot).map_err(|_| {
+            error!("A module tried to call api {api} for a bot that didn't exist: {bot}");
+            ApiError::SlackError(SlackError::UnknownBot(bot.to_string()))
+        })?;
 
         info!("Calling {api} for bot: {bot}");
-        match self
-            .client
-            .post(format!("https://slack.com/api/{api}"))
-            .header("Authorization", token)
-            .header("Content-Type", "application/json; charset=utf-8")
-            .body(body)
-            .send()
-            .await
-        {
-            Ok(r) => {
-                let status = r.status();
-                if status == 200 {
-                    return Ok(0);
-                }
-                let response = r.text().await;
-                error!("Slack data returned: {}", response.unwrap_or_default());
+        match api {
+            Apis::PostMessage | Apis::ViewsOpen => {
+                // It's a POST call
+                let body = request
+                    .get("body")
+                    .ok_or(ApiError::MissingParameter("body".to_string()))?
+                    .to_string();
+                match self
+                    .client
+                    .post(format!("https://slack.com/api/{api}"))
+                    .header("Authorization", token)
+                    .header("Content-Type", "application/json; charset=utf-8")
+                    .body(body)
+                    .send()
+                    .await
+                {
+                    Ok(r) => {
+                        let status = r.status();
+                        if status == 200 {
+                            return Ok("".to_string());
+                        }
+                        let response = r.text().await;
+                        error!("Slack data returned: {}", response.unwrap_or_default());
 
-                return Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(status.as_u16())))
+                        return Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(
+                            status.as_u16(),
+                        )));
+                    }
+                    Err(e) => return Err(ApiError::NetworkError(e)),
+                }
             }
-            Err(e) => return Err(ApiError::NetworkError(e))
+            Apis::LookupByEmail => {
+                // It's a GET call
+                let email = request
+                    .get("email")
+                    .ok_or(ApiError::MissingParameter("email".to_string()))?
+                    .to_string();
+                match self
+                    .client
+                    .get(format!("https://slack.com/api/{api}?email={email}"))
+                    .header("Authorization", token)
+                    .send()
+                    .await
+                {
+                    Ok(r) => {
+                        let status = r.status();
+                        if status == 200 {
+                            let response = r.json::<SlackUserProfile>().await.map_err(|_| {
+                                ApiError::SlackError(SlackError::UnexpectedPayload(
+                                    "could not deserialize to Slack user profile".to_string(),
+                                ))
+                            })?;
+                            return Ok(response.user.id);
+                        }
+                        error!("Failed to retrieve user's Slack ID");
+                        return Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(
+                            status.as_u16(),
+                        )));
+                    }
+                    Err(e) => return Err(ApiError::NetworkError(e)),
+                }
+            }
         }
     }
 
     /// Open an arbitrary view for a configured bot. The view contents is defined by the caller but the bot
     /// must be configured in Plaid.
-    pub async fn views_open(&self, params: &str,  _: &str) -> Result<u32, ApiError> {
-        self.call_slack(params, Apis::ViewsOpen).await
+    pub async fn views_open(&self, params: &str, _: &str) -> Result<u32, ApiError> {
+        self.call_slack(params, Apis::ViewsOpen).await.map(|_| 0)
     }
 
     /// Call the Slack postMessage API. The message and location are defined by the module but the bot
     /// must be configured in Plaid.
-    pub async fn post_message(&self, params: &str,  _: &str) -> Result<u32, ApiError>  {
-        self.call_slack(params, Apis::PostMessage).await
+    pub async fn post_message(&self, params: &str, _: &str) -> Result<u32, ApiError> {
+        self.call_slack(params, Apis::PostMessage).await.map(|_| 0)
+    }
+
+    /// Calls the Slack API to retrieve a user's Slack ID from their email address
+    pub async fn get_id_from_email(&self, params: &str, _: &str) -> Result<String, ApiError> {
+        self.call_slack(params, Apis::LookupByEmail).await
     }
 }

--- a/plaid/src/apis/slack/mod.rs
+++ b/plaid/src/apis/slack/mod.rs
@@ -35,6 +35,7 @@ pub enum SlackError {
     UnknownHook(String),
     UnknownBot(String),
     UnexpectedStatusCode(u16),
+    UnexpectedPayload(String),
 }
 
 impl Slack {

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -288,6 +288,7 @@ impl_new_function_with_error_buffer!(rustica, new_mtls_cert);
 // Slack Functions
 impl_new_function!(slack, views_open);
 impl_new_function!(slack, post_message);
+impl_new_function_with_error_buffer!(slack, get_id_from_email);
 impl_new_function!(slack, post_to_arbitrary_webhook);
 impl_new_function!(slack, post_to_named_webhook);
 
@@ -488,6 +489,7 @@ pub fn to_api_function(
         }
         "slack_post_message" => Function::new_typed_with_env(&mut store, &env, slack_post_message),
         "slack_views_open" => Function::new_typed_with_env(&mut store, &env, slack_views_open),
+        "slack_get_id_from_email" => Function::new_typed_with_env(&mut store, &env, slack_get_id_from_email),
 
         // General Calls
         "general_simple_json_post_request" => {


### PR DESCRIPTION
This PR adds a Slack API call to retrieve a Slack ID from a user's email address. See https://api.slack.com/methods/users.lookupByEmail for more information.

@obelisk Perhaps it would make more sense to return a richer Slack user profile and then let the caller pick only the parts that are needed (i.e., the ID). What do you think?

This is also the first GET request we make to the Slack API, so the client code has been rearranged to allow for this and be easily expandable in the future.