### PR TITLE
Add size limit for storing in the DB

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -52,9 +52,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -67,9 +67,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -124,30 +124,31 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "memchr"
@@ -178,7 +179,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -190,18 +191,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -251,6 +252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,18 +265,18 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -278,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -314,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -426,24 +433,24 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -452,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -462,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -475,9 +482,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-core"

--- a/modules/tests/test_db/harness/harness.sh
+++ b/modules/tests/test_db/harness/harness.sh
@@ -27,6 +27,17 @@ curl -d "delete:my_key" http://$PLAID_LOCATION/webhook/$URL
 curl -d "get:my_key" http://$PLAID_LOCATION/webhook/$URL
 curl -d "delete:another_key" http://$PLAID_LOCATION/webhook/$URL
 curl -d "get:another_key" http://$PLAID_LOCATION/webhook/$URL
+# At this point the DB is empty
+curl -d "insert:my_key:first_value" http://$PLAID_LOCATION/webhook/$URL
+curl -d "insert:a_key:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" http://$PLAID_LOCATION/webhook/$URL # too many bytes for the configured storage limit
+curl -d "get:a_key" http://$PLAID_LOCATION/webhook/$URL # Empty because insertion failed
+curl -d "insert:a_key:a" http://$PLAID_LOCATION/webhook/$URL # this is within the limit, so it's fine
+curl -d "get:a_key" http://$PLAID_LOCATION/webhook/$URL # a
+curl -d "delete:my_key" http://$PLAID_LOCATION/webhook/$URL
+curl -d "delete:a_key" http://$PLAID_LOCATION/webhook/$URL
+# now the DB is empty, so we can insert the long key/value pair
+curl -d "insert:a_key:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" http://$PLAID_LOCATION/webhook/$URL
+curl -d "get:a_key" http://$PLAID_LOCATION/webhook/$URL
 
 sleep 2
 
@@ -40,8 +51,11 @@ kill $RH_PID 2>&1 > /dev/null
 # second_value
 # Empty
 # Empty
