### PR TITLE
Add support for triggering GHA via repository_dispatch

### DIFF
--- a/plaid-stl/src/github/mod.rs
+++ b/plaid-stl/src/github/mod.rs
@@ -113,6 +113,17 @@ pub struct GithubFileContent {
 
 // END OF Structs used for deserializing GH's response when searching for code
 
+/// Parameters sent to the runtime when triggering a GHA via repository_dispatch.
+/// See https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event for more details
+#[derive(Serialize, Deserialize)]
+pub struct RepositoryDispatchParams<T> {
+    pub owner: String,
+    pub repo: String,
+    pub event_type: String,
+    /// This is arbitrary content. We just need to be able to (de)serialize it.
+    pub client_payload: T,
+}
+
 impl FileSearchResultItem {
     /// Retrieve the content of the search result
     pub fn retrieve_raw_content(&self) -> Result<String, PlaidFunctionError> {
@@ -1419,4 +1430,38 @@ pub fn filter_search_results(
         filtered_results.push(result);
     }
     filtered_results
+}
+
+/// Trigger a GHA workflow via repository_dispatch.
+/// For more details, see
+/// * https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event
+/// * https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#repository_dispatch
+pub fn trigger_repo_dispatch<T>(
+    owner: &str,
+    repo: &str,
+    event_type: &str,
+    client_payload: T
+) -> Result<(), PlaidFunctionError> where T: Serialize + Deserialize<'static> {
+    extern "C" {
+        new_host_function!(github, trigger_repo_dispatch);
+    }
+
+    let params = RepositoryDispatchParams::<T> {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        event_type: event_type.to_string(),
+        client_payload
+    };
+
+    let params = serde_json::to_string(&params).unwrap();
+    let res =
+        unsafe { github_trigger_repo_dispatch(params.as_bytes().as_ptr(), params.as_bytes().len()) };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    Ok(())
 }

--- a/plaid/src/apis/github/actions.rs
+++ b/plaid/src/apis/github/actions.rs
@@ -1,0 +1,58 @@
+use super::Github;
+use crate::apis::{github::GitHubError, ApiError};
+use plaid_stl::github::RepositoryDispatchParams;
+use serde::Serialize;
+use serde_json::Value;
+
+/// Payload sent to the GH API when triggering a GH Actions workflow via repository dispatch
+#[derive(Serialize)]
+struct RepositoryDispatchPayload<'a, T>
+where
+    T: Serialize,
+{
+    event_type: &'a str,
+    client_payload: &'a T,
+}
+
+impl Github {
+    /// Trigger a GHA workflow via repository_dispatch
+    /// For more details, see
+    /// * https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event
+    /// * https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#repository_dispatch
+    pub async fn trigger_repo_dispatch(&self, params: &str, module: &str) -> Result<u32, ApiError> {
+        let request: RepositoryDispatchParams<Value> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let owner = self.validate_username(&request.owner)?;
+        let repo = self.validate_repository_name(&request.repo)?;
+        let event_type = self.validate_event_type(&request.event_type)?;
+        // Since client_payload can be an arbitrary JSON, we "validate" it alredy when deserializing it to a Value.
+        // However, we have no control over the content.
+
+        info!("Triggering repository_dispatch GHA for repository [{owner}/{repo}] on behalf of [{module}]");
+
+        let address = format!("/repos/{owner}/{repo}/dispatches");
+
+        let body = RepositoryDispatchPayload {
+            event_type,
+            client_payload: &request.client_payload,
+        };
+
+        match self
+            .make_generic_post_request(address, &body, &module)
+            .await
+        {
+            Ok((status, Ok(_))) => {
+                if status == 204 {
+                    Ok(0)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/plaid/src/apis/github/mod.rs
+++ b/plaid/src/apis/github/mod.rs
@@ -1,3 +1,4 @@
+mod actions;
 mod code;
 mod copilot;
 mod environments;

--- a/plaid/src/apis/github/validators.rs
+++ b/plaid/src/apis/github/validators.rs
@@ -57,7 +57,7 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
     // This validates a SHA-1 hash which is what all commit hashes are.
     define_regex_validator!(validators, "commit_hash", r"^\b([a-f0-9]{40})\b$");
 
-    // This validates a postive integer
+    // This validates a positive integer
     define_regex_validator!(validators, "pint", r"^\d+$");
 
     // Follows Github's guidelines on branch naming conventions
@@ -67,6 +67,8 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
     define_regex_validator!(validators, "environment_name", r"^[a-zA-Z][a-zA-Z0-9./_-]*$");
     define_regex_validator!(validators, "secret_name", r"^[A-Z][A-Z0-9_]*$");
     define_regex_validator!(validators, "filename", r"^[a-zA-Z0-9\.]{1,32}$");
+
+    define_regex_validator!(validators, "event_type", r"^[\w\-_]+$");
 
     validators
 }
@@ -81,3 +83,4 @@ create_regex_validator_func!(branch_name);
 create_regex_validator_func!(environment_name);
 create_regex_validator_func!(secret_name);
 create_regex_validator_func!(filename);
+create_regex_validator_func!(event_type);

--- a/plaid/src/functions/api.rs
+++ b/plaid/src/functions/api.rs
@@ -232,6 +232,7 @@ impl_new_function!(github, update_branch_protection_rule);
 impl_new_function!(github, create_environment_for_repo);
 impl_new_function!(github, configure_secret);
 impl_new_function!(github, create_deployment_branch_protection_rule);
+impl_new_function!(github, trigger_repo_dispatch);
 
 impl_new_function_with_error_buffer!(github, make_graphql_query);
 impl_new_function_with_error_buffer!(github, make_advanced_graphql_query);
@@ -481,6 +482,9 @@ pub fn to_api_function(
         }
         "github_list_seats_in_org_copilot" => {
             Function::new_typed_with_env(&mut store, &env, github_list_seats_in_org_copilot)
+        }
+        "github_trigger_repo_dispatch" => {
+            Function::new_typed_with_env(&mut store, &env, github_trigger_repo_dispatch)
         }
 
         // Slack Calls


### PR DESCRIPTION
This PR exposes a new API `trigger_repo_dispatch` through which a rule can trigger a GHA workflow via `repository_dispatch` on a given repository.