### PR TITLE
Parse Copilot datetime in plaid-stl and add function to remove multiple Copilot seats

### DIFF
--- a/plaid-stl/src/datetime.rs
+++ b/plaid-stl/src/datetime.rs
@@ -1,0 +1,18 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Deserializer};
+
+// Custom deserializer for an optional DateTime<Utc>
+pub fn deserialize_option_timestamp<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Try to deserialize as a string (ISO 8601 format) or return None if missing
+    let opt = Option::<String>::deserialize(deserializer)?;
+
+    // Parse the timestamp string into a DateTime<Utc>, if it's present
+    Ok(opt.and_then(|s| {
+        DateTime::parse_from_rfc3339(&s)
+            .ok()
+            .map(|dt| dt.with_timezone(&Utc))
+    }))
+}

--- a/plaid-stl/src/github/mod.rs
+++ b/plaid-stl/src/github/mod.rs
@@ -497,6 +497,57 @@ pub fn remove_user_from_copilot_subscription(org: &str, user: &str) -> Result<Co
     Ok(response_body)
 }
 
+/// Remove multiple users from the org's Copilot subscription
+/// ## Arguments
+///
+/// * `org` - The org owning the subscription
+/// * `users` - The list of users to remove from Copilot subscription
+pub fn remove_users_from_copilot_subscription(org: &str, users: Vec<&str>) -> Result<CopilotRemoveUsersResponse, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(github, remove_users_from_org_copilot);
+    }
+
+    #[derive(Serialize)]
+    struct Params<'a> {
+        org: &'a str,
+        selected_usernames: Vec<&'a str>,
+    }
+    let params = Params {
+        org,
+        selected_usernames: users,
+    };
+
+    const RETURN_BUFFER_SIZE: usize = 1024; // 1 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let params = serde_json::to_string(&params).unwrap();
+    let res = unsafe {
+        github_remove_users_from_org_copilot(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    let response_body = String::from_utf8(return_buffer)
+        .map_err(|_| PlaidFunctionError::InternalApiError)?;
+    let response_body = serde_json::from_str::<CopilotRemoveUsersResponse>(&response_body)
+        .map_err(|_| PlaidFunctionError::InternalApiError)?;
+
+    Ok(response_body)
+}
+
 /// TODO: Do not use this function, it is deprecated and will be removed soon
 pub fn add_user_to_repo(repo: &str, user: &str, permission: Option<&str>) -> Result<(), i32> {
     add_user_to_repo_detailed(repo, user, permission).map_err(|_| -4)

--- a/plaid-stl/src/github/mod.rs
+++ b/plaid-stl/src/github/mod.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, fmt::Display};
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize, Deserializer};
+use serde::{Deserialize, Serialize};
 
-use crate::PlaidFunctionError;
+use crate::{PlaidFunctionError, datetime::deserialize_option_timestamp};
 
 pub enum ReviewPatAction {
     Approve,
@@ -54,22 +54,6 @@ pub struct CopilotSeat {
     // Deserialize the date field from the ISO 8601 format
     #[serde(default, deserialize_with = "deserialize_option_timestamp")]
     pub updated_at: Option<DateTime<Utc>>,
-}
-
-// Custom deserializer for an optional DateTime<Utc>
-fn deserialize_option_timestamp<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    // Try to deserialize as a string (ISO 8601 format) or return None if missing
-    let opt = Option::<String>::deserialize(deserializer)?;
-
-    // Parse the timestamp string into a DateTime<Utc>, if it's present
-    Ok(opt.and_then(|s| {
-        DateTime::parse_from_rfc3339(&s)
-            .ok()
-            .map(|dt| dt.with_timezone(&Utc))
-    }))
 }
 
 #[derive(Debug, Deserialize)]

--- a/plaid-stl/src/github/mod.rs
+++ b/plaid-stl/src/github/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fmt::Display};
-
-use serde::{Deserialize, Serialize};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize, Deserializer};
 
 use crate::PlaidFunctionError;
 
@@ -44,8 +44,32 @@ pub struct CopilotAssignee {
 /// A seat in a Github Org Copilot subscription
 pub struct CopilotSeat {
     pub assignee: CopilotAssignee,
-    pub last_activity_at: Option<String>,
     pub plan_type: String,
+    // Deserialize the date field from the ISO 8601 format
+    #[serde(default, deserialize_with = "deserialize_option_timestamp")]
+    pub last_activity_at: Option<DateTime<Utc>>,
+    // Deserialize the date field from the ISO 8601 format
+    #[serde(default, deserialize_with = "deserialize_option_timestamp")]
+    pub created_at: Option<DateTime<Utc>>,
+    // Deserialize the date field from the ISO 8601 format
+    #[serde(default, deserialize_with = "deserialize_option_timestamp")]
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+// Custom deserializer for an optional DateTime<Utc>
+fn deserialize_option_timestamp<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Try to deserialize as a string (ISO 8601 format) or return None if missing
+    let opt = Option::<String>::deserialize(deserializer)?;
+
+    // Parse the timestamp string into a DateTime<Utc>, if it's present
+    Ok(opt.and_then(|s| {
+        DateTime::parse_from_rfc3339(&s)
+            .ok()
+            .map(|dt| dt.with_timezone(&Utc))
+    }))
 }
 
 #[derive(Debug, Deserialize)]

--- a/plaid-stl/src/lib.rs
+++ b/plaid-stl/src/lib.rs
@@ -75,6 +75,7 @@ pub mod web;
 pub mod yubikey;
 
 pub mod messages;
+pub mod datetime;
 
 //pub use ::plaid::LogSource;
 

--- a/plaid-stl/src/npm/shared_structs/mod.rs
+++ b/plaid-stl/src/npm/shared_structs/mod.rs
@@ -3,8 +3,9 @@
 //! host / guest boundary.
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use std::fmt::Display;
+use crate::datetime::deserialize_option_timestamp;
 
 /// Permission that is granted to a team over an npm package
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -170,22 +171,6 @@ pub struct NpmToken {
     // Deserialize the date field from the ISO 8601 format
     #[serde(default, deserialize_with = "deserialize_option_timestamp")]
     pub expires: Option<DateTime<Utc>>,
-}
-
-// Custom deserializer for an optional DateTime<Utc>
-fn deserialize_option_timestamp<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    // Try to deserialize as a string (ISO 8601 format) or return None if missing
-    let opt = Option::<String>::deserialize(deserializer)?;
-
-    // Parse the timestamp string into a DateTime<Utc>, if it's present
-    Ok(opt.and_then(|s| {
-        DateTime::parse_from_rfc3339(&s)
-            .ok()
-            .map(|dt| dt.with_timezone(&Utc))
-    }))
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
- Parse datetime returned from Copilot API in plaid-stl: I realized the npm module of plaid-stl does parse datetime strings returned from APIs. I think parsing it in the plaid-stl would make it much easier to write rules. Also, I need to add the `created_at` field to handle cases where people literally never used their Copilot membership before.
- Add Copilot function to remove multiple users: Initially I wanted to remove user one by one so we specifically tell if the removal took effect from looking at `seats_cancelled`. But I think we'll just remove multiple users at once and let Github attempts it on a best-effort basis.