### PR TITLE
Set X-Spiferack header

### DIFF
--- a/runtime/plaid/src/apis/npm/npm_web_client.rs
+++ b/runtime/plaid/src/apis/npm/npm_web_client.rs
@@ -630,6 +630,7 @@ impl Npm {
                 NPMJS_COM_URL, self.config.npm_scope, team, user
             ))
             .header("Content-Type", "text/plain;charset=UTF-8")
+            .header("X-Spiferack", "1")
             .body(body)
             .send()
             .await
@@ -665,6 +666,7 @@ impl Npm {
                 "{}/settings/{}/members/{}/delete",
                 NPMJS_COM_URL, self.config.npm_scope, user
             ))
+            .header("X-Spiferack", "1")
             .json(&payload)
             .send()
             .await


### PR DESCRIPTION
This missing header was causing npm to respond with a 404. The reason is unknown, but it is a pattern we have already encountered, so trying to add `X-Spiferack: 1` is usually a good starting point.