### PR TITLE
Fix config checker release

### DIFF
--- a/.github/workflows/ConfigChecker.yaml
+++ b/.github/workflows/ConfigChecker.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   release_config_checker:
     name: Release config checker


### PR DESCRIPTION
The GH action to create a release needs extra permissions.