### PR TITLE
Modify GitHub data generator to work with GitHub app credentials

### DIFF
--- a/plaid/resources/plaid.toml
+++ b/plaid/resources/plaid.toml
@@ -149,6 +149,20 @@ secret_key = ""
 # sleep_duration = 100 ## This means the message is sent every 0.1 seconds
 # [data.websocket."websockets"."demo_rpc_call"."headers"]
 
+# [data.github]
+# org = ""
+# log_type = "Web" # Can be one of Web, Git, All
+
+# Authentication using FPAT
+# [data.github.authentication]
+# token = ""
+
+# Authentication using GitHub App Creds
+## [data.github.authentication]
+## app_id = 1234
+## installation_id = 1234
+## private_key = ""
+
 [webhooks."internal"]
 listen_address = "0.0.0.0:4554"
 [webhooks."internal".webhooks."AAAA"]

--- a/plaid/src/apis/github/mod.rs
+++ b/plaid/src/apis/github/mod.rs
@@ -70,38 +70,8 @@ pub enum GitHubError {
 
 impl Github {
     pub fn new(config: GithubConfig) -> Self {
-        let client_builder = match &config.authentication {
-            Authentication::Token { token } => {
-                info!("Configuring GitHub API with GitHub PAT");
-                Octocrab::builder().personal_token(token.clone())
-            }
-            Authentication::App {
-                app_id,
-                private_key,
-                ..
-            } => {
-                info!("Configuring GitHub API with GitHub App");
-                let encoding_key = EncodingKey::from_rsa_pem(private_key.as_bytes())
-                    .expect("Failed to create encoding key from private key for GitHub API");
+        let client = build_github_client(&config.authentication);
 
-                Octocrab::builder().app((*app_id).into(), encoding_key)
-            }
-        }
-        .add_header(
-            USER_AGENT,
-            format!("Rust/Plaid{}", env!("CARGO_PKG_VERSION")),
-        );
-
-        let mut client = client_builder
-            .build()
-            .expect("Failed to create GitHub client");
-
-        if let Authentication::App {
-            installation_id, ..
-        } = &config.authentication
-        {
-            client = client.installation((*installation_id).into());
-        }
         // Create all the validators and compile all the regexes. If the module contains
         // any invalid regexes it will panic.
         let validators = validators::create_validators();
@@ -194,7 +164,7 @@ impl Github {
     /// to help facilitate the conversion from a token usage to GitHub app. It also means that
     /// extra parsing can be avoided since we need to re-serialize anyway to pass back to the rules
     /// (at least currently).
-    async fn make_generic_delete_request<T: Serialize> (
+    async fn make_generic_delete_request<T: Serialize>(
         &self,
         uri: String,
         body: Option<&T>,
@@ -215,4 +185,42 @@ impl Github {
             Err(e) => Err(ApiError::GitHubError(GitHubError::ClientError(e))),
         }
     }
+}
+
+/// Builds an instance of a Github API client
+pub fn build_github_client(authentication: &Authentication) -> Octocrab {
+    let client_builder = match authentication {
+        Authentication::Token { token } => {
+            info!("Configuring GitHub client with GitHub PAT");
+            Octocrab::builder().personal_token(token.clone())
+        }
+        Authentication::App {
+            app_id,
+            private_key,
+            ..
+        } => {
+            info!("Configuring GitHub client with GitHub App");
+            let encoding_key = EncodingKey::from_rsa_pem(private_key.as_bytes())
+                .expect("Failed to create encoding key from private key for GitHub API");
+
+            Octocrab::builder().app((*app_id).into(), encoding_key)
+        }
+    }
+    .add_header(
+        USER_AGENT,
+        format!("Rust/Plaid{}", env!("CARGO_PKG_VERSION")),
+    );
+
+    let mut client = client_builder
+        .build()
+        .expect("Failed to create GitHub client");
+
+    if let Authentication::App {
+        installation_id, ..
+    } = authentication
+    {
+        client = client.installation((*installation_id).into());
+    }
+
+    client
 }

--- a/plaid/src/data/github/mod.rs
+++ b/plaid/src/data/github/mod.rs
@@ -101,7 +101,7 @@ where
         "git" => Ok(LogType::Git),
         "all" => Ok(LogType::All),
         _ => Err(serde::de::Error::custom(
-            "Invalid log tpye provided. Expected one of All, Git, Web",
+            "Invalid log type provided. Expected one of All, Git, Web",
         )),
     }
 }

--- a/plaid/src/data/github/mod.rs
+++ b/plaid/src/data/github/mod.rs
@@ -78,7 +78,7 @@ pub struct GithubConfig {
 }
 
 impl GithubConfig {
-    /// Create a new instance of a `GitHub` config
+    /// Create a new instance of a `GithubConfig`
     pub fn new(authentication: Authentication, org: String, log_type: LogType) -> Self {
         Self {
             authentication,
@@ -99,7 +99,10 @@ where
     match log_type.as_str() {
         "web" => Ok(LogType::Web),
         "git" => Ok(LogType::Git),
-        _ => Ok(LogType::All),
+        "all" => Ok(LogType::All),
+        _ => Err(serde::de::Error::custom(
+            "Invalid log tpye provided. Expected one of All, Git, Web",
+        )),
     }
 }
 

--- a/plaid/src/data/github/mod.rs
+++ b/plaid/src/data/github/mod.rs
@@ -1,20 +1,24 @@
-use plaid_stl::messages::{Generator, LogSource, LogbacksAllowed};
-
+use crate::apis::github::{build_github_client, Authentication};
+use crate::executor::Message;
 use crossbeam_channel::Sender;
-use reqwest::Client;
-use serde::Deserialize;
-
 use lru::LruCache;
+use octocrab::{self, Octocrab};
+use plaid_stl::messages::{Generator, LogSource, LogbacksAllowed};
+use serde::Deserialize;
+use serde_json::Value;
 use std::cmp::{Ordering, Reverse};
 use std::collections::BinaryHeap;
 use std::num::NonZeroUsize;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::executor::Message;
-
-enum LogType {
+/// Represents the event types GitHub will include in the response
+/// to the audit log request
+pub enum LogType {
+    /// Returns web (non-Git) events.
     Web,
+    /// Returns Git events.
     Git,
+    /// Returns both web and Git events.
     All,
 }
 
@@ -35,9 +39,13 @@ impl std::fmt::Display for LogType {
     }
 }
 
+/// Represents a Github audit log returned from the API. For more information on audit logs,
+/// see [here](https://docs.github.com/en/enterprise-cloud@latest/rest/orgs/orgs?apiVersion=2022-11-28#get-the-audit-log-for-an-organization)
 #[derive(Eq, PartialEq)]
 pub struct GithubAuditLog {
+    /// The time the audit log event occurred, given as a Unix timestamp
     timestamp: u64,
+    /// The serialized log
     serialized_log: String,
 }
 
@@ -55,34 +63,63 @@ impl Ord for GithubAuditLog {
 
 #[derive(Deserialize)]
 pub struct GithubConfig {
-    pub token: String,
-    pub org: String,
-    pub log_type: String,
+    /// The authentication method used when configuring the GitHub API module. More
+    /// methods may be added here in the future but one variant of the enum must be defined.
+    /// See the Authentication enum structure above for more details.
+    authentication: Authentication,
+    /// The GitHub organization that logs are fetched from
+    org: String,
+    /// The type of logs this data generator produces
+    #[serde(deserialize_with = "parse_log_type")]
+    log_type: LogType,
+    /// Denotes if logs produced by this generator are allowed to initiate log backs
     #[serde(default)]
-    pub logbacks_allowed: LogbacksAllowed,
+    logbacks_allowed: LogbacksAllowed,
 }
 
+impl GithubConfig {
+    /// Create a new instance of a `GitHub` config
+    pub fn new(authentication: Authentication, org: String, log_type: LogType) -> Self {
+        Self {
+            authentication,
+            org,
+            log_type,
+            logbacks_allowed: LogbacksAllowed::default(),
+        }
+    }
+}
+
+/// Custom parser for log type
+fn parse_log_type<'de, D>(deserializer: D) -> Result<LogType, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let log_type = String::deserialize(deserializer)?.to_lowercase();
+
+    match log_type.as_str() {
+        "web" => Ok(LogType::Web),
+        "git" => Ok(LogType::Git),
+        _ => Ok(LogType::All),
+    }
+}
+
+/// Represents the entire GitHub data generator set up
 pub struct Github {
-    client: Client,
+    /// API client
+    client: Octocrab,
+    /// The configuration of the generator
     config: GithubConfig,
+    /// Contains GitHub logs that are yet to be cannonicalized
     canonicalization_contents: LruCache<String, u64>,
+    /// Logs awaiting to be sent to the execution system.
     canonicalization: BinaryHeap<Reverse<GithubAuditLog>>,
+    /// The logger used to send logs to the execution system for processing
     logger: Sender<Message>,
-    log_type: LogType,
 }
 
 impl Github {
     pub fn new(config: GithubConfig, logger: Sender<Message>) -> Self {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .build()
-            .unwrap();
-
-        let log_type = match config.log_type.as_str() {
-            "web" => LogType::Web,
-            "git" => LogType::Git,
-            _ => LogType::All,
-        };
+        let client = build_github_client(&config.authentication);
 
         Self {
             config,
@@ -90,62 +127,73 @@ impl Github {
             canonicalization_contents: LruCache::new(NonZeroUsize::new(512).unwrap()),
             canonicalization: BinaryHeap::new(),
             logger,
-            log_type,
         }
     }
 
+    /// Gets the audit log for an organization.
+    ///
+    /// The audit log allows organization admins to quickly review the actions performed by members of the organization.
+    /// It includes details such as who performed the action, what the action was, and when it was performed.
     pub async fn fetch_audit_logs(&mut self) -> Result<(), String> {
         // Get the most recent 100 logs
         let address = format!(
             "https://api.github.com/orgs/{}/audit-log?include={}&per_page=100",
-            self.config.org, self.log_type
+            self.config.org, self.config.log_type
         );
 
         let response = self
             .client
-            .get(&address)
-            .header("User-Agent", "Rust/Plaid")
-            .header("Authorization", format!("token {}", self.config.token))
-            .header("Accept", "application/vnd.github.v3+json")
-            .send()
+            ._get(&address)
             .await
             .map_err(|e| format!("Could not get logs from GitHub: {}", e))?;
 
-        let body = response
-            .text()
+        if !response.status().is_success() {
+            return Err(format!(
+                "Call to get GitHub logs failed with code: {}",
+                response.status()
+            ));
+        }
+
+        let body = self
+            .client
+            .body_to_string(response)
             .await
-            .map_err(|e| format!("Could not get data from Github: {}", e))?;
-        let logs: Vec<serde_json::Value> = serde_json::from_str(body.as_str())
+            .map_err(|e| format!("Failed to read body of GitHub response. Error: {e}"))?;
+
+        let logs: Vec<Value> = serde_json::from_str(body.as_str())
             .map_err(|e| format!("Could not parse data from Github: {}\n\n{}", e, body))?;
 
         let mut new_logs = 0;
         for log in logs {
             // We parsed from JSON so serialization back should be safe
             let log_str = serde_json::to_string(&log).unwrap();
-            if !self.canonicalization_contents.contains(&log_str) {
-                let timestamp = match log.get("@timestamp") {
-                    Some(v) => {
-                        if let Some(v) = v.as_u64() {
-                            v
-                        } else {
-                            error!("Got a log from Github without numerical @timestamp field");
-                            continue;
-                        }
-                    }
-                    None => {
-                        error!("Got a log from Github without @timestamp field");
-                        continue;
-                    }
-                };
-                let gh_audit_log = GithubAuditLog {
-                    timestamp,
-                    serialized_log: log_str.clone(),
-                };
-
-                self.canonicalization.push(std::cmp::Reverse(gh_audit_log));
-                self.canonicalization_contents.push(log_str, timestamp);
-                new_logs += 1;
+            if self.canonicalization_contents.contains(&log_str) {
+                continue;
             }
+
+            let timestamp = match log.get("@timestamp") {
+                Some(v) => {
+                    let Some(v) = v.as_u64() else {
+                        error!("Got a log from Github without numerical @timestamp field");
+                        continue;
+                    };
+
+                    v
+                }
+                None => {
+                    error!("Got a log from Github without @timestamp field");
+                    continue;
+                }
+            };
+
+            let gh_audit_log = GithubAuditLog {
+                timestamp,
+                serialized_log: log_str.clone(),
+            };
+
+            self.canonicalization.push(std::cmp::Reverse(gh_audit_log));
+            self.canonicalization_contents.push(log_str, timestamp);
+            new_logs += 1;
         }
 
         let heap_time = match self.canonicalization.peek() {
@@ -180,14 +228,14 @@ impl Github {
             // take it off the heap.
             if current_time - heap_top.timestamp > CANONICALIZATION_TIME {
                 let log = self.canonicalization.pop().unwrap();
-                self.logger
-                    .send(Message::new(
-                        format!("github"),
-                        log.0.serialized_log.into_bytes(),
-                        LogSource::Generator(Generator::Github),
-                        self.config.logbacks_allowed.clone(),
-                    ))
-                    .unwrap();
+                if let Err(e) = self.logger.send(Message::new(
+                    format!("github"),
+                    log.0.serialized_log.into_bytes(),
+                    LogSource::Generator(Generator::Github),
+                    self.config.logbacks_allowed.clone(),
+                )) {
+                    error!("Failed to send GitHub log to executor. Error: {e}")
+                }
             } else {
                 trace!("Top of heap is: {}", heap_top.timestamp);
                 break;


### PR DESCRIPTION
This makes the GitHub data generator compatible with GitHub app creds, removing the need for FPATs as described in [this issue](https://github.com/obelisk/plaid/issues/6)

It could be nice to have the API and data generator share the same GitHub client, but that would require breaking changes to the config to move the authentication settings outside of the API and data generators section. 