### PR TITLE
Unify data generators for GH and Okta

### DIFF
--- a/runtime/plaid/examples/tailers/github.rs
+++ b/runtime/plaid/examples/tailers/github.rs
@@ -2,7 +2,7 @@ use crossbeam_channel::bounded;
 use plaid::apis::github::Authentication;
 use serde::Deserialize;
 
-use plaid::data::github::*;
+use plaid::data::{get_and_process_dg_logs, github::*};
 
 use std::env;
 use std::time::Duration;
@@ -60,7 +60,7 @@ async fn main() {
 
     loop {
         //println!("Start of log group");
-        gh.fetch_audit_logs().await.unwrap();
+        get_and_process_dg_logs(&mut gh).await.unwrap();
 
         while let Ok(log) = logger_rx.recv_timeout(Duration::from_secs(0)) {
             let log: GitHubLog = serde_json::from_slice(&log.data).unwrap();

--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -78,6 +78,20 @@ pub struct GithubConfig {
     sleep_duration: u64,
 }
 
+impl GithubConfig {
+    /// Create a new instance of a `GithubConfig`
+    pub fn new(authentication: Authentication, org: String, log_type: LogType) -> Self {
+        Self {
+            authentication,
+            org,
+            log_type,
+            logbacks_allowed: LogbacksAllowed::default(),
+            canon_time: 20,
+            sleep_duration: 1000,
+        }
+    }
+}
+
 /// This function provides the default sleep duration in milliseconds.
 /// It is used as the default value for deserialization of the `sleep_duration` field,
 /// of `GithubConfig` in the event that no value is provided.

--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -146,7 +146,7 @@ impl Github {
             config,
             client,
             last_seen: OffsetDateTime::now_utc(),
-            seen_logs_uuid: LruCache::new(NonZeroUsize::new(512).unwrap()),
+            seen_logs_uuid: LruCache::new(NonZeroUsize::new(4096).unwrap()),
             logger,
         }
     }

--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -6,10 +6,11 @@ use octocrab::{self, Octocrab};
 use plaid_stl::messages::{Generator, LogSource, LogbacksAllowed};
 use serde::Deserialize;
 use serde_json::Value;
-use std::cmp::{Ordering, Reverse};
-use std::collections::BinaryHeap;
+use std::cmp::Ordering;
 use std::num::NonZeroUsize;
-use std::time::{SystemTime, UNIX_EPOCH};
+use time::OffsetDateTime;
+
+use super::{DataGenerator, DataGeneratorLog};
 
 /// Represents the event types GitHub will include in the response
 /// to the audit log request
@@ -21,13 +22,6 @@ pub enum LogType {
     /// Returns both web and Git events.
     All,
 }
-
-/// If a log at the top of the heap is this much older than a log that just came in
-/// we will assume we will not see an earlier log and will ship it.
-///
-/// GitHub seems to find canonicalization after 20 seconds (at least on web)
-/// 1000 = 1 second
-const CANONICALIZATION_TIME: u64 = 20_000;
 
 impl std::fmt::Display for LogType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -75,18 +69,24 @@ pub struct GithubConfig {
     /// Denotes if logs produced by this generator are allowed to initiate log backs
     #[serde(default)]
     logbacks_allowed: LogbacksAllowed,
+    /// Canonicalization time, i.e., after how many seconds we can consider logs as "stable"
+    #[serde(default = "default_canon_time")]
+    canon_time: u64,
+    /// Number of milliseconds to wait in between calls to the GH API.
+    /// If no value is provided here, we will use a default value (1 second).
+    #[serde(default = "default_sleep_milliseconds")]
+    sleep_duration: u64,
 }
 
-impl GithubConfig {
-    /// Create a new instance of a `GithubConfig`
-    pub fn new(authentication: Authentication, org: String, log_type: LogType) -> Self {
-        Self {
-            authentication,
-            org,
-            log_type,
-            logbacks_allowed: LogbacksAllowed::default(),
-        }
-    }
+/// This function provides the default sleep duration in milliseconds.
+/// It is used as the default value for deserialization of the `sleep_duration` field,
+/// of `GithubConfig` in the event that no value is provided.
+fn default_sleep_milliseconds() -> u64 {
+    1000
+}
+
+fn default_canon_time() -> u64 {
+    20
 }
 
 /// Custom parser for log type
@@ -112,12 +112,16 @@ pub struct Github {
     client: Octocrab,
     /// The configuration of the generator
     config: GithubConfig,
-    /// Contains GitHub logs that are yet to be cannonicalized
-    canonicalization_contents: LruCache<String, u64>,
-    /// Logs awaiting to be sent to the execution system.
-    canonicalization: BinaryHeap<Reverse<GithubAuditLog>>,
+    /// Timestamp of the last seen log we have processed
+    last_seen: OffsetDateTime,
     /// The logger used to send logs to the execution system for processing
     logger: Sender<Message>,
+    /// An LRU where we store the UUIDs of logs that we have already seen and sent into the logging system.
+    /// This, together with some overlapping queries to the GH API, helps us ensure that all logs are processed
+    /// exactly once.
+    /// This LRU has a limited capacity: when this is reached, the least-recently-used item is removed to make space for a new insertion.
+    /// Note: we only use the "key" part to keep track of the UUIDs we have seen. The "value" part is not used and always set to 0u32.
+    seen_logs_uuid: LruCache<String, u32>,
 }
 
 impl Github {
@@ -127,53 +131,76 @@ impl Github {
         Self {
             config,
             client,
-            canonicalization_contents: LruCache::new(NonZeroUsize::new(512).unwrap()),
-            canonicalization: BinaryHeap::new(),
+            last_seen: OffsetDateTime::now_utc(),
+            seen_logs_uuid: LruCache::new(NonZeroUsize::new(512).unwrap()),
             logger,
         }
     }
+}
 
-    /// Gets the audit log for an organization.
-    ///
-    /// The audit log allows organization admins to quickly review the actions performed by members of the organization.
-    /// It includes details such as who performed the action, what the action was, and when it was performed.
-    pub async fn fetch_audit_logs(&mut self) -> Result<(), String> {
-        // Get the most recent 100 logs
+impl DataGenerator for &mut Github {
+    // For the documentation on these methods, see the trait.
+
+    async fn fetch_logs(
+        &self,
+        since: time::OffsetDateTime,
+        until: time::OffsetDateTime,
+    ) -> Result<Vec<super::DataGeneratorLog>, ()> {
+        let since = match since.format(&time::format_description::well_known::Rfc3339) {
+            Ok(since) => since,
+            Err(e) => {
+                error!("Failed to parse 'since' datetime. Error: {e}");
+                return Err(());
+            }
+        };
+        let until = match until.format(&time::format_description::well_known::Rfc3339) {
+            Ok(until) => until,
+            Err(e) => {
+                error!("Failed to parse 'until' datetime. Error: {e}");
+                return Err(());
+            }
+        };
+
         let address = format!(
-            "https://api.github.com/orgs/{}/audit-log?include={}&per_page=100",
+            "https://api.github.com/orgs/{}/audit-log?include={}&per_page=100&order=asc&phrase=created:{since}..{until}",
             self.config.org, self.config.log_type
         );
 
-        let response = self
-            .client
-            ._get(&address)
-            .await
-            .map_err(|e| format!("Could not get logs from GitHub: {}", e))?;
+        let response = self.client._get(&address).await.map_err(|e| {
+            let err_str = format!("Could not get logs from GitHub: {}", e);
+            error!("{}", err_str);
+        })?;
 
         if !response.status().is_success() {
-            return Err(format!(
+            let err_str = format!(
                 "Call to get GitHub logs failed with code: {}",
                 response.status()
-            ));
+            );
+            error!("{}", err_str);
+            return Err(());
         }
 
-        let body = self
-            .client
-            .body_to_string(response)
-            .await
-            .map_err(|e| format!("Failed to read body of GitHub response. Error: {e}"))?;
+        let body = self.client.body_to_string(response).await.map_err(|e| {
+            let err_str = format!("Failed to read body of GitHub response. Error: {e}");
+            error!("{}", err_str);
+        })?;
 
-        let logs: Vec<Value> = serde_json::from_str(body.as_str())
-            .map_err(|e| format!("Could not parse data from Github: {}\n\n{}", e, body))?;
+        let logs: Vec<Value> = serde_json::from_str(body.as_str()).map_err(|e| {
+            let err_str = format!("Could not parse data from Github: {}\n\n{}", e, body);
+            error!("{}", err_str);
+        })?;
 
-        let mut new_logs = 0;
-        for log in logs {
-            // We parsed from JSON so serialization back should be safe
-            let log_str = serde_json::to_string(&log).unwrap();
-            if self.canonicalization_contents.contains(&log_str) {
-                continue;
-            }
+        // If there have been no new logs since we last polled, we can exit the loop early
+        // Exiting here will result in a 10 second wait between restarts
+        if logs.is_empty() {
+            debug!("No new GitHub logs since: {}", self.last_seen);
+            return Ok(vec![]);
+        }
 
+        // Loop over the logs we did get from GitHub, attempt to parse their timestamps, and return a vector of such logs
+        let mut output_logs: Vec<DataGeneratorLog> = Vec::with_capacity(logs.len());
+
+        for log in &logs {
             let timestamp = match log.get("@timestamp") {
                 Some(v) => {
                     let Some(v) = v.as_u64() else {
@@ -189,65 +216,73 @@ impl Github {
                 }
             };
 
-            let gh_audit_log = GithubAuditLog {
-                timestamp,
-                serialized_log: log_str.clone(),
+            // The timestamp from GitHub is in milliseconds
+            let log_timestamp =
+                match OffsetDateTime::from_unix_timestamp_nanos(timestamp as i128 * 1_000_000) {
+                    Ok(t) => t,
+                    Err(_) => {
+                        error!("Couldn't parse timestamp into datetime");
+                        continue;
+                    }
+                };
+
+            let uuid = match log.get("_document_id").and_then(|v| v.as_str()) {
+                Some(id) => id,
+                None => {
+                    error!("Got a GH log without ID");
+                    continue;
+                }
             };
 
-            self.canonicalization.push(std::cmp::Reverse(gh_audit_log));
-            self.canonicalization_contents.push(log_str, timestamp);
-            new_logs += 1;
+            // We parsed from JSON so serialization back should be safe
+            let log_bytes = serde_json::to_vec(&log).unwrap();
+
+            output_logs.push(DataGeneratorLog {
+                id: uuid.to_string(),
+                timestamp: log_timestamp,
+                payload: log_bytes,
+            });
         }
 
-        let heap_time = match self.canonicalization.peek() {
-            Some(x) => x.0.timestamp,
-            _ => 0,
-        };
+        Ok(output_logs)
+    }
 
-        info!("Received {new_logs} new logs which are waiting for canonicalization. Next time on heap is: {heap_time}");
-        // In theory, if we've added all logs above into the heap, we should go back and add more
-        // until we see logs we recognize up to the capacity of the LRU cache.
+    fn get_name(&self) -> String {
+        "GitHub".to_string()
+    }
 
-        // In practice, for this to be a concern we'd need to receive more than 100 logs in the calling period
-        // (about 10 seconds) which I have not seen happen
+    fn get_sleep_duration(&self) -> u64 {
+        self.config.sleep_duration
+    }
 
-        let start = SystemTime::now();
-        let current_time = start
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_millis() as u64;
+    fn get_canon_time(&self) -> u64 {
+        self.config.canon_time
+    }
 
-        while let Some(heap_top) = self.canonicalization.peek() {
-            let heap_top = &heap_top.0;
+    fn get_last_seen(&self) -> time::OffsetDateTime {
+        self.last_seen
+    }
 
-            // If GitHub servers are ahead of us in time, this will occur
-            if current_time < heap_top.timestamp {
-                info!("Most recent log is from the future. Waiting for canonicalization");
-                break;
-            }
+    fn set_last_seen(&mut self, v: time::OffsetDateTime) {
+        self.last_seen = v;
+    }
 
-            // If the difference between the heap top and the current time is greater
-            // than the time to wait for canonicalization, then we can send the log and
-            // take it off the heap.
-            if current_time - heap_top.timestamp > CANONICALIZATION_TIME {
-                let log = self.canonicalization.pop().unwrap();
-                if let Err(e) = self.logger.send(Message::new(
-                    format!("github"),
-                    log.0.serialized_log.into_bytes(),
-                    LogSource::Generator(Generator::Github),
-                    self.config.logbacks_allowed.clone(),
-                )) {
-                    error!("Failed to send GitHub log to executor. Error: {e}")
-                }
-            } else {
-                trace!("Top of heap is: {}", heap_top.timestamp);
-                break;
-            }
-        }
+    fn was_already_seen(&self, id: impl std::fmt::Display) -> bool {
+        self.seen_logs_uuid.contains(&id.to_string())
+    }
 
-        debug!("Heap Size: {}", self.canonicalization.len());
-        debug!("LRU Size: {}", self.canonicalization_contents.len());
-        debug!("Current Timestamp: {}", current_time);
-        Ok(())
+    fn mark_already_seen(&mut self, id: impl std::fmt::Display) {
+        self.seen_logs_uuid.put(id.to_string(), 0u32);
+    }
+
+    fn send_for_processing(&self, payload: Vec<u8>) {
+        self.logger
+            .send(Message::new(
+                format!("github"),
+                payload,
+                LogSource::Generator(Generator::Github),
+                self.config.logbacks_allowed.clone(),
+            ))
+            .unwrap();
     }
 }

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -192,7 +192,7 @@ struct DataGeneratorLog {
 
 /// This is what data generators have in common
 #[allow(async_fn_in_trait)]
-trait DataGenerator {
+pub trait DataGenerator {
     /// Fetch from the source some logs that were produced between `since` and `until`.
     ///
     /// Note: this function does not necessarily return _all_ logs that were produced in that time frame,
@@ -240,7 +240,7 @@ fn get_time() -> u64 {
 
 /// Get logs from a data generator, one page at a time, and send them to rules for processing.
 /// Internally, this method handles making overlapping queries and logs de-duplication.
-async fn get_and_process_dg_logs(mut dg: impl DataGenerator) -> Result<(), ()> {
+pub async fn get_and_process_dg_logs(mut dg: impl DataGenerator) -> Result<(), ()> {
     let sleep_duration = Duration::from_millis(dg.get_sleep_duration());
 
     loop {

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -10,11 +10,16 @@ use crate::{
     storage::{Storage, StorageError},
 };
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    fmt::Display,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use crossbeam_channel::Sender;
 
 use serde::Deserialize;
+use time::OffsetDateTime;
 
 pub use self::internal::DelayedMessage;
 
@@ -110,8 +115,8 @@ impl Data {
         if let Some(mut gh) = di.github {
             handle.spawn(async move {
                 loop {
-                    if let Err(e) = gh.fetch_audit_logs().await {
-                        error!("GitHub Data Fetch Error: {}", e)
+                    if let Err(_) = get_and_process_dg_logs(&mut gh).await {
+                        error!("GitHub Data Fetch Error")
                     }
 
                     tokio::time::sleep(Duration::from_secs(10)).await;
@@ -123,8 +128,8 @@ impl Data {
         if let Some(mut okta) = di.okta {
             handle.spawn(async move {
                 loop {
-                    if let Err(e) = okta.fetch_system_logs().await {
-                        error!("Okta Data Fetch Error: {:?}", e)
+                    if let Err(_) = get_and_process_dg_logs(&mut okta).await {
+                        error!("Okta Data Fetch Error")
                     }
 
                     tokio::time::sleep(Duration::from_secs(10)).await;
@@ -172,5 +177,186 @@ impl Data {
 
         info!("Started Data Generators");
         Ok(internal_sender)
+    }
+}
+
+/// Represents a generic log produced by a data generator
+struct DataGeneratorLog {
+    /// The unique ID for this log, as returned by the data source (e.g., GH, Okta)
+    pub id: String,
+    /// The timestamp at which this log was produced, as returned by the data source (e.g., GH, Okta).
+    pub timestamp: OffsetDateTime,
+    /// The payload for this log
+    pub payload: Vec<u8>,
+}
+
+/// This is what data generators have in common
+#[allow(async_fn_in_trait)]
+trait DataGenerator {
+    /// Fetch from the source some logs that were produced between `since` and `until`.
+    ///
+    /// Note: this function does not necessarily return _all_ logs that were produced in that time frame,
+    /// so one might need to call this multiple times across different pages returned by the source.
+    async fn fetch_logs(
+        &self,
+        since: OffsetDateTime,
+        until: OffsetDateTime,
+    ) -> Result<Vec<DataGeneratorLog>, ()>;
+
+    /// Get a name for the data generator (useful e.g., for logging)
+    fn get_name(&self) -> String;
+
+    /// Get the duration (in milliseconds) the thread will sleep for, after fetching a page of logs
+    fn get_sleep_duration(&self) -> u64;
+
+    /// Get the number of seconds after which we assume the external API we are querying for logs
+    /// reaches stability. This means that we assume all events that have happened at least these many
+    /// seconds ago are now reflected in the logs returned by the API and nothing will change.
+    fn get_canon_time(&self) -> u64;
+
+    /// Get the datetime of the last (i.e., more recent) log we have seen
+    fn get_last_seen(&self) -> OffsetDateTime;
+
+    /// Set the datetime of the last (i.e., more recent) log we have seen
+    fn set_last_seen(&mut self, v: OffsetDateTime);
+
+    /// Check if a log with this ID was already seen before
+    fn was_already_seen(&self, id: impl Display) -> bool;
+
+    /// Mark a log with this ID as "already seen"
+    fn mark_already_seen(&mut self, id: impl Display);
+
+    /// Forward the payload to the channels for processing
+    fn send_for_processing(&self, payload: Vec<u8>);
+}
+
+/// Get the system time in seconds from the Epoch
+fn get_time() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_secs()
+}
+
+/// Get logs from a data generator, one page at a time, and send them to rules for processing.
+/// Internally, this method handles making overlapping queries and logs de-duplication.
+async fn get_and_process_dg_logs(mut dg: impl DataGenerator) -> Result<(), ()> {
+    let sleep_duration = Duration::from_millis(dg.get_sleep_duration());
+
+    loop {
+        // Get the logs until canon_time seconds ago
+        let now = get_time();
+        let until = now - dg.get_canon_time();
+        let until = match OffsetDateTime::from_unix_timestamp(until as i64) {
+            Ok(u) => u,
+            Err(_) => {
+                error!("Could not build 'until' parameter");
+                return Err(());
+            }
+        };
+
+        if until < dg.get_last_seen() {
+            // We are in a strange situation. E.g., we have just booted, so
+            // last_seen = now and until = now - canon_time, which makes until < last_seen.
+            // This does not make sense, but it's not really an error. We return and, at some
+            // point, we will run again with a 'sensible' set of parameters.
+            debug!(
+                "[{}] Waiting for canonicalization: {until} (until) < {} (last seen).",
+                dg.get_name(),
+                dg.get_last_seen(),
+            );
+            return Ok(());
+        }
+
+        // Get some logs that happened between `last_seen` and `until`.
+        // Walk back a couple of second from the actual value of last_seen, to account for problems
+        // with time granularity. E.g., events happening in the same second could be missed.
+        // Overlapping queries will prevent this problem from happening.
+        // We would introduce the issue of seeing the same log multiple times, but this is handled later.
+        let since = dg
+            .get_last_seen()
+            .saturating_sub(time::Duration::seconds(2));
+
+        let logs = match dg.fetch_logs(since, until).await {
+            Ok(logs) => logs,
+            Err(_) => {
+                error!("Could not get {} logs from source", dg.get_name());
+                return Err(());
+            }
+        };
+
+        // If we get no logs at all from the API, then we exit and we will retry later
+        if logs.is_empty() {
+            debug!(
+                "No new {} logs since: {}",
+                dg.get_name(),
+                dg.get_last_seen()
+            );
+            return Ok(());
+        }
+
+        // Loop over the logs we got from the API and send them into the logging system
+
+        // Keep track of how many logs we actually send for processing (and do not discard because already-seen)
+        let mut sent_for_processing = 0u32;
+
+        for log in logs {
+            // Check if we have already seen this UUID:
+            // - If we have, skip this log and continue
+            // - If we haven't, add this log's UUID to the data structure and keep processing it
+            if dg.was_already_seen(&log.id) {
+                // We have already seen this log: skip it
+                continue;
+            }
+            // We have not seen this log: add it to the cache
+            dg.mark_already_seen(log.id);
+
+            // Check if this is the latest log we've seen and update if so.
+            // We'll use the new value to filter the subsequent API calls.
+            //
+            // We can ask the API to return the logs in ascending order so we could in theory just
+            // take the last timstamp and set it as our max log time. I'm okay with doing another check here in the
+            // case that the API's sorting fails to ensure that we do not miss any logs. The number of comparisions here
+            // is nothing to be concerned about.
+            if log.timestamp > dg.get_last_seen() {
+                dg.set_last_seen(log.timestamp);
+            }
+
+            // Send log into the logging system to be processed by the rule(s)
+            //
+            // Eventually these errors need to bubble up so the service can shut down
+            // then be restarted by an orchestration service
+            dg.send_for_processing(log.payload);
+            sent_for_processing += 1;
+        }
+        // If there have been no new logs sent for processing, we exit.
+        // Exiting here will result in a 10 second wait between restarts
+        if sent_for_processing == 0 {
+            debug!(
+                "No new {} logs since: {}. We have already seen them all",
+                dg.get_name(),
+                dg.get_last_seen()
+            );
+
+            // Important: we have to move the window forward. Otherwise, on the next call nothing will
+            // change: with the same `since`, we will get the same logs and we will discard them all because
+            // they will all be in the cache. I.e., the system will enter a deadlock.
+            // To prevent this, we move `since` forward by a portion of the lookback window.
+            // This ensures that, eventually, we will get some new logs.
+            dg.set_last_seen(
+                dg.get_last_seen()
+                    .saturating_add(time::Duration::seconds(1)),
+            );
+
+            return Ok(());
+        }
+        info!(
+            "Sent {sent_for_processing} {} logs for processing. Newest time seen is: {}",
+            dg.get_name(),
+            dg.get_last_seen()
+        );
+
+        // Wait for the specified period before making another request
+        tokio::time::sleep(sleep_duration).await
     }
 }

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -181,7 +181,7 @@ impl Data {
 }
 
 /// Represents a generic log produced by a data generator
-struct DataGeneratorLog {
+pub struct DataGeneratorLog {
     /// The unique ID for this log, as returned by the data source (e.g., GH, Okta)
     pub id: String,
     /// The timestamp at which this log was produced, as returned by the data source (e.g., GH, Okta).
@@ -269,13 +269,13 @@ pub async fn get_and_process_dg_logs(mut dg: impl DataGenerator) -> Result<(), (
         }
 
         // Get some logs that happened between `last_seen` and `until`.
-        // Walk back a couple of second from the actual value of last_seen, to account for problems
+        // Walk back a second from the actual value of last_seen, to account for problems
         // with time granularity. E.g., events happening in the same second could be missed.
         // Overlapping queries will prevent this problem from happening.
         // We would introduce the issue of seeing the same log multiple times, but this is handled later.
         let since = dg
             .get_last_seen()
-            .saturating_sub(time::Duration::seconds(2));
+            .saturating_sub(time::Duration::seconds(1));
 
         let logs = match dg.fetch_logs(since, until).await {
             Ok(logs) => logs,
@@ -345,7 +345,7 @@ pub async fn get_and_process_dg_logs(mut dg: impl DataGenerator) -> Result<(), (
             // This ensures that, eventually, we will get some new logs.
             dg.set_last_seen(
                 dg.get_last_seen()
-                    .saturating_add(time::Duration::seconds(1)),
+                    .saturating_add(time::Duration::milliseconds(500)),
             );
 
             return Ok(());

--- a/runtime/plaid/src/data/okta/mod.rs
+++ b/runtime/plaid/src/data/okta/mod.rs
@@ -118,7 +118,7 @@ impl Okta {
             config,
             last_seen: OffsetDateTime::now_utc(),
             logger,
-            seen_logs_uuid: LruCache::new(NonZeroUsize::new(512).unwrap()),
+            seen_logs_uuid: LruCache::new(NonZeroUsize::new(4096).unwrap()),
         }
     }
 }

--- a/runtime/plaid/src/data/okta/mod.rs
+++ b/runtime/plaid/src/data/okta/mod.rs
@@ -1,13 +1,14 @@
-use crate::executor::Message;
+use crate::{data::DataGeneratorLog, executor::Message};
 use crossbeam_channel::Sender;
 use lru::LruCache;
 use plaid_stl::messages::{Generator, LogSource, LogbacksAllowed};
 use reqwest::Client;
 use serde::Deserialize;
 use serde_json::Value;
-use std::num::NonZeroUsize;
-use std::time::Duration;
+use std::{num::NonZeroUsize, time::Duration};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+use super::DataGenerator;
 
 const OKTA_LOG_PUBLISHED_FIELD_KEY: &str = "published";
 const OKTA_LOG_UUID_FIELD_KEY: &str = "uuid";
@@ -40,6 +41,9 @@ pub struct OktaConfig {
     /// will be able to as well). If this is not set, it will default to Limited(0).
     #[serde(default)]
     pub logbacks_allowed: LogbacksAllowed,
+    /// Canonicalization time, i.e., after how many seconds we can consider logs as "stable"
+    #[serde(default = "default_canon_time")]
+    canon_time: u64,
 }
 
 /// Custom parser for limit. Returns an error if a limit = 0 or limit > 1000 is given
@@ -67,6 +71,10 @@ fn default_sleep_milliseconds() -> u64 {
     1
 }
 
+fn default_canon_time() -> u64 {
+    60
+}
+
 /// This function provides the default limit for the number of system logs returned from Okta.
 /// It is used as the default value for deserialization of the `limit` field,
 /// of `OktaConfig` in the event that no value is provided.
@@ -86,8 +94,8 @@ pub struct Okta {
     client: Client,
     /// Contains domain and token
     config: OktaConfig,
-    /// Filters the lower time bound of the log events published property for bounded queries or persistence time for polling queries
-    since: OffsetDateTime,
+    /// Timestamp of the last seen log we have processed
+    last_seen: OffsetDateTime,
     /// Sending channel used to send logs into the execution system
     logger: Sender<Message>,
     /// An LRU where we store the UUIDs of Okta logs that we have already seen and sent into the logging system.
@@ -108,199 +116,177 @@ impl Okta {
         Self {
             client,
             config,
-            since: OffsetDateTime::now_utc(),
+            last_seen: OffsetDateTime::now_utc(),
             logger,
             seen_logs_uuid: LruCache::new(NonZeroUsize::new(512).unwrap()),
         }
     }
+}
 
-    /// Fetch logs from Okta API
-    pub async fn fetch_system_logs(&mut self) -> Result<(), ()> {
-        // Start with the most recent logs
-        let mut most_recent_log_seen = OffsetDateTime::UNIX_EPOCH;
+impl DataGenerator for &mut Okta {
+    // For the documentation on these methods, see the trait.
 
-        let sleep_duration = Duration::from_millis(self.config.sleep_duration);
+    async fn fetch_logs(
+        &self,
+        since: OffsetDateTime,
+        until: OffsetDateTime,
+    ) -> Result<Vec<super::DataGeneratorLog>, ()> {
+        // Okta requires the query parameters to be in RFC3339 format. We attempt to format them here.
+        // On failure, we return and allow the data orchestrator to restart the loop
+        let since = match since.format(&Rfc3339) {
+            Ok(since) => since,
+            Err(e) => {
+                error!("Failed to parse 'since' datetime to RFC3339 format. Error: {e}");
+                return Err(());
+            }
+        };
+        let until = match until.format(&Rfc3339) {
+            Ok(until) => until,
+            Err(e) => {
+                error!("Failed to parse 'until' datetime to RFC3339 format. Error: {e}");
+                return Err(());
+            }
+        };
 
-        loop {
-            // To ensure we are not missing any logs that might have come through in the meantime, we
-            // go 1 minute back in time. This produces overlapping calls, i.e., we will see some logs
-            // multiple times. To avoid processing these logs more than once, we store their UUIDs in
-            // a dedicated data struct. So we pay a performance price in exchange for more log stability.
-            let since = match self.since.checked_sub(time::Duration::minutes(1)) {
-                Some(s) => s,
-                None => {
-                    error!("Something went wrong while computing `since` value");
-                    return Ok(());
-                }
-            };
-            // Okta requires the query parameter to be in RFC3339 format. We attempt to format it here.
-            // On failure, we return and allow the data orchestrator to restart the loop
-            let since = match since.format(&Rfc3339) {
-                Ok(since) => since,
-                Err(e) => {
-                    error!("Failed to parse datetime to RFC3339 format. Error: {e}");
-                    return Ok(());
-                }
-            };
+        // TODO Maybe remove configurability for sortOrder. With this new system, only ASCENDING
+        // really makes sense. Otherwise we are most likely going to miss older logs.
+        let address = format!(
+            "https://{}/api/v1/logs?sortOrder={}&since={since}&until={until}&limit={}",
+            self.config.domain, self.config.log_sorting, self.config.limit
+        );
 
-            let address = format!(
-                "https://{}/api/v1/logs?sortOrder={}&since={since}&limit={}",
-                self.config.domain, self.config.log_sorting, self.config.limit
+        let response = self
+            .client
+            .get(address)
+            .header("Accept", "application/json")
+            .header("Authorization", format!("SSWS {}", self.config.token))
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Could not get logs from Okta: {e}");
+            })?;
+
+        // Check the response status code
+        // If it's outside of the 2XX range, we log the error and exit the loop, allowing the
+        // data generator to handle a restart
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_body = response.text().await.ok();
+            error!(
+                "Call to Okta API failed with code: {status}. Error: {}",
+                error_body.unwrap_or_default()
             );
+            return Err(());
+        }
 
-            let response = self
-                .client
-                .get(address)
-                .header("Accept", "application/json")
-                .header("Authorization", format!("SSWS {}", self.config.token))
-                .send()
-                .await
-                .map_err(|e| {
-                    error!("Could not get logs from Okta: {e}");
-                })?;
+        // Get the body from the response from Okta
+        let body = response
+            .text()
+            .await
+            .map_err(|e| error!("Could not get logs from Okta: {e}"))?;
 
-            // Check the response status code
-            // If it's outside of the 2XX range, we log the error and exit the loop, allowing the
-            // data generator to handle a restart
-            if !response.status().is_success() {
-                let status = response.status();
-                let error_body = response.text().await.ok();
-                error!(
-                    "Call to Okta API failed with code: {status}. Error: {}",
-                    error_body.unwrap_or_default()
-                );
-                return Ok(());
-            }
+        // Attempt to deserialize the response from Okta
+        let logs: Vec<Value> = serde_json::from_str(body.as_str())
+            .map_err(|e| error!("Could not parse data from Okta: {e}\n\n{body}"))?;
 
-            // Get the body from the response from Okta
-            let body = response
-                .text()
-                .await
-                .map_err(|e| error!("Could not get logs from Okta: {e}"))?;
+        // If there have been no new logs since we last polled, we can exit the loop early
+        // Exiting here will result in a 10 second wait between restarts
+        if logs.is_empty() {
+            debug!("No new Okta logs since: {}", self.last_seen);
+            return Ok(vec![]);
+        }
 
-            // Attempt to deserialize the response from Okta
-            let logs: Vec<Value> = serde_json::from_str(body.as_str())
-                .map_err(|e| error!("Could not parse data from Okta: {e}\n\n{body}"))?;
+        // Loop over the logs we did get from Okta, attempt to parse their timestamps, and return a vector of such logs
+        let mut output_logs: Vec<DataGeneratorLog> = Vec::with_capacity(logs.len());
 
-            // If there have been no new logs since we last polled, we can exit the loop early
-            // Exiting here will result in a 10 second wait between restarts
-            if logs.is_empty() {
-                debug!("No new Okta logs since: {}", self.since);
-                return Ok(());
-            }
-
-            // Loop over the logs we did get from Okta, attempt to parse their timestamps, check if they are really new, and send them into the logging system
-
-            // Keep track of how many logs we actually send for processing (and do not discard because already-seen)
-            let mut sent_for_processing = 0u32;
-
-            for log in &logs {
-                let published = match log
-                    .as_object()
-                    .and_then(|obj| obj.get(OKTA_LOG_PUBLISHED_FIELD_KEY))
-                    .and_then(|val| val.as_str())
-                {
-                    Some(published) => published,
-                    None => {
-                        error!("Missing or invalid 'published' field in Okta log: {log:?}",);
-                        continue;
-                    }
-                };
-
-                let uuid = match log
-                    .as_object()
-                    .and_then(|obj| obj.get(OKTA_LOG_UUID_FIELD_KEY))
-                    .and_then(|val| val.as_str())
-                {
-                    Some(uuid) => uuid,
-                    None => {
-                        error!("Missing or invalid 'uuid' field in Okta log: {log:?}",);
-                        continue;
-                    }
-                };
-
-                // Check if we have already seen this UUID:
-                // - If we have, skip this log and continue
-                // - If we haven't, add this log's UUID to the data structure and keep processing it
-                if self.seen_logs_uuid.contains(uuid) {
-                    // We have already seen this log
+        for log in &logs {
+            let published = match log
+                .as_object()
+                .and_then(|obj| obj.get(OKTA_LOG_PUBLISHED_FIELD_KEY))
+                .and_then(|val| val.as_str())
+            {
+                Some(published) => published,
+                None => {
+                    error!("Missing or invalid 'published' field in Okta log: {log:?}",);
                     continue;
                 }
-                // We have not seen this log: add it to the cache
-                self.seen_logs_uuid.put(uuid.to_string(), 0u32);
+            };
 
-                let log_timestamp = match OffsetDateTime::parse(published, &Rfc3339) {
-                    Ok(dt) => dt,
-                    Err(_) => {
-                        error!("Got an invalid date from Okta: {}", published);
-                        continue;
-                    }
-                };
-
-                // Check if this is the latest log we've seen and update if so
-                // We'll use the new most_recent_log_seen time to filter the subsequent
-                // API calls to Okta afterwards
-                //
-                // By default, the Okta API returns the logs in ascending order so we could in theory just
-                // take the last timstamp and set it as our max log time. I'm okay with doing another check here in the
-                // case that Okta's sorting fails to ensure that we do not miss any logs. The number of comparisions here (1000 max)
-                // is nothing to be concerned about.
-                if log_timestamp > most_recent_log_seen {
-                    most_recent_log_seen = log_timestamp;
+            let log_timestamp = match OffsetDateTime::parse(published, &Rfc3339) {
+                Ok(dt) => dt,
+                Err(_) => {
+                    error!("Got an invalid date from Okta: {}", published);
+                    continue;
                 }
+            };
 
-                // Attempts to parse the log received from Okta to bytes.
-                let log_bytes = match serde_json::to_vec(&log) {
-                    Ok(bytes) => bytes,
-                    Err(e) => {
-                        error!("Failed to serialize Okta logs to bytes. Error: {e}");
-                        continue;
-                    }
-                };
+            let uuid = match log
+                .as_object()
+                .and_then(|obj| obj.get(OKTA_LOG_UUID_FIELD_KEY))
+                .and_then(|val| val.as_str())
+            {
+                Some(uuid) => uuid,
+                None => {
+                    error!("Missing or invalid 'uuid' field in Okta log: {log:?}",);
+                    continue;
+                }
+            };
 
-                // Send log into logging system to be processed by rule(s)
-                //
-                // Eventually these errors need to bubble up so the service can shut down
-                // then be restarted by an orchestration service
-                self.logger
-                    .send(Message::new(
-                        "okta".to_string(),
-                        log_bytes,
-                        LogSource::Generator(Generator::Okta),
-                        self.config.logbacks_allowed.clone(),
-                    ))
-                    .unwrap();
-                sent_for_processing += 1;
-            }
-            // If there have been no new logs sent for processing, we exit.
-            // Exiting here will result in a 10 second wait between restarts
-            if sent_for_processing == 0 {
-                debug!(
-                    "No new Okta logs since: {}. We have already seen them all.",
-                    self.since
-                );
-                // Important: we have to move the window forward. Otherwise, on the next call nothing will
-                // change: with the same `since`, we will get the same logs and we will discard them all because
-                // they will all be in the cache. I.e., the system will enter a deadlock.
-                // To prevent this, we move `since` forward by 30 seconds. When we call, we will still go back
-                // 1 minute, effectively shifting the window forward by 30 seconds.
-                // Eventually, we will get some new logs.
-                self.since = match self.since.checked_add(time::Duration::seconds(30)) {
-                    Some(s) => s,
-                    None => {
-                        error!("Error while moving the Okta log window forward");
-                        OffsetDateTime::now_utc() // for lack of anything better
-                    }
-                };
-                return Ok(());
-            }
-            info!(
-                "Sent {sent_for_processing} Okta logs for processing. Newest time seen is: {most_recent_log_seen}"
-            );
+            // Attempt to parse the log received from Okta to bytes.
+            let log_bytes = match serde_json::to_vec(&log) {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    error!("Failed to serialize Okta logs to bytes. Error: {e}");
+                    continue;
+                }
+            };
 
-            // Update the time of our most recent log and wait for the specified period
-            self.since = most_recent_log_seen + sleep_duration;
-            tokio::time::sleep(sleep_duration).await
+            output_logs.push(DataGeneratorLog {
+                id: uuid.to_string(),
+                timestamp: log_timestamp,
+                payload: log_bytes,
+            });
         }
+
+        Ok(output_logs)
+    }
+
+    fn get_name(&self) -> String {
+        "Okta".to_string()
+    }
+
+    fn get_sleep_duration(&self) -> u64 {
+        self.config.sleep_duration
+    }
+
+    fn get_canon_time(&self) -> u64 {
+        self.config.canon_time
+    }
+
+    fn get_last_seen(&self) -> OffsetDateTime {
+        self.last_seen
+    }
+
+    fn set_last_seen(&mut self, v: OffsetDateTime) {
+        self.last_seen = v;
+    }
+
+    fn was_already_seen(&self, id: impl std::fmt::Display) -> bool {
+        self.seen_logs_uuid.contains(&id.to_string())
+    }
+
+    fn mark_already_seen(&mut self, id: impl std::fmt::Display) {
+        self.seen_logs_uuid.put(id.to_string(), 0u32);
+    }
+
+    fn send_for_processing(&self, payload: Vec<u8>) {
+        self.logger
+            .send(Message::new(
+                "okta".to_string(),
+                payload,
+                LogSource::Generator(Generator::Okta),
+                self.config.logbacks_allowed.clone(),
+            ))
+            .unwrap();
     }
 }


### PR DESCRIPTION
This PR unifies the logic for data generators (Okta and GitHub).

The basic idea is that each of Okta and GitHub DG implement a specific logic to fetch some logs from the respective API that were created in a given time window (since...until).

Then there is higher-level logic to take these logs and process them, discarding duplicates, etc. This logic is common between Okta and GH.

Commonalities are expressed through a `DataGenerator` trait which both sources implement. Methods from this trait are then called from the high-level logic to perform all necessary operations.