### PR TITLE
Add documentation for GH fetch files + modify parameter validation

### DIFF
--- a/runtime/plaid-stl/src/github/mod.rs
+++ b/runtime/plaid-stl/src/github/mod.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashMap, fmt::Display};
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fmt::Display};
 
-use crate::{PlaidFunctionError, datetime};
+use crate::{datetime, PlaidFunctionError};
 
 pub enum ReviewPatAction {
     Approve,
@@ -354,7 +354,7 @@ pub fn list_copilot_subscription_seats_by_page(
     let res = String::from_utf8(return_buffer).unwrap();
 
     let res = serde_json::from_str::<CopilotSeatsResult>(&res)
-            .map_err(|_| PlaidFunctionError::InternalApiError)?;
+        .map_err(|_| PlaidFunctionError::InternalApiError)?;
 
     Ok(res.seats)
 }
@@ -363,7 +363,9 @@ pub fn list_copilot_subscription_seats_by_page(
 /// ## Arguments
 ///
 /// * `org` - The org owning the subscription
-pub fn list_all_copilot_subscription_seats(org: &str) -> Result<Vec<CopilotSeat>, PlaidFunctionError> {
+pub fn list_all_copilot_subscription_seats(
+    org: &str,
+) -> Result<Vec<CopilotSeat>, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, list_seats_in_org_copilot);
     }
@@ -423,7 +425,10 @@ pub fn list_all_copilot_subscription_seats(org: &str) -> Result<Vec<CopilotSeat>
 ///
 /// * `org` - The org owning the subscription
 /// * `user` - The user to add to Copilot subscription
-pub fn add_user_to_copilot_subscription(org: &str, user: &str) -> Result<CopilotAddUsersResponse, PlaidFunctionError> {
+pub fn add_user_to_copilot_subscription(
+    org: &str,
+    user: &str,
+) -> Result<CopilotAddUsersResponse, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, add_users_to_org_copilot);
     }
@@ -460,8 +465,8 @@ pub fn add_user_to_copilot_subscription(org: &str, user: &str) -> Result<Copilot
 
     // This should be safe because unless the Plaid runtime is expressly trying
     // to mess with us, this came from a String in the API module.
-    let response_body = String::from_utf8(return_buffer)
-        .map_err(|_| PlaidFunctionError::InternalApiError)?;
+    let response_body =
+        String::from_utf8(return_buffer).map_err(|_| PlaidFunctionError::InternalApiError)?;
     let response_body = serde_json::from_str::<CopilotAddUsersResponse>(&response_body)
         .map_err(|_| PlaidFunctionError::InternalApiError)?;
 
@@ -473,7 +478,10 @@ pub fn add_user_to_copilot_subscription(org: &str, user: &str) -> Result<Copilot
 ///
 /// * `org` - The org owning the subscription
 /// * `user` - The user to remove from Copilot subscription
-pub fn remove_user_from_copilot_subscription(org: &str, user: &str) -> Result<CopilotRemoveUsersResponse, PlaidFunctionError> {
+pub fn remove_user_from_copilot_subscription(
+    org: &str,
+    user: &str,
+) -> Result<CopilotRemoveUsersResponse, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, remove_users_from_org_copilot);
     }
@@ -511,8 +519,8 @@ pub fn remove_user_from_copilot_subscription(org: &str, user: &str) -> Result<Co
 
     // This should be safe because unless the Plaid runtime is expressly trying
     // to mess with us, this came from a String in the API module.
-    let response_body = String::from_utf8(return_buffer)
-        .map_err(|_| PlaidFunctionError::InternalApiError)?;
+    let response_body =
+        String::from_utf8(return_buffer).map_err(|_| PlaidFunctionError::InternalApiError)?;
     let response_body = serde_json::from_str::<CopilotRemoveUsersResponse>(&response_body)
         .map_err(|_| PlaidFunctionError::InternalApiError)?;
 
@@ -524,7 +532,10 @@ pub fn remove_user_from_copilot_subscription(org: &str, user: &str) -> Result<Co
 ///
 /// * `org` - The org owning the subscription
 /// * `users` - The list of users to remove from Copilot subscription
