### PR TITLE
Use a larger buffer when fetching commits from GitHub

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -2716,7 +2716,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plaid"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "alkali",
  "async-trait",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.15.3"
+version = "0.15.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/github/mod.rs
+++ b/runtime/plaid-stl/src/github/mod.rs
@@ -720,7 +720,7 @@ pub fn fetch_commit(user: &str, repo: &str, commit: &str) -> Result<String, Plai
     extern "C" {
         new_host_function_with_error_buffer!(github, fetch_commit);
     }
-    const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
+    const RETURN_BUFFER_SIZE: usize = 5 * 1024 * 1024; // 5 MiB
 
     #[derive(Serialize)]
     struct Request<'a> {

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.15.3"
+version = "0.15.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
1 MiB is easily filled with large-ish GitHub commits, so we bump the buffer size to 5 MiB.