### PR TITLE
Add STL function to delete keys from Plaid DB

### DIFF
--- a/modules/tests/test_db/harness/harness.sh
+++ b/modules/tests/test_db/harness/harness.sh
@@ -16,13 +16,19 @@ RH_PID=$!
 
 sleep 2
 # Call the webhook
-curl http://$PLAID_LOCATION/webhook/$URL?key=some_key
-curl -d "first_value" http://$PLAID_LOCATION/webhook/$URL
-curl http://$PLAID_LOCATION/webhook/$URL?key=some_key
-curl http://$PLAID_LOCATION/webhook/$URL?key=my_key
-curl -d "second_value" http://$PLAID_LOCATION/webhook/$URL
-curl http://$PLAID_LOCATION/webhook/$URL?key=some_key
-curl http://$PLAID_LOCATION/webhook/$URL?key=my_key
+curl -d "get:some_key" http://$PLAID_LOCATION/webhook/$URL
+curl -d "insert:my_key:first_value" http://$PLAID_LOCATION/webhook/$URL
+curl -d "get:some_key" http://$PLAID_LOCATION/webhook/$URL
+curl -d "get:my_key" http://$PLAID_LOCATION/webhook/$URL
+curl -d "insert:my_key:second_value" http://$PLAID_LOCATION/webhook/$URL
+curl -d "get:some_key" http://$PLAID_LOCATION/webhook/$URL
+curl -d "get:my_key" http://$PLAID_LOCATION/webhook/$URL
+curl -d "delete:my_key" http://$PLAID_LOCATION/webhook/$URL
+curl -d "get:my_key" http://$PLAID_LOCATION/webhook/$URL
+curl -d "delete:another_key" http://$PLAID_LOCATION/webhook/$URL
+curl -d "get:another_key" http://$PLAID_LOCATION/webhook/$URL
+
+sleep 2
 
 kill $RH_PID 2>&1 > /dev/null
 
@@ -32,8 +38,10 @@ kill $RH_PID 2>&1 > /dev/null
 # first_value
 # Empty
 # second_value
+# Empty
+# Empty
 
-echo -e "Empty\nEmpty\nfirst_value\nEmpty\nsecond_value" > expected.txt
+echo -e "Empty\nEmpty\nfirst_value\nEmpty\nsecond_value\nEmpty\nEmpty" > expected.txt
 diff expected.txt $FILE
 RESULT=$?
 

--- a/modules/tests/test_db/src/lib.rs
+++ b/modules/tests/test_db/src/lib.rs
@@ -1,38 +1,41 @@
 use std::collections::HashMap;
 
-use plaid_stl::{
-    entrypoint_with_source_and_response, messages::LogSource, network::make_named_request, plaid,
-};
+use plaid_stl::{entrypoint_with_source, messages::LogSource, network::make_named_request, plaid};
 
-entrypoint_with_source_and_response!();
+entrypoint_with_source!();
 