-pub fn remove_users_from_copilot_subscription(org: &str, users: Vec<&str>) -> Result<CopilotRemoveUsersResponse, PlaidFunctionError> {
+pub fn remove_users_from_copilot_subscription(
+    org: &str,
+    users: Vec<&str>,
+) -> Result<CopilotRemoveUsersResponse, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, remove_users_from_org_copilot);
     }
@@ -562,8 +573,8 @@ pub fn remove_users_from_copilot_subscription(org: &str, users: Vec<&str>) -> Re
 
     // This should be safe because unless the Plaid runtime is expressly trying
     // to mess with us, this came from a String in the API module.
-    let response_body = String::from_utf8(return_buffer)
-        .map_err(|_| PlaidFunctionError::InternalApiError)?;
+    let response_body =
+        String::from_utf8(return_buffer).map_err(|_| PlaidFunctionError::InternalApiError)?;
     let response_body = serde_json::from_str::<CopilotRemoveUsersResponse>(&response_body)
         .map_err(|_| PlaidFunctionError::InternalApiError)?;
 
@@ -793,6 +804,13 @@ pub fn list_files(
     Ok(String::from_utf8(return_buffer).unwrap())
 }
 
+/// Gets the contents of a file or directory in a repository.
+/// ## Arguments:
+///
+/// * `organization`: The account owner of the repository. The name is not case sensitive.
+/// * `repository_name`: The name of the repository without the .git extension. The name is not case sensitive.
+/// * `file_path`: Path of the file or directory to read
+/// * `reference`: The name of the commit/branch/tag
 pub fn fetch_file(
     organization: &str,
     repository_name: &str,
@@ -1451,8 +1469,11 @@ pub fn trigger_repo_dispatch<T>(
     owner: &str,
     repo: &str,
     event_type: &str,
-    client_payload: T
-) -> Result<(), PlaidFunctionError> where T: Serialize + Deserialize<'static> {
+    client_payload: T,
+) -> Result<(), PlaidFunctionError>
+where
+    T: Serialize + Deserialize<'static>,
+{
     extern "C" {
         new_host_function!(github, trigger_repo_dispatch);
     }
@@ -1461,12 +1482,13 @@ pub fn trigger_repo_dispatch<T>(
         owner: owner.to_string(),
         repo: repo.to_string(),
         event_type: event_type.to_string(),
-        client_payload
+        client_payload,
     };
 
     let params = serde_json::to_string(&params).unwrap();
-    let res =
-        unsafe { github_trigger_repo_dispatch(params.as_bytes().as_ptr(), params.as_bytes().len()) };
+    let res = unsafe {
+        github_trigger_repo_dispatch(params.as_bytes().as_ptr(), params.as_bytes().len())
+    };
 
     // There was an error with the Plaid system. Maybe the API is not
     // configured.

--- a/runtime/plaid/src/apis/github/repos.rs
+++ b/runtime/plaid/src/apis/github/repos.rs
@@ -159,6 +159,15 @@ impl Github {
         let file_path = request.get("file_path").ok_or(ApiError::BadRequest)?;
         let reference = request.get("reference").ok_or(ApiError::BadRequest)?;
 
+        // Reference can be commit hash OR a branch name.
+        // To validate that the provided ref is valid, we must check that it is either a
+        // commit hash or branch name using the provided validator functions
+        if self.validate_commit_hash(&reference).is_err()
+            && self.validate_branch_name(&reference).is_err()
+        {
+            return Err(ApiError::BadRequest);
+        }
+
         info!("Fetching contents of file in repository [{organization}/{repository_name}] at {file_path} and reference {reference}");
         let address =
             format!("/repos/{organization}/{repository_name}/contents/{file_path}?ref={reference}");

--- a/runtime/plaid/src/apis/github/repos.rs
+++ b/runtime/plaid/src/apis/github/repos.rs
@@ -160,7 +160,10 @@ impl Github {
 
         // If this call return Ok(_), it means the provided file path contains ".." which we do
         // not want to allow
-        if self.validate_file_path(file_path).is_ok() {
+        if self
+            .validate_contains_parent_directory_component(file_path)
+            .is_ok()
+        {
             return Err(ApiError::BadRequest);
         }
 

--- a/runtime/plaid/src/apis/github/repos.rs
+++ b/runtime/plaid/src/apis/github/repos.rs
@@ -157,6 +157,13 @@ impl Github {
             request.get("repository_name").ok_or(ApiError::BadRequest)?,
         )?;
         let file_path = request.get("file_path").ok_or(ApiError::BadRequest)?;
+
+        // If this call return Ok(_), it means the provided file path contains ".." which we do
+        // not want to allow
+        if self.validate_file_path(file_path).is_ok() {
+            return Err(ApiError::BadRequest);
+        }
+
         let reference = request.get("reference").ok_or(ApiError::BadRequest)?;
 
         // Reference can be commit hash OR a branch name.

--- a/runtime/plaid/src/apis/github/validators.rs
+++ b/runtime/plaid/src/apis/github/validators.rs
@@ -64,11 +64,18 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
     // https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names#naming-branches-and-tags
     define_regex_validator!(validators, "branch_name", r"^[a-zA-Z][a-zA-Z0-9./_-]*$");
 
-    define_regex_validator!(validators, "environment_name", r"^[a-zA-Z][a-zA-Z0-9./_-]*$");
+    define_regex_validator!(
+        validators,
+        "environment_name",
+        r"^[a-zA-Z][a-zA-Z0-9./_-]*$"
+    );
     define_regex_validator!(validators, "secret_name", r"^[A-Z][A-Z0-9_]*$");
     define_regex_validator!(validators, "filename", r"^[a-zA-Z0-9\.]{1,32}$");
 
     define_regex_validator!(validators, "event_type", r"^[\w\-_]+$");
+
+    // Matches if .. is present in a file path
+    define_regex_validator!(validators, "file_path", r"");
 
     validators
 }
@@ -84,3 +91,4 @@ create_regex_validator_func!(environment_name);
 create_regex_validator_func!(secret_name);
 create_regex_validator_func!(filename);
 create_regex_validator_func!(event_type);
+create_regex_validator_func!(file_path);

--- a/runtime/plaid/src/apis/github/validators.rs
+++ b/runtime/plaid/src/apis/github/validators.rs
@@ -75,7 +75,7 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
     define_regex_validator!(validators, "event_type", r"^[\w\-_]+$");
 
     // Matches if .. is present in a file path
-    define_regex_validator!(validators, "file_path", r"");
+    define_regex_validator!(validators, "file_path", r"\.\.");
 
     validators
 }

--- a/runtime/plaid/src/apis/github/validators.rs
+++ b/runtime/plaid/src/apis/github/validators.rs
@@ -75,7 +75,7 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
     define_regex_validator!(validators, "event_type", r"^[\w\-_]+$");
 
     // Matches if .. is present in a file path
-    define_regex_validator!(validators, "file_path", r"\.\.");
+    define_regex_validator!(validators, "contains_parent_directory_component", r"\.\.");
 
     validators
 }
@@ -91,4 +91,4 @@ create_regex_validator_func!(environment_name);
 create_regex_validator_func!(secret_name);
 create_regex_validator_func!(filename);
 create_regex_validator_func!(event_type);
-create_regex_validator_func!(file_path);
+create_regex_validator_func!(contains_parent_directory_component);


### PR DESCRIPTION
The `fetch_file` API required a commit hash for the `ref` parameter. In cases where we need to fetch a file from a branch, this is too restrictive. This PR modifies the parameter validation for `ref` to check that it is either a valid commit hash OR branch name. It also adds an additional check to `file_path` to validate that it does not contain `..`

It also adds some formatting changes (not on purpose but we can blame my formatter). However, this is a great plug for https://github.com/obelisk/plaid/pull/58 as it means we won't run into scenarios where code gets changed because of formatting