### PR TITLE
Implement benchmarking system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Artefacts
 /compiled_modules
+/runtime/benchmark-results
 
 # Private items
 /runtime/plaid/private-resources

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 # Artefacts
 /compiled_modules
-/runtime/benchmark-results/*
+/runtime/performance-monitoring/*
 
 # Private items
 /runtime/plaid/private-resources

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 # Artefacts
 /compiled_modules
-/runtime/benchmark-results
+/runtime/benchmark-results/*
 
 # Private items
 /runtime/plaid/private-resources

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -2732,6 +2732,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-tungstenite 0.23.1",
+ "tokio-util",
  "toml",
  "totp-rs",
  "url",

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -56,6 +56,7 @@ tokio-tungstenite = { version = "0.23.1", features = [
 futures-util = "0.3.30"
 aws-sdk-kms = { version = "1.41.0", optional = true }
 aws-config = { version = "1.5.5", optional = true }
+tokio-util = "0.7.12"
 
 [[example]]
 name = "github-tailer"

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -42,6 +42,10 @@ sled = "0.34.7"
 tar = "0.4.41"
 time = "0.3"
 tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7.12"
+tokio-tungstenite = { version = "0.23.1", features = [
+    "rustls-tls-native-roots",
+] }
 toml = "0.5"
 totp-rs = "5.6.0"
 url = "2.5.2"
@@ -50,13 +54,9 @@ warp = { version = "0.3", features = ["tls"] }
 wasmer = { version = "4", default-features = false, features = ["cranelift"] }
 wasmer-middlewares = "4"
 jsonwebtoken = { version = "9.2" }
-tokio-tungstenite = { version = "0.23.1", features = [
-    "rustls-tls-native-roots",
-] }
 futures-util = "0.3.30"
 aws-sdk-kms = { version = "1.41.0", optional = true }
 aws-config = { version = "1.5.5", optional = true }
-tokio-util = "0.7.12"
 
 [[example]]
 name = "github-tailer"

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -1,5 +1,12 @@
 execution_threads = 2
 
+# Uncomment this to run with performance monitoring enabled
+[performance_monitoring]
+
+# This is an optional field. If no path is provided, the resulting
+# file is written to /runtime/performance-monitoring/metrics.txt
+# output_file_path = "../somedirectory/file.txt" 
+
 [storage.sled]
 path = "/tmp/sled"
 

--- a/runtime/plaid/src/benchmark/mod.rs
+++ b/runtime/plaid/src/benchmark/mod.rs
@@ -1,0 +1,184 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::mpsc::Receiver;
+use tokio::time::{timeout, Duration};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Deserialize)]
+pub struct Benchmarking {
+    /// The full path to the output file where benchmarking metrics should be written
+    #[serde(default = "default_results_file_path")]
+    output_file_path: String,
+}
+
+/// Default file path for benchmarking results if none is provided in the config
+fn default_results_file_path() -> String {
+    format!(
+        "{}/../benchmark-results/metrics.txt",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
+/// Metadata about a rule's execution
+pub struct ModulePerformanceMetadata {
+    /// The name of the module
+    pub module: String,
+    /// Time (in microseconds) for execution to complete
+    pub execution_time: u128,
+    /// The amount of computation used by the rule
+    pub computation_used: u64,
+}
+
+/// Represents a module's aggregate performance
+struct AggregatePerformanceData {
+    /// The number of times the module has been executed
+    runs: u64,
+    /// The total time (in microseconds) the module has spent in the execution loop
+    total_execution_time: u128,
+    /// The total computation used by the module
+    total_computation_used: u64,
+    /// Denotes whether the system should continue collecting performance metadata
+    maxed_out: bool,
+}
+
+impl AggregatePerformanceData {
+    /// Creates a new `AggregatePerformanceData` with initial execution time and computation used.
+    fn new(execution_time: u128, computation_used: u64) -> Self {
+        Self {
+            runs: 1,
+            total_execution_time: execution_time,
+            total_computation_used: computation_used,
+            maxed_out: false,
+        }
+    }
+
+    /// Updates the aggregate data atomically with the latest execution time and computation used.
+    /// If overflow occurs, the update is rolled back and none of the fields are modified.
+    fn update(&mut self, message: &ModulePerformanceMetadata) {
+        if self.maxed_out {
+            return;
+        }
+
+        // Check if the additions would overflow before proceeding
+        if let (Some(new_total_execution_time), Some(new_total_computation_used)) = (
+            self.total_execution_time
+                .checked_add(message.execution_time),
+            self.total_computation_used
+                .checked_add(message.computation_used),
+        ) {
+            // Atomic update
+            self.runs += 1;
+            self.total_execution_time = new_total_execution_time;
+            self.total_computation_used = new_total_computation_used;
+        } else {
+            error!("Overflow occurred updating execution data for [{}]. No further execution data will be collected.", message.module);
+            self.maxed_out = true;
+        }
+    }
+}
+
+impl Benchmarking {
+    pub async fn start(
+        &self,
+        receiver: Receiver<ModulePerformanceMetadata>,
+        cancellation_token: CancellationToken,
+    ) {
+        let aggregate_performance_metadata = benchmark_loop(receiver, cancellation_token).await;
+
+        if let Err(e) =
+            generate_report(&aggregate_performance_metadata, &self.output_file_path).await
+        {
+            error!("Failed to generate benchmark report. Error: {e}")
+        }
+    }
+}
+
+async fn benchmark_loop(
+    mut receiver: Receiver<ModulePerformanceMetadata>,
+    cancellation_token: CancellationToken,
+) -> HashMap<String, AggregatePerformanceData> {
+    let mut aggregate_performance_metadata = HashMap::new();
+
+    // Benchmarking loop runs until the server is shutdown
+    while !cancellation_token.is_cancelled() {
+        match timeout(Duration::from_secs(5), receiver.recv()).await {
+            Ok(Some(message)) => {
+                aggregate_performance_metadata
+                    .entry(message.module.clone())
+                    .and_modify(|aggregate: &mut AggregatePerformanceData| {
+                        aggregate.update(&message);
+                    })
+                    .or_insert_with(|| {
+                        AggregatePerformanceData::new(
+                            message.execution_time,
+                            message.computation_used,
+                        )
+                    });
+            }
+            Ok(None) => {
+                error!("Sending end of benchmarking system has disconnected. No further benchmark data will be recorded");
+                break;
+            }
+            _ => continue,
+        }
+    }
+
+    aggregate_performance_metadata
+}
+
+/// Generates a performance report based on the given aggregate performance data
+/// and writes the results to the specified file.
+async fn generate_report(
+    aggregate_performance_metadata: &HashMap<String, AggregatePerformanceData>,
+    file_path: &str,
+) -> Result<(), tokio::io::Error> {
+    debug!("Writing benchmarking results file to {file_path}...");
+
+    // Check if benchmark_results directory exists
+    // Extract the directory path from the file path
+    if let Some(dir_path) = std::path::Path::new(file_path).parent() {
+        // Check if the directory exists
+        if !dir_path.exists() {
+            // Create the directory if it doesn't exist
+            tokio::fs::create_dir_all(dir_path).await?;
+        }
+    }
+
+    // Open a file in write mode asynchronously. If the file doesn't exist, it will be created.
+    let mut file = File::create(file_path).await?;
+
+    // Write the report header
+    file.write_all(b"Performance Report:\n").await?;
+
+    // Write the data for each module
+    for (module, data) in aggregate_performance_metadata {
+        file.write_all(format!("Module: {}\n", module).as_bytes())
+            .await?;
+        file.write_all(format!("\tRuns: {}\n", data.runs).as_bytes())
+            .await?;
+        file.write_all(
+            format!(
+                "\tAverage Computation Used: {}\n",
+                data.total_computation_used / data.runs
+            )
+            .as_bytes(),
+        )
+        .await?;
+        file.write_all(
+            format!(
+                "\tAverage Execution Time (microseconds): {}\n",
+                data.total_execution_time / data.runs as u128
+            )
+            .as_bytes(),
+        )
+        .await?;
+        file.write_all(b"\n").await?;
+    }
+
+    // Ensure the file is flushed and fully written
+    file.flush().await?;
+
+    Ok(())
+}

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (performance_sender, performance_handle) = match config.performance_monitoring {
         Some(perf) => {
             warn!("Plaid is running with performance monitoring enabled - this is NOT recommended for production deployments. Metadata about rule execution will be logged to a channel that aggregates and reports metrics.");
-            let (sender, rx) = tokio::sync::mpsc::channel::<ModulePerformanceMetadata>(4096);
+            let (sender, rx) = crossbeam_channel::bounded::<ModulePerformanceMetadata>(4096);
     
             let token = cancellation_token.clone();
             let handle = tokio::task::spawn(async move {

--- a/runtime/plaid/src/config.rs
+++ b/runtime/plaid/src/config.rs
@@ -6,6 +6,8 @@ use serde::{de, Deserialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
+use crate::benchmark::Benchmarking;
+
 use super::apis::Apis;
 use super::data::DataConfig;
 use super::loader::Configuration as LoaderConfiguration;
@@ -114,6 +116,10 @@ pub struct Configuration {
     /// The maximum number of logs in the queue to be processed at once
     #[serde(default = "default_log_queue_size")]
     pub log_queue_size: usize,
+    /// Configuration for how Plaid benchmarks rules. When enabled,
+    /// Plaid outputs a metrics file with performance metadata for all
+    /// rules than have been run at least once.
+    pub benchmark_mode: Option<Benchmarking>,
     /// Configuration for persistent data. This allows modules to store data between
     /// invocations
     pub storage: Option<StorageConfig>,

--- a/runtime/plaid/src/config.rs
+++ b/runtime/plaid/src/config.rs
@@ -6,7 +6,7 @@ use serde::{de, Deserialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::benchmark::Benchmarking;
+use crate::performance::PerformanceMonitoring;
 
 use super::apis::Apis;
 use super::data::DataConfig;
@@ -116,10 +116,10 @@ pub struct Configuration {
     /// The maximum number of logs in the queue to be processed at once
     #[serde(default = "default_log_queue_size")]
     pub log_queue_size: usize,
-    /// Configuration for how Plaid benchmarks rules. When enabled,
+    /// Configuration for how Plaid monitors rule performance. When enabled,
     /// Plaid outputs a metrics file with performance metadata for all
     /// rules than have been run at least once.
-    pub benchmark_mode: Option<Benchmarking>,
+    pub performance_monitoring: Option<PerformanceMonitoring>,
     /// Configuration for persistent data. This allows modules to store data between
     /// invocations
     pub storage: Option<StorageConfig>,

--- a/runtime/plaid/src/executor/mod.rs
+++ b/runtime/plaid/src/executor/mod.rs
@@ -8,8 +8,7 @@ use crate::logging::{Logger, LoggingError};
 use crate::performance::ModulePerformanceMetadata;
 use crate::storage::Storage;
 
-use crossbeam_channel::Receiver;
-use tokio::sync::mpsc::Sender;
+use crossbeam_channel::{Receiver, Sender};
 use tokio::sync::oneshot::Sender as OneShotSender;
 
 use plaid_stl::messages::{LogSource, LogbacksAllowed};
@@ -454,7 +453,7 @@ fn process_message_with_module(
 
                     // If performance monitoring is enabled, log data to the monitoring system
                     if let Some(ref sender) = performance_mode {
-                        if let Err(e) = sender.blocking_send(ModulePerformanceMetadata {
+                        if let Err(e) = sender.send(ModulePerformanceMetadata {
                             module: module.name.clone(),
                             execution_time: begin.elapsed().as_micros(),
                             computation_used: computation_limit - remaining,

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -311,6 +311,9 @@ pub fn to_api_function(
         "fetch_source" => {
             Function::new_typed_with_env(&mut store, &env, super::message::fetch_source)
         }
+        "fetch_data_and_source" => {
+            Function::new_typed_with_env(&mut store, &env, super::message::fetch_data_and_source)
+        }
         "fetch_accessory_data_by_name" => Function::new_typed_with_env(
             &mut store,
             &env,
@@ -336,22 +339,17 @@ pub fn to_api_function(
             Function::new_typed_with_env(&mut store, &env, super::internal::print_debug_string)
         }
         "get_time" => Function::new_typed(&mut store, super::internal::get_time),
-        "storage_insert" => {
-            Function::new_typed_with_env(&mut store, &env, super::storage::insert)
-        }
-        "storage_get" => {
-            Function::new_typed_with_env(&mut store, &env, super::storage::get)
-        }
+        "storage_insert" => Function::new_typed_with_env(&mut store, &env, super::storage::insert),
+        "storage_get" => Function::new_typed_with_env(&mut store, &env, super::storage::get),
         "storage_list_keys" => {
             Function::new_typed_with_env(&mut store, &env, super::storage::list_keys)
         }
-        "cache_insert" => {
-            Function::new_typed_with_env(&mut store, &env, super::cache::insert)
-        }
+        "cache_insert" => Function::new_typed_with_env(&mut store, &env, super::cache::insert),
         "cache_get" => Function::new_typed_with_env(&mut store, &env, super::cache::get),
         "log_back" => Function::new_typed_with_env(&mut store, &env, super::internal::log_back),
-        "log_back_unlimited" => Function::new_typed_with_env(&mut store, &env, super::internal::log_back_unlimited),
-        
+        "log_back_unlimited" => {
+            Function::new_typed_with_env(&mut store, &env, super::internal::log_back_unlimited)
+        }
         // Npm Calls
         "npm_publish_empty_stub" => {
             Function::new_typed_with_env(&mut store, &env, npm_publish_empty_stub)
@@ -373,9 +371,7 @@ pub fn to_api_function(
             Function::new_typed_with_env(&mut store, &env, npm_list_granular_tokens)
         }
 
-        "npm_delete_package" => {
-            Function::new_typed_with_env(&mut store, &env, npm_delete_package)
-        }
+        "npm_delete_package" => Function::new_typed_with_env(&mut store, &env, npm_delete_package),
 
         "npm_add_user_to_team" => {
             Function::new_typed_with_env(&mut store, &env, npm_add_user_to_team)
@@ -408,7 +404,7 @@ pub fn to_api_function(
         "npm_get_token_details" => {
             Function::new_typed_with_env(&mut store, &env, npm_get_token_details)
         }
-        
+
         // Okta Calls
         "okta_remove_user_from_group" => {
             Function::new_typed_with_env(&mut store, &env, okta_remove_user_from_group)
@@ -437,12 +433,8 @@ pub fn to_api_function(
         "github_fetch_commit" => {
             Function::new_typed_with_env(&mut store, &env, github_fetch_commit)
         }
-        "github_list_files" => {
-            Function::new_typed_with_env(&mut store, &env, github_list_files)
-        }
-        "github_fetch_file" => {
-            Function::new_typed_with_env(&mut store, &env, github_fetch_file)
-        }
+        "github_list_files" => Function::new_typed_with_env(&mut store, &env, github_list_files),
+        "github_fetch_file" => Function::new_typed_with_env(&mut store, &env, github_fetch_file),
         "github_list_fpat_requests_for_org" => {
             Function::new_typed_with_env(&mut store, &env, github_list_fpat_requests_for_org)
         }
@@ -467,9 +459,11 @@ pub fn to_api_function(
         "github_configure_secret" => {
             Function::new_typed_with_env(&mut store, &env, github_configure_secret)
         }
-        "github_create_deployment_branch_protection_rule" => {
-            Function::new_typed_with_env(&mut store, &env, github_create_deployment_branch_protection_rule)
-        }
+        "github_create_deployment_branch_protection_rule" => Function::new_typed_with_env(
+            &mut store,
+            &env,
+            github_create_deployment_branch_protection_rule,
+        ),
         "github_search_for_file" => {
             Function::new_typed_with_env(&mut store, &env, github_search_for_file)
         }
@@ -495,7 +489,9 @@ pub fn to_api_function(
         }
         "slack_post_message" => Function::new_typed_with_env(&mut store, &env, slack_post_message),
         "slack_views_open" => Function::new_typed_with_env(&mut store, &env, slack_views_open),
-        "slack_get_id_from_email" => Function::new_typed_with_env(&mut store, &env, slack_get_id_from_email),
+        "slack_get_id_from_email" => {
+            Function::new_typed_with_env(&mut store, &env, slack_get_id_from_email)
+        }
 
         // General Calls
         "general_simple_json_post_request" => {

--- a/runtime/plaid/src/functions/message.rs
+++ b/runtime/plaid/src/functions/message.rs
@@ -3,6 +3,64 @@ use crate::executor::Env;
 
 use wasmer::{AsStoreRef, FunctionEnvMut, WasmPtr};
 
+pub fn fetch_data_and_source(
+    env: FunctionEnvMut<Env>,
+    data_buffer: WasmPtr<u8>,
+    buffer_size: u32,
+) -> i32 {
+    let store = env.as_store_ref();
+    let memory_view = match get_memory(&env, &store) {
+        Ok(memory_view) => memory_view,
+        Err(e) => {
+            error!(
+                "{}: Memory error in fetch_from_module: {:?}",
+                env.data().name,
+                e
+            );
+            return e as i32;
+        }
+    };
+
+    let log_data = &env.data().message.data;
+
+    // Get the from_module if it exists (which it won't if this is from a data generator
+    // like GitHub, Okta, or a Webhook)
+    let source = &env.data().message.source;
+
+    // I really think this is overkill and we could just unwrap() this but
+    // in the future we may run modules that are completely untrusted allowing things
+    // like names to sneak in and perhaps cause issues. That is still a problem here
+    // because this would then not succeed and the module will not know where a log came
+    // from, but at least we can handle that.
+    let source = match serde_json::to_vec(source) {
+        Ok(s) => s,
+        Err(e) => {
+            error!(
+                "{}: Could not serialize the source: {}. Error: {e}",
+                env.data().name,
+                env.data().message.source,
+            );
+            return -4;
+        }
+    };
+
+    // Get the length of the log and convert it to a byte representation
+    let log_length = (log_data.len() as u32).to_le_bytes();
+
+    let mut rule_data = Vec::new();
+    rule_data.extend_from_slice(&log_length);
+    rule_data.extend_from_slice(log_data);
+    rule_data.extend_from_slice(&source);
+
+    match safely_write_data_back(&memory_view, &rule_data, data_buffer, buffer_size) {
+        Ok(x) => x,
+        Err(e) => {
+            error!("{}: Error in fetch_data: {:?}", env.data().name, e);
+            e as i32
+        }
+    }
+}
+
 /// Wrap the fetch_data call in a native WASM function.
 pub fn fetch_data(env: FunctionEnvMut<Env>, data_buffer: WasmPtr<u8>, buffer_size: u32) -> i32 {
     let store = env.as_store_ref();

--- a/runtime/plaid/src/lib.rs
+++ b/runtime/plaid/src/lib.rs
@@ -2,11 +2,11 @@
 extern crate log;
 
 pub mod apis;
-pub mod benchmark;
 pub mod config;
 pub mod data;
 pub mod executor;
 pub mod functions;
 pub mod loader;
 pub mod logging;
+pub mod performance;
 pub mod storage;

--- a/runtime/plaid/src/lib.rs
+++ b/runtime/plaid/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate log;
 
 pub mod apis;
+pub mod benchmark;
 pub mod config;
 pub mod data;
 pub mod executor;


### PR DESCRIPTION
Currently, we're unable to quantify how subtle changes to a rule or the Plaid runtime affect performance. This PR implements a mechanism to benchmark and compare Plaid rules, enabling developers and plaidmins to maximize their instance's performance. When enabled, it logs rule execution metadata (rule name, execution time, computation used) to a task that aggregates this data based on rule name. On shutdown, the benchmarking system writes this data out to a file.

Triggering shutdown of the server is done with `CTRL+C` or by sending a `SIGTERM` signal. Plaid is configured to listen for this signal and begin a graceful shutdown. Right now, graceful shutdown means waiting for the `benchmark_loop` task to exit. This allows us to guarantee that our benchmarking data will be written to a file prior to exiting. However, graceful shutdown allows us to do more in the future. We could extend this idea to the execution loop and only shutdown once the message queue is empty, therefore guaranteeing that all logs will be processed.

### Output
The benchmarking system outputs a file like:
```
Performance Report:
Module: testing_test_release_default.wasm
	Runs: 3510
	Average Computation Used: 4752.00
	Average Execution Time (microseconds): 2012

Module: testing_test.wasm
	Runs: 3510
	Average Computation Used: 31317.00
	Average Execution Time (microseconds): 1967
```

In this simple example, we can see that when we compile the `testing_test.wasm` rule with the `--release` flag, we reduce the computation used by about 85%! That's a big difference. 