-const KEY: &str = "my_key";
-
-/// When a GET is received, return a value read from the DB
-fn handle_get() -> Result<Option<String>, i32> {
-    let key = plaid::get_accessory_data_by_name("key").unwrap();
-    let mut value = plaid::storage::get(&key).unwrap();
-    if value.is_empty() {
-        value = "Empty".as_bytes().to_vec();
+/// When a POST is received, perform the requested action
+fn handle_post(log: &str) -> Result<(), i32> {
+    // The format of the log will be
+    // action:key[:value]
+    let parts: Vec<&str> = log.split(':').collect();
+    match parts[0] {
+        "get" => {
+            let key = parts[1];
+            let mut value = plaid::storage::get(&key).unwrap();
+            if value.is_empty() {
+                value = "Empty".as_bytes().to_vec();
+            }
+            make_named_request(
+                "test-response",
+                String::from_utf8(value).unwrap().as_str(),
+                HashMap::new(),
+            )
+            .unwrap();
+        }
+        "insert" => {
+            plaid::storage::insert(parts[1], parts[2].as_bytes()).unwrap();
+        }
+        "delete" => {
+            plaid::storage::delete(parts[1]).unwrap();
+        }
+        _ => panic!(),
     }
-    make_named_request(
-        "test-response",
-        String::from_utf8(value).unwrap().as_str(),
-        HashMap::new(),
-    )
-    .unwrap();
-    Ok(Some("OK".to_string()))
+    Ok(())
 }
 
-/// When a POST is received, write the received value to the DB, under a predefined key
-fn handle_post(log: &str) -> Result<Option<String>, i32> {
-    plaid::storage::insert(KEY, log.as_bytes()).unwrap();
-    Ok(Some("OK".to_string()))
-}
-
-fn main(log: String, source: LogSource) -> Result<Option<String>, i32> {
+fn main(log: String, source: LogSource) -> Result<(), i32> {
     match source {
-        LogSource::WebhookGet(_) => handle_get(),
         LogSource::WebhookPost(_) => handle_post(&log),
         _ => panic!(),
     }

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -26,7 +26,6 @@ lru_cache_size = 200
 "test_persistent_response.wasm" = 1024
 "test_sshcerts_usage.wasm" = 1024
 "test_logback.wasm" = 1024
-"test_db.wasm" = 1024
 "test_mnr.wasm" = 1024
 
 [loading.secrets]
@@ -251,10 +250,6 @@ type = "None"
 [webhooks."internal".webhooks."testdb"]
 log_type = "test_db"
 headers = []
-[webhooks."internal".webhooks."testdb".get_mode]
-response_mode = "rule:test_db.wasm"
-[webhooks."internal".webhooks."testdb".get_mode.caching_mode]
-type = "None"
 
 [webhooks."internal".webhooks."testfileopen"]
 log_type = "test_fileopen"

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -343,6 +343,7 @@ pub fn to_api_function(
         "get_time" => Function::new_typed(&mut store, super::internal::get_time),
         "storage_insert" => Function::new_typed_with_env(&mut store, &env, super::storage::insert),
         "storage_get" => Function::new_typed_with_env(&mut store, &env, super::storage::get),
+        "storage_delete" => Function::new_typed_with_env(&mut store, &env, super::storage::delete),
         "storage_list_keys" => {
             Function::new_typed_with_env(&mut store, &env, super::storage::list_keys)
         }

--- a/runtime/plaid/src/functions/storage.rs
+++ b/runtime/plaid/src/functions/storage.rs
@@ -86,7 +86,7 @@ pub fn insert(
     }
 }
 
-/// Store data in the storage system if one is configured
+/// Get data from the storage system if one is configured
 pub fn get(
     env: FunctionEnvMut<Env>,
     key_buf: WasmPtr<u8>,
@@ -163,7 +163,10 @@ pub fn list_keys(
     let memory_view = match get_memory(&env, &store) {
         Ok(memory_view) => memory_view,
         Err(e) => {
-            error!("{}: Memory error in storage_list_keys: {:?}", env_data.name, e);
+            error!(
+                "{}: Memory error in storage_list_keys: {:?}",
+                env_data.name, e
+            );
             return FunctionErrors::CouldNotGetAdequateMemory as i32;
         }
     };
@@ -171,27 +174,38 @@ pub fn list_keys(
     let prefix = match safely_get_string(&memory_view, prefix_buf, prefix_buf_len) {
         Ok(s) => s,
         Err(e) => {
-            error!("{}: Prefix error in storage_list_keys: {:?}", env_data.name, e);
+            error!(
+                "{}: Prefix error in storage_list_keys: {:?}",
+                env_data.name, e
+            );
             return FunctionErrors::ParametersNotUtf8 as i32;
         }
     };
-    let result = env_data
-        .api
-        .clone()
-        .runtime
-        .block_on(async move { storage.list_keys(&env_data.name, Some(prefix.as_str())).await });
+    let result = env_data.api.clone().runtime.block_on(async move {
+        storage
+            .list_keys(&env_data.name, Some(prefix.as_str()))
+            .await
+    });
 
     match result {
         Ok(keys) => {
             let serialized_keys = match serde_json::to_string(&keys) {
                 Ok(sk) => sk,
                 Err(e) => {
-                    error!("Could not serialize keys for namespaces {}: {e}", &env_data.name);
+                    error!(
+                        "Could not serialize keys for namespaces {}: {e}",
+                        &env_data.name
+                    );
                     return 0;
                 }
             };
 
-            match safely_write_data_back(&memory_view, &serialized_keys.as_bytes(), data_buffer, data_buffer_len) {
+            match safely_write_data_back(
+                &memory_view,
+                &serialized_keys.as_bytes(),
+                data_buffer,
+                data_buffer_len,
+            ) {
                 Ok(x) => x,
                 Err(e) => {
                     error!(
@@ -205,6 +219,72 @@ pub fn list_keys(
         Err(e) => {
             error!("Could not list keys for namespace {}: {e}", &env_data.name);
             return 0;
-        },
+        }
+    }
+}
+
+/// Delete data from the storage system if one is configured
+pub fn delete(
+    env: FunctionEnvMut<Env>,
+    key_buf: WasmPtr<u8>,
+    key_buf_len: u32,
+    data_buffer: WasmPtr<u8>,
+    data_buffer_len: u32,
+) -> i32 {
+    let store = env.as_store_ref();
+    let env_data = env.data();
+
+    let storage = if let Some(storage) = &env_data.storage {
+        storage
+    } else {
+        return FunctionErrors::ApiNotConfigured as i32;
+    };
+
+    let memory_view = match get_memory(&env, &store) {
+        Ok(memory_view) => memory_view,
+        Err(e) => {
+            error!("{}: Memory error in storage_delete: {:?}", env_data.name, e);
+            return FunctionErrors::CouldNotGetAdequateMemory as i32;
+        }
+    };
+
+    let key = match safely_get_string(&memory_view, key_buf, key_buf_len) {
+        Ok(s) => s,
+        Err(e) => {
+            error!("{}: Key error in storage_delete: {:?}", env_data.name, e);
+            return FunctionErrors::ParametersNotUtf8 as i32;
+        }
+    };
+
+    let result = match data_buffer_len {
+        // This is a call just to get the size of the buffer, so we do storage.get
+        0 => env_data
+            .api
+            .clone()
+            .runtime
+            .block_on(async move { storage.get(&env_data.name, &key).await }),
+        // This is a call to delete the value, so we do storage.delete
+        _ => env_data
+            .api
+            .clone()
+            .runtime
+            .block_on(async move { storage.delete(&env_data.name, &key).await }),
+    };
+
+    match result {
+        Ok(Some(data)) => {
+            match safely_write_data_back(&memory_view, &data, data_buffer, data_buffer_len) {
+                Ok(x) => x,
+                Err(e) => {
+                    error!(
+                        "{}: Data write error in storage_delete: {:?}",
+                        env_data.name, e
+                    );
+                    e as i32
+                }
+            }
+        }
+        Ok(None) => 0,
+        Err(_) => 0,
     }
 }


### PR DESCRIPTION
Rules can now call `plaid::storage::delete(...)` to delete a key in their namespace.
Also refactored the test for DB functionality.