+# Empty
+# a
+# aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
-echo -e "Empty\nEmpty\nfirst_value\nEmpty\nsecond_value\nEmpty\nEmpty" > expected.txt
+echo -e "Empty\nEmpty\nfirst_value\nEmpty\nsecond_value\nEmpty\nEmpty\nEmpty\na\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" > expected.txt
 diff expected.txt $FILE
 RESULT=$?
 

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -98,9 +98,9 @@ checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "arbitrary"
@@ -170,13 +170,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -185,7 +185,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -198,9 +198,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.13"
+version = "1.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a50b30228d3af8865ce83376b4e99e1ffa34728220fe2860e4df0bb5278d6"
+checksum = "9f40e82e858e02445402906e454a73e244c7f501fcae198977585946c48e8697"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -209,7 +209,7 @@ dependencies = [
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.1",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16d1aa50accc11a4b4d5c50f7fb81cc0cf60328259c587d0e6b0f11385bde46"
+checksum = "bee7643696e7fdd74c10f9eb42848a87fe469d35eae9c3323f80aa98f350baac"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -265,15 +265,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.50.0"
+version = "1.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd059dacda4dfd5b57f2bd453fc6555f9acb496cb77508d517da24cf5d73167"
+checksum = "011f0f9ebfaa2f76f0cddcc05a6951c74c226af8a493c56ef7ca1a880e1de4ac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.60.7",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -287,15 +287,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.57.0"
+version = "1.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac29664d633525cbf4c4de4d0351b0dc0cec7d0d903255ee05d3b0f512a3e97f"
+checksum = "bdc7908d175501c59616048f93fbcb5a909766e6e04f4cf13e4a0f7c88e9d007"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.1",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -310,15 +310,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.53.0"
+version = "1.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1605dc0bf9f0a4b05b451441a17fcb0bda229db384f23bf5cead3adbab0664ac"
+checksum = "921a13ed6aabe2d1258f65ef7804946255c799224440774c30e1a2c65cdf983a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.1",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -332,15 +332,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.54.0"
+version = "1.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f3f73466ff24f6ad109095e0f3f2c830bfb4cd6c8b12f744c8e61ebf4d3ba1"
+checksum = "196c952738b05dfc917d82a3e9b5ba850822a6d6a86d677afda2a156cc172ceb"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.1",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -354,15 +354,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.54.0"
+version = "1.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249b2acaa8e02fd4718705a9494e3eb633637139aa4bb09d70965b0448e865db"
+checksum = "33ef5b73a927ed80b44096f8c20fb4abae65469af15198367e179ae267256e9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json 0.61.1",
+ "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3820e0c08d0737872ff3c7c1f21ebbb6693d832312d6152bf18ef50a5471c2"
+checksum = "690118821e46967b3c4501d67d7d52dd75106a9c54cf36cefa1985cedbe94e05"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -390,7 +390,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.1.0",
+ "http 1.2.0",
  "once_cell",
  "percent-encoding",
  "sha2",
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427cb637d15d63d6f9aae26358e1c9a9c09d5aa490d64b09354c8217cfef0f28"
+checksum = "fa59d1327d8b5053c54bf2eaae63bf629ba9e904434d0835a28ed3c0ed0a614e"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.11"
+version = "0.60.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
+checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -431,18 +431,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.60.7"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
-dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.61.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e69cc50921eb913c6b662f8d909131bb3e6ad6cb6090d3a39b66fc5c52095"
+checksum = "623a51127f24c30776c8b374295f2df78d92517386f77ba30773f15a30ce1422"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -459,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.6"
+version = "1.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05dd41a70fc74051758ee75b5c4db2c0ca070ed9229c3df50e9475cda1cb985"
+checksum = "865f7050bbc7107a6c98a397a9fcd9413690c27fa718446967cf03b2d3ac517e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -474,7 +465,7 @@ dependencies = [
  "http-body 0.4.6",
  "http-body 1.0.1",
  "httparse",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
@@ -494,7 +485,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.1.0",
+ "http 1.2.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -503,16 +494,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.11"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ddc9bd6c28aeb303477170ddd183760a956a03e083b3902a990238a7e3792d"
+checksum = "a28f6feb647fb5e0d5b50f0472c19a7db9462b74e2fec01bb0b44eedcc834e97"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -538,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+checksum = "b0df5a18c4f951c645300d365fec53a61418bcf4650f604f85fe2a665bfaa0c2"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -613,9 +604,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "binstring"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0d60973d9320722cb1206f412740e162a33b8547ea8d6be75d7cff237c7a85"
+checksum = "ed79c2a8151273c70956b5e3cdfdc1ff6c1a8b9779ba59c6807d281b32ee2f86"
 
 [[package]]
 name = "bitflags"
@@ -625,9 +616,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitvec"
@@ -697,9 +688,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "bytes-utils"
@@ -713,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -734,9 +725,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -749,18 +740,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -768,15 +759,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "coarsetime"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b3839cf01bb7960114be3ccf2340f541b6d0c81f8690b007b2b39f750f7e5d"
+checksum = "4252bf230cb600c19826a575b31c8c9c84c6f11acfab6dfcad2e941b10b6f8e2"
 dependencies = [
  "libc",
  "wasix",
@@ -870,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -971,18 +962,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -999,18 +990,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-bigint"
@@ -1036,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "ct-codecs"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "026ac6ceace6298d2c557ef5ed798894962296469ec7842288ea64674201a2d1"
+checksum = "b916ba8ce9e4182696896f015e8a5ae6081b305f74690baa8465e35f5a142ea4"
 
 [[package]]
 name = "darling"
@@ -1060,7 +1051,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1071,7 +1062,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1096,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "der"
@@ -1153,7 +1144,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1176,7 +1167,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1286,7 +1277,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1310,12 +1301,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1326,9 +1317,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -1370,9 +1361,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "form_urlencoded"
@@ -1455,7 +1446,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1561,7 +1552,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.6.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1589,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1638,12 +1629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,24 +1654,24 @@ dependencies = [
 
 [[package]]
 name = "hmac-sha1-compact"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9d405ec732fa3fcde87264e54a32a84956a377b3e3107de96e59b798c84a7"
+checksum = "18492c9f6f9a560e0d346369b665ad2bdbc89fa9bceca75796584e79042694c3"
 
 [[package]]
 name = "hmac-sha256"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3688e69b38018fec1557254f64c8dc2cc8ec502890182f395dbb0aa997aa5735"
+checksum = "4a8575493d277c9092b988c780c94737fb9fd8651a1001e16bee3eccfc1baedb"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "hmac-sha512"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ce1f4656bae589a3fab938f9f09bf58645b7ed01a2c5f8a3c238e01a4ef78a"
+checksum = "b0b3a0f572aa8389d325f5852b9e0a333a15b0f86ecccbb3fdb6e97cd86dc67c"
 dependencies = [
  "digest",
 ]
@@ -1704,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -1731,7 +1716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -1742,7 +1727,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1767,9 +1752,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1791,14 +1776,14 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -1816,7 +1801,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -1831,8 +1816,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
- "http 1.1.0",
- "hyper 1.5.1",
+ "http 1.2.0",
+ "hyper 1.5.2",
  "hyper-util",
  "log",
  "rustls 0.22.4",
@@ -1845,18 +1830,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.1.0",
- "hyper 1.5.1",
+ "http 1.2.0",
+ "hyper 1.5.2",
  "hyper-util",
- "rustls 0.23.17",
+ "rustls 0.23.21",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tower-service",
  "webpki-roots",
 ]
@@ -1867,7 +1852,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1883,9 +1868,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2031,7 +2016,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2073,12 +2058,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2092,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
@@ -2108,16 +2093,17 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2138,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "jwt-simple"
-version = "0.12.10"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ae7e0018905a795d6f2a60ac32a547490abdd8df509906a8c6171e6d861711"
+checksum = "b00e03c08ce71da10a3ad9267b963c03fc4234a56713d87648547b3fdda872a6"
 dependencies = [
  "anyhow",
  "binstring",
@@ -2158,7 +2144,7 @@ dependencies = [
  "serde",
  "serde_json",
  "superboring",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "zeroize",
 ]
 
@@ -2193,9 +2179,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libflate"
@@ -2233,16 +2219,16 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "libc",
- "redox_syscall 0.5.7",
+ "redox_syscall 0.5.8",
 ]
 
 [[package]]
 name = "libsodium-sys-stable"
-version = "1.22.1"
+version = "1.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798a1c6d8c3424c0686ca46f2929d81809b371ef61a68c5d1880570584d32b85"
+checksum = "a7717550bb3ec725f7b312848902d1534f332379b1d575d2347ec265c8814566"
 dependencies = [
  "cc",
  "libc",
@@ -2257,15 +2243,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "litrs"
@@ -2291,9 +2277,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lru"
@@ -2301,7 +2287,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2361,26 +2347,25 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minisign-verify"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05b5d0594e0cb1ad8cee3373018d2b84e25905dc75b2468114cc9a8e86cfc20"
+checksum = "6367d84fb54d4242af283086402907277715b8fe46976963af5ebf173f8efba3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -2485,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -2507,10 +2492,10 @@ dependencies = [
  "either",
  "futures",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-rustls 0.26.0",
  "hyper-timeout",
  "hyper-util",
@@ -2525,7 +2510,7 @@ dependencies = [
  "serde_urlencoded",
  "snafu",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-http",
  "tracing",
  "url",
@@ -2554,9 +2539,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "outref"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
@@ -2625,7 +2610,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.7",
+ "redox_syscall 0.5.8",
  "smallvec",
  "windows-targets",
 ]
@@ -2672,29 +2657,29 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -2731,7 +2716,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plaid"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "alkali",
  "async-trait",
@@ -2745,7 +2730,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "hex",
- "http 1.1.0",
+ "http 1.2.0",
  "jsonwebtoken",
  "jwt-simple",
  "log",
@@ -2777,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -2837,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -2891,9 +2876,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.17",
+ "rustls 0.23.21",
  "socket2",
- "thiserror 2.0.3",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
 ]
@@ -2909,10 +2894,10 @@ dependencies = [
  "rand",
  "ring 0.17.8",
  "rustc-hash",
- "rustls 0.23.17",
+ "rustls 0.23.21",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.3",
+ "thiserror 2.0.11",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2920,9 +2905,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
+checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2934,9 +2919,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -3021,11 +3006,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -3098,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3108,11 +3093,11 @@ dependencies = [
  "cookie_store",
  "futures-core",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
- "hyper-rustls 0.27.3",
+ "hyper 1.5.2",
+ "hyper-rustls 0.27.5",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -3122,7 +3107,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.17",
+ "rustls 0.23.21",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -3130,7 +3115,8 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
+ "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3230,9 +3216,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rsa"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
 dependencies = [
  "const-oid",
  "digest",
@@ -3257,9 +3243,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustc_version"
@@ -3281,15 +3267,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3320,9 +3306,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.17"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "once_cell",
  "ring 0.17.8",
@@ -3377,9 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 dependencies = [
  "web-time",
 ]
@@ -3404,6 +3390,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -3477,7 +3469,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3486,9 +3478,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3496,21 +3488,21 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
+checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -3537,20 +3529,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -3651,13 +3643,13 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "time",
 ]
 
@@ -3716,14 +3708,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3765,9 +3757,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superboring"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee25cd9d145d2c1ef92a52720376eeb510c8870dfa0f84edb371901ec6a12ca"
+checksum = "515cce34a781d7250b8a65706e0f2a5b99236ea605cb235d4baed6685820478f"
 dependencies = [
  "getrandom",
  "hmac-sha256",
@@ -3789,9 +3781,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3827,7 +3819,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3873,11 +3865,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -3888,25 +3880,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -3925,9 +3917,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3945,9 +3937,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3960,9 +3952,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3978,13 +3970,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4010,12 +4002,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.17",
- "rustls-pki-types",
+ "rustls 0.23.21",
  "tokio",
 ]
 
@@ -4039,19 +4030,19 @@ checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.17",
+ "rustls 0.23.21",
  "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tungstenite 0.23.0",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4100,20 +4091,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-http"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4133,9 +4139,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -4145,20 +4151,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
@@ -4178,7 +4184,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.1.0",
+ "http 1.2.0",
  "httparse",
  "log",
  "rand",
@@ -4197,11 +4203,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.1.0",
+ "http 1.2.0",
  "httparse",
  "log",
  "rand",
- "rustls 0.23.17",
+ "rustls 0.23.21",
  "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
@@ -4216,9 +4222,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicase"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -4246,9 +4252,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.10.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -4294,9 +4300,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 
 [[package]]
 name = "vcpkg"
@@ -4336,7 +4342,7 @@ dependencies = [
  "futures-util",
  "headers",
  "http 0.2.12",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "log",
  "mime",
  "mime_guess",
@@ -4373,47 +4379,48 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4421,22 +4428,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasmer"
@@ -4591,16 +4601,16 @@ version = "0.121.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
- "bitflags 2.6.0",
- "indexmap 2.6.0",
+ "bitflags 2.8.0",
+ "indexmap 2.7.1",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4618,9 +4628,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.6"
+version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4862,9 +4872,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
 dependencies = [
  "libc",
  "linux-raw-sys",
@@ -4879,9 +4889,9 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.12"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yasna"
@@ -4894,9 +4904,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -4906,13 +4916,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
  "synstructure 0.13.1",
 ]
 
@@ -4934,27 +4944,27 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
  "synstructure 0.13.1",
 ]
 
@@ -4983,23 +4993,23 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "zip"
-version = "2.2.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5e4288ea4057ae23afc69a4472434a87a2495cafce6632fd1c4ec9f5cf3494"
+checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
 dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.6.0",
+ "indexmap 2.7.1",
  "memchr",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "zopfli",
 ]
 

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.14.2"
+version = "0.15.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/messages.rs
+++ b/runtime/plaid-stl/src/messages.rs
@@ -27,6 +27,11 @@ pub enum LogSource {
     Logback(String),
 }
 
+/// Represents how many logbacks can be triggered by the module that handles a message.
+/// This can be a finite value (u32, with 0 a valid value) or it can be unlimited.
+/// These are the TOML encodings for the two cases:
+/// * "Unlimited"
+/// * { Limited = value }
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LogbacksAllowed {
     Unlimited,

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.14.2"
+version = "0.15.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -60,6 +60,12 @@ okta = 200
 "example_rule.wasm" = 50
 "test_crashtest.wasm" = 150
 
+[loading.storage_size]
+default = "Unlimited"
+[loading.storage_size.log_type]
+[loading.storage_size.module_overrides]
+"test_db.wasm" = { Limited = 50 }
+
 # [apis."okta"]
 # token = ""
 # domain = ""

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Loading all the modules");
     // Load all the modules that form our Nanoservices and Plaid rules
-    let modules = Arc::new(loader::load(config.loading).unwrap());
+    let modules = Arc::new(loader::load(config.loading, storage.clone()).await.unwrap());
     let modules_by_name = Arc::new(modules.get_modules());
 
     info!(

--- a/runtime/plaid/src/executor/mod.rs
+++ b/runtime/plaid/src/executor/mod.rs
@@ -3,7 +3,7 @@ use crate::apis::Api;
 use crate::functions::{
     create_bindgen_externref_xform, create_bindgen_placeholder, link_functions_to_module, LinkError,
 };
-use crate::loader::{LimitValue, PlaidModule};
+use crate::loader::PlaidModule;
 use crate::logging::{Logger, LoggingError};
 use crate::performance::ModulePerformanceMetadata;
 use crate::storage::Storage;
@@ -16,9 +16,8 @@ use serde::{Deserialize, Serialize};
 use wasmer::{FunctionEnv, Imports, Instance, Memory, RuntimeError, Store, TypedFunction};
 use wasmer_middlewares::metering::{get_remaining_points, MeteringPoints};
 
-use lru::LruCache;
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::Instant;
 
@@ -94,20 +93,14 @@ impl Message {
 
 /// Environment for executing a module on a message
 pub struct Env {
-    // Name of the current module
-    pub name: String,
-    // Cache if available
-    pub cache: Option<Arc<RwLock<LruCache<String, String>>>>,
+    // A handle to the module which is processing the message
+    pub module: Arc<PlaidModule>,
     // The message that is being processed.
     pub message: Message,
     // A handle to the API to make external calls
     pub api: Arc<Api>,
     // A handle to the storage system if one is configured
     pub storage: Option<Arc<Storage>>,
-    // Number of bytes the module is currently saving in persistent storage
-    pub storage_current: Arc<RwLock<u64>>,
-    // Max number of bytes the module can save to persistent storage
-    pub storage_limit: LimitValue,
     // A sender to the external logging system
     pub external_logging_system: Logger,
     /// Memory for host-guest communication
@@ -236,13 +229,10 @@ fn prepare_for_execution(
     }
 
     let env = Env {
-        name: plaid_module.name.clone(),
-        cache: plaid_module.cache.clone(),
+        module: plaid_module.clone(),
         message: message.create_duplicate(),
         api: api.clone(),
         storage: storage.clone(),
-        storage_current: plaid_module.storage_current.clone(),
-        storage_limit: plaid_module.storage_limit.clone(),
         external_logging_system: els.clone(),
         memory: None,
         response,
@@ -311,43 +301,6 @@ fn prepare_for_execution(
         .map_err(|_| ExecutorError::InvalidEntrypoint)?;
 
     Ok((store, instance, ep, envr))
-}
-
-/// Update bytes counter for storage used by a module
-fn update_used_storage(
-    plaid_module: &Arc<PlaidModule>,
-    env: &FunctionEnv<Env>,
-    store: &Store,
-) -> Result<(), ExecutorError> {
-    // Take the new value for used storage from the env
-    let new_used_storage = match env.as_ref(&store).storage_current.read() {
-        Ok(data) => *data,
-        Err(e) => {
-            error!(
-                "Critical error getting a read lock on used storage: {:?}",
-                e
-            );
-            return Err(ExecutorError::MemoryError(
-                "Critical error getting a read lock on used storage".to_string(),
-            ));
-        }
-    };
-    // Write the new value in the long-lived struct that represents the module
-    match plaid_module.storage_current.write() {
-        Ok(mut v) => {
-            *v = new_used_storage;
-            Ok(())
-        }
-        Err(e) => {
-            error!(
-                "Critical error getting a write lock on used storage: {:?}",
-                e
-            );
-            Err(ExecutorError::MemoryError(
-                "Critical error getting a write lock on used storage".to_string(),
-            ))
-        }
-    }
 }
 
 /// Update a module's persistent response
@@ -542,16 +495,6 @@ fn process_message_with_module(
         els.log_module_error(
             module.name.clone(),
             format!("Failed to update persistent response: {e}"),
-            message.data.clone(),
-        )
-        .unwrap();
-    }
-
-    // Update the counter for used storage
-    if let Err(e) = update_used_storage(&module, &env, &mut store) {
-        els.log_module_error(
-            module.name.clone(),
-            format!("Failed to update used storage counter: {e}"),
             message.data.clone(),
         )
         .unwrap();

--- a/runtime/plaid/src/functions/cache.rs
+++ b/runtime/plaid/src/functions/cache.rs
@@ -18,7 +18,7 @@ pub fn insert(
     let store = env.as_store_ref();
     let env_data = env.data();
 
-    let cache = if let Some(c) = &env_data.cache {
+    let cache = if let Some(c) = &env_data.module.cache {
         c
     } else {
         return FunctionErrors::CacheDisabled as i32;
@@ -27,7 +27,7 @@ pub fn insert(
     let memory_view = match get_memory(&env, &store) {
         Ok(memory_view) => memory_view,
         Err(e) => {
-            error!("{}: Memory error in cache_insert: {:?}", env_data.name, e);
+            error!("{}: Memory error in cache_insert: {:?}", env_data.module.name, e);
             return FunctionErrors::CouldNotGetAdequateMemory as i32;
         }
     };
@@ -35,7 +35,7 @@ pub fn insert(
     let key = match safely_get_string(&memory_view, key_buf, key_buf_len) {
         Ok(s) => s,
         Err(e) => {
-            error!("{}: Key error in cache_insert: {:?}", env_data.name, e);
+            error!("{}: Key error in cache_insert: {:?}", env_data.module.name, e);
             return FunctionErrors::ParametersNotUtf8 as i32;
         }
     };
@@ -44,7 +44,7 @@ pub fn insert(
     let value = match safely_get_string(&memory_view, value_buf, value_buf_len) {
         Ok(d) => d,
         Err(e) => {
-            error!("{}: Value error in cache_insert: {:?}", env_data.name, e);
+            error!("{}: Value error in cache_insert: {:?}", env_data.module.name, e);
             return FunctionErrors::CouldNotGetAdequateMemory as i32;
         }
     };
@@ -61,7 +61,7 @@ pub fn insert(
                 Err(e) => {
                     error!(
                         "{}: Data write error in cache_insert: {:?}",
-                        env_data.name, e
+                        env_data.module.name, e
                     );
                     e as i32
                 }
@@ -71,7 +71,7 @@ pub fn insert(
         Err(e) => {
             if let Err(e) = env_data.external_logging_system.log_internal_message(
                 crate::logging::Severity::Error,
-                format!("Cache system error in [{}]: {:?}", env_data.name, e),
+                format!("Cache system error in [{}]: {:?}", env_data.module.name, e),
             ) {
                 error!("Logging system is not working!!: {:?}", e);
             }
@@ -91,7 +91,7 @@ pub fn get(
     let store = env.as_store_ref();
     let env_data = env.data();
 
-    let cache = if let Some(c) = &env_data.cache {
+    let cache = if let Some(c) = &env_data.module.cache {
         c
     } else {
         return FunctionErrors::CacheDisabled as i32;
@@ -100,7 +100,7 @@ pub fn get(
     let memory_view = match get_memory(&env, &store) {
         Ok(memory_view) => memory_view,
         Err(e) => {
-            error!("{}: Memory error in cache_get: {:?}", env_data.name, e);
+            error!("{}: Memory error in cache_get: {:?}", env_data.module.name, e);
             return FunctionErrors::CouldNotGetAdequateMemory as i32;
         }
     };
@@ -108,7 +108,7 @@ pub fn get(
     let key = match safely_get_string(&memory_view, key_buf, key_buf_len) {
         Ok(s) => s,
         Err(e) => {
-            error!("{}: Key error in cache_get: {:?}", env_data.name, e);
+            error!("{}: Key error in cache_get: {:?}", env_data.module.name, e);
             return FunctionErrors::ParametersNotUtf8 as i32;
         }
     };
@@ -123,7 +123,7 @@ pub fn get(
             ) {
                 Ok(x) => x,
                 Err(e) => {
-                    error!("{}: Data write error in cache_get: {:?}", env_data.name, e);
+                    error!("{}: Data write error in cache_get: {:?}", env_data.module.name, e);
                     e as i32
                 }
             }
@@ -132,7 +132,7 @@ pub fn get(
         Err(e) => {
             if let Err(e) = env_data.external_logging_system.log_internal_message(
                 crate::logging::Severity::Error,
-                format!("Cache system error in [{}]: {:?}", env_data.name, e),
+                format!("Cache system error in [{}]: {:?}", env_data.module.name, e),
             ) {
                 error!("Logging system is not working!!: {:?}", e);
             }

--- a/runtime/plaid/src/functions/internal.rs
+++ b/runtime/plaid/src/functions/internal.rs
@@ -18,7 +18,7 @@ pub fn print_debug_string(env: FunctionEnvMut<Env>, log_buffer: WasmPtr<u8>, log
         Err(e) => {
             error!(
                 "{}: Memory error in fetch_from_module: {:?}",
-                env.data().name,
+                env.data().module.name,
                 e
             );
             return;
@@ -28,12 +28,12 @@ pub fn print_debug_string(env: FunctionEnvMut<Env>, log_buffer: WasmPtr<u8>, log
     let message = match safely_get_string(&memory_view, log_buffer, log_buffer_size) {
         Ok(s) => s,
         Err(e) => {
-            error!("{}: Error in print_debug_string: {:?}", env.data().name, e);
+            error!("{}: Error in print_debug_string: {:?}", env.data().module.name, e);
             return;
         }
     };
 
-    debug!("Message from [{}]: {message}", env.data().name);
+    debug!("Message from [{}]: {message}", env.data().module.name);
 }
 
 /// Implement a way for a module to set a descriptive context for
@@ -49,7 +49,7 @@ pub fn set_error_context(
         Err(e) => {
             error!(
                 "{}: Memory error in fetch_from_module: {:?}",
-                env.data().name,
+                env.data().module.name,
                 e
             );
             return;
@@ -59,7 +59,7 @@ pub fn set_error_context(
     let message = match safely_get_string(&memory_view, context_buffer, context_buffer_size) {
         Ok(s) => s,
         Err(e) => {
-            error!("{}: Error in set_error_context: {:?}", env.data().name, e);
+            error!("{}: Error in set_error_context: {:?}", env.data().module.name, e);
             return;
         }
     };
@@ -132,7 +132,7 @@ pub fn log_back_detailed(
     // How many logbacks the rule would like this new invocation to be able to trigger
     logbacks_requested: LogbacksAllowed,
 ) -> u32 {
-    let name = env.data().name.clone();
+    let name = env.data().module.name.clone();
     // We need to check that the that the module has the logbacks_allowed "budget"
     // for the logback they are requesting
     let assigned_budget = match &mut env.data_mut().message.logbacks_allowed {
@@ -178,7 +178,7 @@ pub fn log_back_detailed(
     let memory_view = match get_memory(&env, &store) {
         Ok(memory_view) => memory_view,
         Err(e) => {
-            error!("{}: Memory error in log_back: {:?}", env_data.name, e);
+            error!("{}: Memory error in log_back: {:?}", env_data.module.name, e);
             return 1;
         }
     };
@@ -186,7 +186,7 @@ pub fn log_back_detailed(
     let type_ = match safely_get_string(&memory_view, type_buf, type_buf_len) {
         Ok(s) => s,
         Err(e) => {
-            error!("{}: Error in log_back: {:?}", env_data.name, e);
+            error!("{}: Error in log_back: {:?}", env_data.module.name, e);
             return 1;
         }
     };
@@ -195,7 +195,7 @@ pub fn log_back_detailed(
     let log = match safely_get_memory(&memory_view, log_buf, log_buf_len) {
         Ok(d) => d,
         Err(e) => {
-            error!("{}: Error in log_back: {:?}", env_data.name, e);
+            error!("{}: Error in log_back: {:?}", env_data.module.name, e);
             return 1;
         }
     };
@@ -204,7 +204,7 @@ pub fn log_back_detailed(
     api.clone().runtime.block_on(async move {
         match api.general.as_ref() {
             Some(general) => {
-                if general.log_back(&type_, &log, &env_data.name, delay as u64, assigned_budget) {
+                if general.log_back(&type_, &log, &env_data.module.name, delay as u64, assigned_budget) {
                     0
                 } else {
                     1
@@ -245,7 +245,7 @@ pub fn fetch_random_bytes(
         Err(e) => {
             error!(
                 "{}: Memory error in fetch_random_bytes: {:?}",
-                env_data.name, e
+                env_data.module.name, e
             );
             return FunctionErrors::CouldNotGetAdequateMemory as i32;
         }
@@ -256,7 +256,7 @@ pub fn fetch_random_bytes(
         Err(e) => {
             error!(
                 "{}: Data write error in fetch_random_bytes: {:?}",
-                env_data.name, e
+                env_data.module.name, e
             );
             e as i32
         }

--- a/runtime/plaid/src/functions/message.rs
+++ b/runtime/plaid/src/functions/message.rs
@@ -15,7 +15,7 @@ pub fn fetch_data_and_source(
         Err(e) => {
             error!(
                 "{}: Memory error in fetch_from_module: {:?}",
-                env.data().name,
+                env.data().module.name,
                 e
             );
             return e as i32;
@@ -38,7 +38,7 @@ pub fn fetch_data_and_source(
         Err(e) => {
             error!(
                 "{}: Could not serialize the source: {}. Error: {e}",
-                env.data().name,
+                env.data().module.name,
                 env.data().message.source,
             );
             return -4;
@@ -56,7 +56,7 @@ pub fn fetch_data_and_source(
     match safely_write_data_back(&memory_view, &rule_data, data_buffer, buffer_size) {
         Ok(x) => x,
         Err(e) => {
-            error!("{}: Error in fetch_data: {:?}", env.data().name, e);
+            error!("{}: Error in fetch_data: {:?}", env.data().module.name, e);
             e as i32
         }
     }
@@ -70,7 +70,7 @@ pub fn fetch_data(env: FunctionEnvMut<Env>, data_buffer: WasmPtr<u8>, buffer_siz
         Err(e) => {
             error!(
                 "{}: Memory error in fetch_from_module: {:?}",
-                env.data().name,
+                env.data().module.name,
                 e
             );
             return e as i32;
@@ -82,7 +82,7 @@ pub fn fetch_data(env: FunctionEnvMut<Env>, data_buffer: WasmPtr<u8>, buffer_siz
     match safely_write_data_back(&memory_view, data, data_buffer, buffer_size) {
         Ok(x) => x,
         Err(e) => {
-            error!("{}: Error in fetch_data: {:?}", env.data().name, e);
+            error!("{}: Error in fetch_data: {:?}", env.data().module.name, e);
             e as i32
         }
     }
@@ -96,7 +96,7 @@ pub fn fetch_source(env: FunctionEnvMut<Env>, data_buffer: WasmPtr<u8>, buffer_s
         Err(e) => {
             error!(
                 "{}: Memory error in fetch_from_module: {:?}",
-                env.data().name,
+                env.data().module.name,
                 e
             );
             return e as i32;
@@ -117,7 +117,7 @@ pub fn fetch_source(env: FunctionEnvMut<Env>, data_buffer: WasmPtr<u8>, buffer_s
     } else {
         error!(
             "{}: Could not serialize the source: {}",
-            env.data().name,
+            env.data().module.name,
             env.data().message.source,
         );
         return -4;
@@ -127,7 +127,7 @@ pub fn fetch_source(env: FunctionEnvMut<Env>, data_buffer: WasmPtr<u8>, buffer_s
     match safely_write_data_back(&memory_view, source.as_bytes(), data_buffer, buffer_size) {
         Ok(x) => x,
         Err(e) => {
-            error!("{}: Error in fetch_source: {:?}", env.data().name, e);
+            error!("{}: Error in fetch_source: {:?}", env.data().module.name, e);
             e as i32
         }
     }
@@ -147,7 +147,7 @@ pub fn fetch_accessory_data_by_name(
         Err(e) => {
             error!(
                 "{}: Memory error in fetch_from_module: {:?}",
-                env.data().name,
+                env.data().module.name,
                 e
             );
             return e as i32;
@@ -161,7 +161,7 @@ pub fn fetch_accessory_data_by_name(
         Err(e) => {
             error!(
                 "{}: Error in fetch_accessory_data_by_name: {:?}",
-                env.data().name,
+                env.data().module.name,
                 e
             );
             return e as i32;
@@ -175,7 +175,7 @@ pub fn fetch_accessory_data_by_name(
             Err(e) => {
                 error!(
                     "{}: Error in fetch_accessory_data_by_name: {:?}",
-                    env.data().name,
+                    env.data().module.name,
                     e
                 );
                 e as i32

--- a/runtime/plaid/src/functions/mod.rs
+++ b/runtime/plaid/src/functions/mod.rs
@@ -25,6 +25,7 @@ pub enum FunctionErrors {
     CacheDisabled = -7,
     CouldNotGetAdequateMemory = -8,
     FailedToWriteGuestMemory = -9,
+    StorageLimitReached = -10,
 }
 
 #[derive(Debug)]

--- a/runtime/plaid/src/functions/response.rs
+++ b/runtime/plaid/src/functions/response.rs
@@ -18,7 +18,7 @@ pub fn get_response(
         Err(e) => {
             error!(
                 "{}: Memory error in fetch_from_module: {:?}",
-                env.data().name,
+                env.data().module.name,
                 e
             );
             return FunctionErrors::CouldNotGetAdequateMemory as i32;
@@ -28,7 +28,7 @@ pub fn get_response(
     let response = match &env.data().response {
         Some(r) => r,
         None => {
-            error!("{}: No response set", env.data().name);
+            error!("{}: No response set", env.data().module.name);
             return 0;
         }
     };
@@ -43,7 +43,7 @@ pub fn get_response(
         Err(e) => {
             error!(
                 "{}: Data write error in get_response: {:?}",
-                env.data().name,
+                env.data().module.name,
                 e
             );
             e as i32
@@ -64,7 +64,7 @@ pub fn set_response(
         Err(e) => {
             error!(
                 "{}: Memory error in fetch_from_module: {:?}",
-                env.data().name,
+                env.data().module.name,
                 e
             );
             return;
@@ -74,7 +74,7 @@ pub fn set_response(
     let message = match safely_get_string(&memory_view, response_buffer, response_buffer_size) {
         Ok(s) => s,
         Err(e) => {
-            error!("{}: Error in set_response: {:?}", env.data().name, e);
+            error!("{}: Error in set_response: {:?}", env.data().module.name, e);
             return;
         }
     };

--- a/runtime/plaid/src/functions/storage.rs
+++ b/runtime/plaid/src/functions/storage.rs
@@ -58,62 +58,81 @@ pub fn insert(
     };
 
     let storage_key = key.clone();
-    let get_key = key.clone();
-    let key_len = storage_key.as_bytes().len();
 
-    // Get a lock on the storage counter for the module that is processing this message.
-    // This ensures no race conditions if multiple instances of the same module are running in parallel.
-    // The guard will go out of scope at the end of this method, thus releasing the lock.
-    let mut storage_current = match env_data.module.storage_current.write() {
-        Ok(g) => g,
-        Err(e) => {
-            error!("Critical error getting a lock on used storage: {:?}", e);
-            return FunctionErrors::InternalApiError as i32;
+    // The insertion proceeds differently depending on whether the module's storage is limited or not.
+    let insertion_result = match env_data.module.storage_limit {
+        LimitValue::Unlimited => {
+            // The module has unlimited storage, so we don't check / update any counters and just proceed with the operation
+            env_data.api.clone().runtime.block_on(async move {
+                storage
+                    .insert(env_data.module.name.clone(), storage_key, value)
+                    .await
+            })
+        }
+        LimitValue::Limited(storage_limit) => {
+            // The module has limited storage, so we need to check / update counters (with locks) because the operation might have to be rejected.
+
+            // Get a lock on the storage counter for the module that is processing this message.
+            // This ensures no race conditions if multiple instances of the same module are running in parallel.
+            // The guard will go out of scope at the end of this block, thus releasing the lock. After this block, we won't touch the counter again.
+            let mut storage_current = match env_data.module.storage_current.write() {
+                Ok(g) => g,
+                Err(e) => {
+                    error!("Critical error getting a lock on used storage: {:?}", e);
+                    return FunctionErrors::InternalApiError as i32;
+                }
+            };
+
+            // We check if this insert would overwrite some existing data. If so, we need to take that into account when
+            // computing the storage that would be occupied at the end of the insert operation.
+            // Note: if we have existing data, then we need to count the key's length as well. This is because at the end
+            // of a possible insertion, we would have only one key.
+            let get_key = key.clone();
+            let key_len = key.as_bytes().len();
+            let existing_data_size = match env_data
+                .api
+                .clone()
+                .runtime
+                .block_on(async move { storage.get(&env_data.module.name, &get_key).await })
+            {
+                Ok(data) => match data {
+                    None => 0u64,
+                    Some(d) => d.len() as u64 + key_len as u64,
+                },
+                Err(_) => {
+                    return FunctionErrors::InternalApiError as i32;
+                }
+            };
+
+            // Calculate the amount of storage that would be used after successfully inserting.
+            // Note: we _substract_ the size of existing data. If we were to insert the new data, the old data would be overwritten.
+            let would_be_used_storage =
+                *storage_current + key_len as u64 + value.len() as u64 - existing_data_size;
+            // no problem with underflowing because the result will never be negative (since *storage_current >= existing_data_size)
+
+            // If we would go above the limited storage, reject the insert
+            if would_be_used_storage > storage_limit {
+                error!("{}: Could not insert key/value with key {storage_key} as that would bring us above the configured storage limit.", env_data.module.name);
+                return FunctionErrors::StorageLimitReached as i32;
+            }
+
+            let result = env_data.api.clone().runtime.block_on(async move {
+                storage
+                    .insert(env_data.module.name.clone(), storage_key, value)
+                    .await
+            });
+            // If the insertion went well, update counter for used storage.
+            // If the insertion failed for some reason, we don't update the counter and release the lock: no harm done.
+            if result.is_ok() {
+                *storage_current = would_be_used_storage;
+            }
+            result
         }
     };
 
-    // We check if this insert would overwrite some existing data. If so, we need to take that into account when
-    // computing the storage that would be occupied at the end of the insert operation.
-    // Note: if we have existing data, then we need to count the key's length as well. This is because at the end
-    // of a possible insertion, we would have only one key.
-    let existing_data_size = match env_data
-        .api
-        .clone()
-        .runtime
-        .block_on(async move { storage.get(&env_data.module.name, &get_key).await })
-    {
-        Ok(data) => match data {
-            None => 0u64,
-            Some(d) => d.len() as u64 + key_len as u64,
-        },
-        Err(_) => {
-            return FunctionErrors::InternalApiError as i32;
-        }
-    };
-
-    // Calculate the amount of storage that would be used after successfully inserting.
-    // Note: we _substract_ the size of existing data. If we were to insert the new data, the old data would be overwritten.
-    let would_be_used_storage =
-        *storage_current + key_len as u64 + value.len() as u64 - existing_data_size; // no problem with underflowing because the result will never be negative (since used_storage >= existing_data_size)
-
-    // If we have limited storage, this insert might fail
-    if let LimitValue::Limited(storage_limit) = env_data.module.storage_limit {
-        if would_be_used_storage > storage_limit {
-            error!("{}: Could not insert key/value with key {storage_key} as that would bring us above the configured storage limit.", env_data.module.name);
-            return FunctionErrors::StorageLimitReached as i32;
-        }
-    }
-
-    let result = env_data.api.clone().runtime.block_on(async move {
-        storage
-            .insert(env_data.module.name.clone(), storage_key, value)
-            .await
-    });
-
-    match result {
+    // Process the insertion result and return info to the caller
+    match insertion_result {
         Ok(data) => {
-            // The insertion went fine: update counter for used storage
-            *storage_current = would_be_used_storage;
             match data {
                 Some(data) => {
                     // If the data is too large to fit in the buffer that was passed to us. Unfortunately this is a somewhat
@@ -322,17 +341,6 @@ pub fn delete(
         }
     };
 
-    // Get a lock on the storage counter for the module that is processing this message.
-    // This ensures no race conditions if multiple instances of the same module are running in parallel.
-    // The guard will go out of scope at the end of this method, thus releasing the lock.
-    let mut storage_current = match env_data.module.storage_current.write() {
-        Ok(g) => g,
-        Err(e) => {
-            error!("Critical error getting a lock on used storage: {:?}", e);
-            return FunctionErrors::InternalApiError as i32;
-        }
-    };
-
     let key = match safely_get_string(&memory_view, key_buf, key_buf_len) {
         Ok(s) => s,
         Err(e) => {
@@ -345,49 +353,79 @@ pub fn delete(
     };
     let key_len = key.as_bytes().len();
 
-    let result = match data_buffer_len {
-        // This is a call just to get the size of the buffer, so we do storage.get
-        0 => env_data
-            .api
-            .clone()
-            .runtime
-            .block_on(async move { storage.get(&env_data.module.name, &key).await }),
-        // This is a call to delete the value, so we do storage.delete
-        _ => env_data
-            .api
-            .clone()
-            .runtime
-            .block_on(async move { storage.delete(&env_data.module.name, &key).await }),
-    };
-
-    match result {
-        Ok(data) => {
-            match data {
-                Some(data) => {
-                    // Check if we were _actually_ deleting something
-                    match data_buffer_len {
-                        0 => {}
-                        _ => {
-                            // We were deleting something, so we decrease the counter for used storage
-                            *storage_current =
-                                *storage_current - key_len as u64 - data.len() as u64;
-                        }
-                    }
-                    match safely_write_data_back(&memory_view, &data, data_buffer, data_buffer_len)
-                    {
-                        Ok(x) => x,
-                        Err(e) => {
-                            error!(
-                                "{}: Data write error in storage_delete: {:?}",
-                                env_data.module.name, e
-                            );
-                            e as i32
-                        }
-                    }
-                }
-                None => 0,
+    let deletion_result = match env_data.module.storage_limit {
+        LimitValue::Unlimited => {
+            // The module has unlimited storage, so we don't update any counters and just proceed with the operation
+            match data_buffer_len {
+                // This is a call just to get the size of the buffer, so we do storage.get
+                0 => env_data
+                    .api
+                    .clone()
+                    .runtime
+                    .block_on(async move { storage.get(&env_data.module.name, &key).await }),
+                // This is a call to delete the value, so we do storage.delete
+                _ => env_data
+                    .api
+                    .clone()
+                    .runtime
+                    .block_on(async move { storage.delete(&env_data.module.name, &key).await }),
             }
         }
+        LimitValue::Limited(_) => {
+            // The module has limited storage, so we need to update counters (with locks)
+
+            // Get a lock on the storage counter for the module that is processing this message.
+            // This ensures no race conditions if multiple instances of the same module are running in parallel.
+            // The guard will go out of scope at the end of this block, thus releasing the lock.  After this block, we won't touch the counter again.
+            let mut storage_current = match env_data.module.storage_current.write() {
+                Ok(g) => g,
+                Err(e) => {
+                    error!("Critical error getting a lock on used storage: {:?}", e);
+                    return FunctionErrors::InternalApiError as i32;
+                }
+            };
+
+            match data_buffer_len {
+                // This is a call just to get the size of the buffer, so we do storage.get
+                0 => env_data
+                    .api
+                    .clone()
+                    .runtime
+                    .block_on(async move { storage.get(&env_data.module.name, &key).await }),
+                // This is a call to delete the value, so we do storage.delete
+                _ => {
+                    let result =
+                        env_data.api.clone().runtime.block_on(async move {
+                            storage.delete(&env_data.module.name, &key).await
+                        });
+                    // If the deletion went well, update counter for used storage.
+                    // If the deletion failed for some reason, we don't update the counter and release the lock: no harm done.
+                    if let Ok(Some(ref data)) = result {
+                        *storage_current = *storage_current - key_len as u64 - data.len() as u64;
+                    }
+                    result
+                }
+            }
+        }
+    };
+
+    // Process the deletion result and return info to the caller
+    match deletion_result {
+        Ok(data) => match data {
+            Some(data) => {
+                match safely_write_data_back(&memory_view, &data, data_buffer, data_buffer_len) {
+                    Ok(x) => x,
+                    Err(e) => {
+                        error!(
+                            "{}: Data write error in storage_delete: {:?}",
+                            env_data.module.name, e
+                        );
+                        e as i32
+                    }
+                }
+            }
+            None => 0,
+        },
         Err(_) => 0,
     }
 }

--- a/runtime/plaid/src/functions/storage.rs
+++ b/runtime/plaid/src/functions/storage.rs
@@ -1,6 +1,6 @@
 use wasmer::{AsStoreRef, FunctionEnvMut, WasmPtr};
 
-use crate::{executor::Env, functions::FunctionErrors};
+use crate::{executor::Env, functions::FunctionErrors, loader::LimitValue};
 
 use super::{get_memory, safely_get_memory, safely_get_string, safely_write_data_back};
 
@@ -49,6 +49,45 @@ pub fn insert(
     };
 
     let storage_key = key.clone();
+    let get_key = key.clone();
+    let key_len = storage_key.as_bytes().len();
+
+    // We check if this insert would overwrite some existing data. If so, we need to take that into account when
+    // computing the storage that would be occupied at the end of the insert operation.
+    // Note: if we have existing data, then we need to count the key's length as well. This is because at the end
+    // of a possible insertion, we would have only one key.
+    let existing_data_size = match env_data
+        .api
+        .clone()
+        .runtime
+        .block_on(async move { storage.get(&env_data.name, &get_key).await })
+    {
+        Ok(data) => match data {
+            None => 0u64,
+            Some(d) => d.len() as u64 + key_len as u64,
+        },
+        Err(_) => {
+            return FunctionErrors::InternalApiError as i32;
+        }
+    };
+
+    // Calculate the amount of storage that would be used after successfully inserting.
+    // Note: we _substract_ the size of existing data. If we were to insert the new data, the old data would be overwritten.
+    let used_storage = match env_data.storage_current.read() {
+        Ok(data) => *data,
+        Err(_) => panic!(),
+    };
+    let would_be_used_storage =
+        used_storage + key_len as u64 + value.len() as u64 - existing_data_size; // no problem with underflowing because the result will never be negative (since used_storage >= existing_data_size)
+
+    // If we have limited storage, this insert might fail
+    if let LimitValue::Limited(storage_limit) = env_data.storage_limit {
+        if would_be_used_storage > storage_limit {
+            error!("{}: Could not insert key/value with key {storage_key} as that would bring us above the configured storage limit. Used: {used_storage}, would be used: {would_be_used_storage}, limit: {storage_limit}", env_data.name);
+            return FunctionErrors::StorageLimitReached as i32;
+        }
+    }
+
     let result = env_data.api.clone().runtime.block_on(async move {
         storage
             .insert(env_data.name.clone(), storage_key, value)
@@ -56,24 +95,42 @@ pub fn insert(
     });
 
     match result {
-        Ok(Some(data)) => {
-            // If the data is too large to fit in the buffer that was passed to us. Unfortunately this is a somewhat
-            // unrecoverable state because we've overwritten the value already. We could fail insertion if the data
-            // buffer passed is too small in future? That would mean doing a get call first, which the client can do
-            // too.
-            match safely_write_data_back(&memory_view, &data, data_buffer, data_buffer_len) {
-                Ok(x) => x,
+        Ok(data) => {
+            // The insertion went fine: update counter for used storage
+            match env_data.storage_current.write() {
+                Ok(mut storage) => {
+                    *storage = would_be_used_storage;
+                }
                 Err(e) => {
                     error!(
-                        "{}: Data write error in storage_insert: {:?}",
-                        env_data.name, e
+                        "Critical error getting a write lock on used storage: {:?}",
+                        e
                     );
-                    e as i32
+                    return FunctionErrors::InternalApiError as i32;
                 }
             }
+            match data {
+                Some(data) => {
+                    // If the data is too large to fit in the buffer that was passed to us. Unfortunately this is a somewhat
+                    // unrecoverable state because we've overwritten the value already. We could fail insertion if the data
+                    // buffer passed is too small in future? That would mean doing a get call first, which the client can do
+                    // too.
+                    match safely_write_data_back(&memory_view, &data, data_buffer, data_buffer_len)
+                    {
+                        Ok(x) => x,
+                        Err(e) => {
+                            error!(
+                                "{}: Data write error in storage_insert: {:?}",
+                                env_data.name, e
+                            );
+                            e as i32
+                        }
+                    }
+                }
+                // This occurs when there is no such key so the number of bytes that have been copied back are 0
+                None => 0,
+            }
         }
-        // This occurs when there is no such key so the number of bytes that have been copied back are 0
-        Ok(None) => 0,
         // If the storage system errors (for example a network problem if using a networked storage provider)
         // the error is made opaque to the client here and we log what happened
         Err(e) => {
@@ -255,6 +312,7 @@ pub fn delete(
             return FunctionErrors::ParametersNotUtf8 as i32;
         }
     };
+    let key_len = key.as_bytes().len();
 
     let result = match data_buffer_len {
         // This is a call just to get the size of the buffer, so we do storage.get
@@ -272,19 +330,44 @@ pub fn delete(
     };
 
     match result {
-        Ok(Some(data)) => {
-            match safely_write_data_back(&memory_view, &data, data_buffer, data_buffer_len) {
-                Ok(x) => x,
-                Err(e) => {
-                    error!(
-                        "{}: Data write error in storage_delete: {:?}",
-                        env_data.name, e
-                    );
-                    e as i32
+        Ok(data) => {
+            match data {
+                Some(data) => {
+                    // Check if we were _actually_ deleting something
+                    match data_buffer_len {
+                        0 => {}
+                        _ => {
+                            // We were deleting something, so we decrease the counter for used storage
+                            match env_data.storage_current.write() {
+                                Ok(mut storage) => {
+                                    // no underflow: the result can never become negative
+                                    *storage = *storage - key_len as u64 - data.len() as u64;
+                                }
+                                Err(e) => {
+                                    error!(
+                                        "Critical error getting a write lock on used storage: {:?}",
+                                        e
+                                    );
+                                    return FunctionErrors::InternalApiError as i32;
+                                }
+                            }
+                        }
+                    }
+                    match safely_write_data_back(&memory_view, &data, data_buffer, data_buffer_len)
+                    {
+                        Ok(x) => x,
+                        Err(e) => {
+                            error!(
+                                "{}: Data write error in storage_delete: {:?}",
+                                env_data.name, e
+                            );
+                            e as i32
+                        }
+                    }
                 }
+                None => 0,
             }
         }
-        Ok(None) => 0,
         Err(_) => 0,
     }
 }

--- a/runtime/plaid/src/storage/mod.rs
+++ b/runtime/plaid/src/storage/mod.rs
@@ -60,10 +60,20 @@ pub trait StorageProvider {
     /// specific keys can be returned. This is helpful as it reduces the amount of compute that
     /// needs to be taken by modules to do basic filtering. More complex filtering (i.e regex)
     /// is not supported as computation for that has unbounded complexity.
-    async fn list_keys(&self, namespace: &str, prefix: Option<&str>) -> Result<Vec<String>, StorageError>;
+    async fn list_keys(
+        &self,
+        namespace: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<String>, StorageError>;
     /// Same as list_keys but will return the keys and values. An optional prefix can be provided
     /// but this only applies to the key, values have no host provided filtering.
-    async fn fetch_all(&self, namespace: &str, prefix: Option<&str>) -> Result<Vec<(String, Vec<u8>)>, StorageError>;
+    async fn fetch_all(
+        &self,
+        namespace: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<(String, Vec<u8>)>, StorageError>;
+    /// Get the number of bytes stored in a namespace. This will include keys and values.
+    async fn get_namespace_byte_size(&self, namespace: &str) -> Result<u64, StorageError>;
 }
 
 impl Storage {
@@ -97,7 +107,11 @@ impl Storage {
         self.database.delete(namespace, key).await
     }
 
-    pub async fn list_keys(&self, namespace: &str, prefix: Option<&str>) -> Result<Vec<String>, StorageError> {
+    pub async fn list_keys(
+        &self,
+        namespace: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<String>, StorageError> {
         self.database.list_keys(namespace, prefix).await
     }
 
@@ -107,5 +121,9 @@ impl Storage {
         prefix: Option<&str>,
     ) -> Result<Vec<(String, Vec<u8>)>, StorageError> {
         self.database.fetch_all(namespace, prefix).await
+    }
+
+    pub async fn get_namespace_byte_size(&self, namespace: &str) -> Result<u64, StorageError> {
+        self.database.get_namespace_byte_size(namespace).await
     }
 }

--- a/runtime/plaid/src/storage/sled/mod.rs
+++ b/runtime/plaid/src/storage/sled/mod.rs
@@ -79,24 +79,26 @@ impl StorageProvider for Sled {
         Ok(result.map(|v| v.to_vec()))
     }
 
-    async fn list_keys(&self, namespace: &str, prefix: Option<&str>) -> Result<Vec<String>, StorageError> {
+    async fn list_keys(
+        &self,
+        namespace: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<String>, StorageError> {
         let tree = self
             .db
             .open_tree(namespace.as_bytes())
             .map_err(|_| StorageError::Access(format!("Could not open Sled tree {namespace}")))?;
 
-
         let key_iter = match prefix {
             Some(p) => tree.scan_prefix(p),
-            None => tree.iter()
+            None => tree.iter(),
         };
         // The use of a filter_map here means keys that fail to be pulled will be thrown away.
         // I don't know if this is possible? Maybe if the database is moved out from under us?
         let keys: Vec<String> = key_iter
             .keys()
             .filter_map(|x| match x {
-                Ok(v) =>
-                    String::from_utf8(v.to_vec()).ok(),
+                Ok(v) => String::from_utf8(v.to_vec()).ok(),
                 Err(e) => {
                     error!("Storage Error Listing Keys: {e}");
                     None
@@ -107,7 +109,11 @@ impl StorageProvider for Sled {
         Ok(keys)
     }
 
-    async fn fetch_all(&self, namespace: &str, prefix: Option<&str>) -> Result<Vec<(String, Vec<u8>)>, StorageError> {
+    async fn fetch_all(
+        &self,
+        namespace: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<(String, Vec<u8>)>, StorageError> {
         let tree = self
             .db
             .open_tree(namespace.as_bytes())
@@ -115,13 +121,15 @@ impl StorageProvider for Sled {
 
         let key_iter = match prefix {
             Some(p) => tree.scan_prefix(p),
-            None => tree.iter()
+            None => tree.iter(),
         };
         // The use of a filter_map here means keys that fail to be pulled will be thrown away.
         // I don't know if this is possible? Maybe if the database is moved out from under us?
         let data: Vec<(String, Vec<u8>)> = key_iter
             .filter_map(|x| match x {
-                Ok((k, v)) => String::from_utf8(k.to_vec()).ok().map(|key| (key, v.to_vec())),
+                Ok((k, v)) => String::from_utf8(k.to_vec())
+                    .ok()
+                    .map(|key| (key, v.to_vec())),
                 Err(e) => {
                     error!("Storage Error Listing Keys: {e}");
                     None
@@ -130,5 +138,15 @@ impl StorageProvider for Sled {
             .collect();
 
         Ok(data)
+    }
+
+    async fn get_namespace_byte_size(&self, namespace: &str) -> Result<u64, StorageError> {
+        let all = self.fetch_all(namespace, None).await?;
+        let mut counter = 0u64;
+        for item in all {
+            // Count bytes for keys and values
+            counter = counter + item.0.as_bytes().len() as u64 + item.1.len() as u64;
+        }
+        Ok(counter)
     }
 }


### PR DESCRIPTION
This PR adds an optional size limit that modules must respect when storing data in the permanent storage (e.g., DB).
If a module tries to store more than it is allowed, the insertion will fail.

Modules can also be given (by default or through overrides) `Unlimited` storage in the DB, in which case we will still count how many bytes they are storing, but we will not fail the insert.

When counting what is stored, we take into account the byte length of the key and the values.

### Breaking changes
The configuration needs a new section that looks like

```
[loading.storage_size]
default = "Unlimited"
[loading.storage_size.log_type]
[loading.storage_size.module_overrides]
"test_db.wasm" = { Limited = 50 }
```
