### PR TITLE
Release config checker binary as an artifact

### DIFF
--- a/.github/workflows/ConfigChecker.yaml
+++ b/.github/workflows/ConfigChecker.yaml
@@ -1,0 +1,32 @@
+name: Release config checker
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release_config_checker:
+    name: Release config checker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            runtime/target/
+          key: ${{ runner.os }}-cargo-configchecker-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build config checker
+        run: cd runtime && cargo build --bin=config_check --release
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: runtime/target/release/config_check


### PR DESCRIPTION
Adds a GHA workflow to release the config check binary as an artifact. This can then be used by other repositories to quickly validate a set of Plaid configs.