### PR TITLE
Testing mode

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -407,6 +407,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_testmode"
+version = "0.1.0"
+dependencies = [
+ "plaid_stl",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "test_time"
 version = "0.1.0"
 dependencies = [

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -4,15 +4,16 @@ resolver = "2"
 
 members = [
     "tests/test_crashtest",
-    "tests/test_persistent_response",
-    "tests/test_sshcerts_usage",
-    "tests/test_time",
-    "tests/test_logback",
     "tests/test_db",
     "tests/test_fileopen",
-    "tests/test_random",
-    "tests/test_mnr",
     "tests/test_get_everything",
+    "tests/test_logback",
+    "tests/test_mnr",
+    "tests/test_persistent_response",
+    "tests/test_random",
+    "tests/test_sshcerts_usage",
+    "tests/test_testmode",
+    "tests/test_time",
 ]
 
 [profile.release]

--- a/modules/tests/test_testmode/Cargo.toml
+++ b/modules/tests/test_testmode/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "test_testmode"
+description = "Test that calling mutative functions in test mode return the correct error"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+plaid_stl = { path = "../../../runtime/plaid-stl" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+
+[lib]
+crate-type = ["cdylib"]

--- a/modules/tests/test_testmode/harness/harness.sh
+++ b/modules/tests/test_testmode/harness/harness.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Define what webhook within Plaid we're going to call
+URL="testmode"
+
+# Call the webhook
+OUTPUT=$(curl -XPOST -d 'crash' http://$PLAID_LOCATION/webhook/$URL)
+OUTPUT=$(curl -XPOST -d 'memory_pressure' http://$PLAID_LOCATION/webhook/$URL)
+
+# There is no defined success critieria here but it's important
+# to keep track of what Plaid does as the compiler's optimizations
+# change with time
+exit 0

--- a/modules/tests/test_testmode/harness/harness.sh
+++ b/modules/tests/test_testmode/harness/harness.sh
@@ -6,8 +6,7 @@ set -e
 URL="testmode"
 
 # Call the webhook
-OUTPUT=$(curl -XPOST -d 'crash' http://$PLAID_LOCATION/webhook/$URL)
-OUTPUT=$(curl -XPOST -d 'memory_pressure' http://$PLAID_LOCATION/webhook/$URL)
+OUTPUT=$(curl -XPOST -d 'unneeded' http://$PLAID_LOCATION/webhook/$URL)
 
 # There is no defined success critieria here but it's important
 # to keep track of what Plaid does as the compiler's optimizations

--- a/modules/tests/test_testmode/src/lib.rs
+++ b/modules/tests/test_testmode/src/lib.rs
@@ -7,6 +7,7 @@ entrypoint_with_source!();
 fn main(log: String, _: LogSource) -> Result<(), i32> {
     plaid::print_debug_string(&format!("Testing testmode With Log: [{log}]"));
 
+    // This should work because the configuration allows this particular request
     match network::make_named_request("testmode_allow", "OK", HashMap::new()) {
         Ok(_) => {
             plaid::print_debug_string("Testmode allowed request succeeded");
@@ -17,6 +18,7 @@ fn main(log: String, _: LogSource) -> Result<(), i32> {
         }
     }
 
+    // This should not work because the configuration denies this particular request
     let _: Result<(), ()> = match network::make_named_request("testmode_deny", "OK", HashMap::new())
     {
         Err(PlaidFunctionError::TestMode) => Ok(()),
@@ -28,5 +30,18 @@ fn main(log: String, _: LogSource) -> Result<(), i32> {
         }
     };
 
+    // This should fail because simple_json_post_request is not allowed in test mode
+    match network::simple_json_post_request("https://captive.apple.com", "{}", None) {
+        Err(PlaidFunctionError::TestMode) => {
+            plaid::print_debug_string("Testmode denied request succeeded");
+        }
+        Err(e) => {
+            plaid::print_debug_string(&format!("Testmode denied request failed: [{e}]"));
+            panic!("Testmode denied request failed");
+        }
+        Ok(_) => {
+            panic!("Testmode request that should have failed succeeded");
+        }
+    }
     Ok(())
 }

--- a/modules/tests/test_testmode/src/lib.rs
+++ b/modules/tests/test_testmode/src/lib.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+
+use plaid_stl::{entrypoint_with_source, messages::LogSource, network, plaid, PlaidFunctionError};
+
+entrypoint_with_source!();
+
+fn main(log: String, _: LogSource) -> Result<(), i32> {
+    plaid::print_debug_string(&format!("Testing testmode With Log: [{log}]"));
+
+    match network::make_named_request("testmode_allow", "OK", HashMap::new()) {
+        Ok(_) => {
+            plaid::print_debug_string("Testmode allowed request succeeded");
+        }
+        Err(e) => {
+            plaid::print_debug_string(&format!("Testmode allowed request failed: [{e}]"));
+            panic!("Testmode allowed request failed");
+        }
+    }
+
+    let _: Result<(), ()> = match network::make_named_request("testmode_deny", "OK", HashMap::new())
+    {
+        Err(PlaidFunctionError::TestMode) => Ok(()),
+        Err(e) => {
+            panic!("Testmode denied request did not fail with the right error: [{e}]");
+        }
+        Ok(_) => {
+            panic!("Testmode request that should have failed succeeded");
+        }
+    };
+
+    Ok(())
+}

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -2716,7 +2716,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plaid"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "alkali",
  "async-trait",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/lib.rs
+++ b/runtime/plaid-stl/src/lib.rs
@@ -22,6 +22,11 @@ pub enum PlaidFunctionError {
     InternalApiError,
     ParametersNotUtf8,
     InvalidPointer,
+    CacheDisabled,
+    CouldNotGetAdequateMemory,
+    FailedToWriteGuestMemory,
+    StorageLimitReached,
+    TestMode,
     Unknown,
 }
 
@@ -34,6 +39,11 @@ impl core::fmt::Display for PlaidFunctionError {
             PlaidFunctionError::InternalApiError => write!(f, "An opaque error occurred within Plaid. Talk to the Plaid management team."),
             PlaidFunctionError::ParametersNotUtf8 => write!(f, "Data sent to the Plaid subsystem was not UTF8 so could not be used."),
             PlaidFunctionError::InvalidPointer => write!(f, "We passed a pointer to Plaid that it couldn't use for some reason"),
+            PlaidFunctionError::CacheDisabled => write!(f, "The cache is disabled"),
+            PlaidFunctionError::CouldNotGetAdequateMemory => write!(f, "Plaid could not get enough memory"),
+            PlaidFunctionError::FailedToWriteGuestMemory => write!(f, "Plaid could not write to guest memory"),
+            PlaidFunctionError::StorageLimitReached => write!(f, "The storage limit has been reached"),
+            PlaidFunctionError::TestMode => write!(f, "The function is not allowed in test mode"),
             PlaidFunctionError::Unknown => write!(f, "An unknown error occurred. This can happen if the Plaid runtime is never than the STL this rule was compiled against."),
 
         }
@@ -49,6 +59,11 @@ impl From<i32> for PlaidFunctionError {
             -4 => Self::InternalApiError,
             -5 => Self::ParametersNotUtf8,
             -6 => Self::InvalidPointer,
+            -7 => Self::CacheDisabled,
+            -8 => Self::CouldNotGetAdequateMemory,
+            -9 => Self::FailedToWriteGuestMemory,
+            -10 => Self::StorageLimitReached,
+            -11 => Self::TestMode,
             _ => Self::Unknown,
         }
     }

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -14,7 +14,11 @@ alkali = "0.3.0"
 async-trait = "0.1.56"
 aws-sdk-secretsmanager = "1.57.0"
 base64 = "0.13"
-clap = { version = "4", default-features = false, features = ["std", "help", "usage"] }
+clap = { version = "4", default-features = false, features = [
+    "std",
+    "help",
+    "usage",
+] }
 crossbeam-channel = "0.5"
 env_logger = "0.8"
 flate2 = "1.0"

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -24,7 +24,18 @@ module_dir = "../compiled_modules/"
 lru_cache_size = 200
 
 test_mode = true
-test_mode_exemptions = []
+test_mode_exemptions = [
+    "test_crashtest.wasm",
+    "test_db.wasm",
+    "test_fileopen.wasm",
+    "test_get_everything.wasm",
+    "test_logback.wasm",
+    "test_mnr.wasm",
+    "test_persistent_response.wasm",
+    "test_random.wasm",
+    "test_sshcerts_usage.wasm",
+    "test_time.wasm",
+]
 
 [loading.persistent_response_size]
 "test_persistent_response.wasm" = 1024

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -65,16 +65,17 @@ test_mode_exemptions = [
 "my_secret" = "verySecureSecret"
 
 [loading.log_type_overrides]
-"test_time.wasm" = "time"
-"test_sshcerts_usage.wasm" = "test_sshcerts"
 "test_crashtest.wasm" = "crashtest"
-"test_persistent_response.wasm" = "prtest"
-"test_logback.wasm" = "test_logback"
 "test_db.wasm" = "test_db"
 "test_fileopen.wasm" = "test_fileopen"
-"test_random.wasm" = "test_random"
-"test_mnr.wasm" = "test_mnr"
 "test_get_everything.wasm" = "test_geteverything"
+"test_logback.wasm" = "test_logback"
+"test_mnr.wasm" = "test_mnr"
+"test_persistent_response.wasm" = "prtest"
+"test_random.wasm" = "test_random"
+"test_sshcerts_usage.wasm" = "test_sshcerts"
+"test_testmode.wasm" = "testmode"
+"test_time.wasm" = "time"
 
 # Configure the computation amount. See the loader module for more
 # information on how computation cost is calculated.
@@ -155,6 +156,24 @@ return_body = true
 return_code = true
 allowed_rules = ["testing_test.wasm"]
 [apis."general"."network"."web_requests"."google_test"."headers"]
+
+[apis."general"."network"."web_requests"."testmode_allow"]
+verb = "get"
+uri = "https://captive.apple.com/"
+return_body = true
+return_code = true
+allowed_rules = ["test_testmode.wasm"]
+available_in_test_mode = true
+[apis."general"."network"."web_requests"."testmode_allow"."headers"]
+
+[apis."general"."network"."web_requests"."testmode_deny"]
+verb = "get"
+uri = "https://captive.apple.com/"
+return_body = true
+return_code = true
+allowed_rules = ["test_testmode.wasm"]
+available_in_test_mode = false
+[apis."general"."network"."web_requests"."testmode_deny"."headers"]
 
 # [apis."general"."network"."web_requests"."list_deploy_keys"]
 # verb = "get"
@@ -318,6 +337,10 @@ headers = ["Authorization", "my_secret"]
 response_mode = "rule:test_get_everything.wasm"
 [webhooks."internal".webhooks."testgeteverything".get_mode.caching_mode]
 type = "None"
+
+[webhooks."internal".webhooks."testmode"]
+log_type = "testmode"
+headers = []
 
 # End webhooks for tests
 

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -22,6 +22,10 @@ path = "/tmp/sled"
 [loading]
 module_dir = "../compiled_modules/"
 lru_cache_size = 200
+
+test_mode = true
+test_mode_exemptions = []
+
 [loading.persistent_response_size]
 "test_persistent_response.wasm" = 1024
 "test_sshcerts_usage.wasm" = 1024
@@ -84,6 +88,7 @@ default = "Unlimited"
 [loading.storage_size.module_overrides]
 "test_db.wasm" = { Limited = 50 }
 
+
 # [apis."okta"]
 # token = ""
 # domain = ""
@@ -95,7 +100,15 @@ verb = "post"
 uri = "http://localhost:8998/response"
 return_body = true
 return_code = true
-allowed_rules = ["test_time.wasm", "test_logback.wasm", "test_db.wasm", "test_fileopen.wasm", "test_random.wasm", "test_mnr.wasm", "test_get_everything.wasm"]
+allowed_rules = [
+    "test_time.wasm",
+    "test_logback.wasm",
+    "test_db.wasm",
+    "test_fileopen.wasm",
+    "test_random.wasm",
+    "test_mnr.wasm",
+    "test_get_everything.wasm",
+]
 [apis."general"."network"."web_requests"."test-response"."headers"]
 testheader = "Some data here"
 

--- a/runtime/plaid/src/apis/general/network.rs
+++ b/runtime/plaid/src/apis/general/network.rs
@@ -1,5 +1,6 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
+use crate::loader::PlaidModule;
 use reqwest::header::HeaderMap;
 use serde::{Deserialize, Serialize};
 
@@ -22,8 +23,8 @@ struct MakeRequestRequest {
     /// Variables to include in the request. Variables take the place of an idenfitifer in the request URI
     variables: HashMap<String, String>,
     /// Dynamic headers to include in the request. These are headers that cannot be statically
-    /// defined in the request configuration. They cannot override a request's statically defined headers 
-    headers: Option<HashMap<String, String>>
+    /// defined in the request configuration. They cannot override a request's statically defined headers
+    headers: Option<HashMap<String, String>>,
 }
 
 /// This struct represents a web request and contains information about what the request is about (e.g., verb and URI),
@@ -44,6 +45,10 @@ pub struct Request {
     allowed_rules: Vec<String>,
     /// Headers to include in the request
     headers: HashMap<String, String>,
+    /// Whether the request is available to modules in test mode. Generally this should be set to false
+    /// if the call has side effects. If it is not set, this will default to false.
+    #[serde(default)]
+    available_in_test_mode: bool,
 }
 
 /// Data returned by a request.
@@ -56,18 +61,28 @@ struct ReturnData {
 impl General {
     /// Make a post to a given address but don't provide any data returned. Only
     /// if the call returned 200
-    /// 
+    ///
     /// This function should be considered an unsafe function because it allows arbitrary calls
     /// outside of normal sandboxing operations. This should only be used if `make_named_request`
     /// cannot be used.
-    pub async fn simple_json_post_request(&self, params: &str, _: &str) -> Result<u32, ApiError> {
-        let request: HashMap<String, String> = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+    pub async fn simple_json_post_request(
+        &self,
+        params: &str,
+        _: Arc<PlaidModule>,
+    ) -> Result<u32, ApiError> {
+        let request: HashMap<String, String> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let url = request.get("url").ok_or(ApiError::MissingParameter("url".to_string()))?;
-        let body = request.get("body").ok_or(ApiError::MissingParameter("body".to_string()))?;
+        let url = request
+            .get("url")
+            .ok_or(ApiError::MissingParameter("url".to_string()))?;
+        let body = request
+            .get("body")
+            .ok_or(ApiError::MissingParameter("body".to_string()))?;
         let auth = request.get("auth");
 
-        let request_builder = self.client
+        let request_builder = self
+            .client
             .post(url)
             .header("Content-Type", "application/json; charset=utf-8");
 
@@ -84,9 +99,14 @@ impl General {
     }
 
     /// Make a named web request on behalf of a given `module`. The request's details are encoded in `params`.
-    pub async fn make_named_request(&self, params: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn make_named_request(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         // Parse the information needed to make the request
-        let request: MakeRequestRequest = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        let request: MakeRequestRequest =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         let request_name = &request.request_name;
 
@@ -100,9 +120,19 @@ impl General {
         };
 
         // If this request is not allowed to be executed by the given rule, bail
-        if !request_specification.allowed_rules.contains(&module.to_string()) {
+        if !request_specification
+            .allowed_rules
+            .contains(&module.to_string())
+        {
             error!("{module} tried to use web-request which it's not allowed to: {request_name}");
             return Err(ApiError::BadRequest);
+        }
+
+        // If the call is coming from a module in test mode, and the request is not allowed to be
+        // called in test mode, return TestMode error
+        if module.test_mode && !request_specification.available_in_test_mode {
+            error!("{module} tried to use web-request which is not available in test mode: {request_name}");
+            return Err(ApiError::TestMode);
         }
 
         let headers_to_include_in_request = match request.headers {
@@ -110,14 +140,17 @@ impl General {
                 let static_headers = request_specification.headers.clone();
                 dynamic_headers.extend(static_headers);
                 dynamic_headers
-            },
-            None => request_specification.headers.clone()
+            }
+            None => request_specification.headers.clone(),
         };
 
         let headers: HeaderMap = match (&headers_to_include_in_request).try_into() {
             Ok(x) => x,
-            Err(e) =>
-                return Err(ApiError::ConfigurationError(format!("{request_name} has the headers misconfigured: {e}"))),
+            Err(e) => {
+                return Err(ApiError::ConfigurationError(format!(
+                    "{request_name} has the headers misconfigured: {e}"
+                )))
+            }
         };
 
         let mut uri = request_specification.uri.clone();
@@ -135,7 +168,8 @@ impl General {
             // Not sure we want to support head
             //"head" => self.client.head(&request_specification.uri),
             _ => return Err(ApiError::BadRequest),
-        }.headers(headers);
+        }
+        .headers(headers);
 
         // A body (even an empty one) must be provided. It can be overriden by
         // the configuration or provided by the rule. But if no body is defined
@@ -166,7 +200,7 @@ impl General {
                     // TODO: This is not really a BadRequest.
                     Err(ApiError::BadRequest)
                 }
-            },
+            }
             Err(e) => Err(ApiError::NetworkError(e)),
         }
     }

--- a/runtime/plaid/src/apis/github/code.rs
+++ b/runtime/plaid/src/apis/github/code.rs
@@ -1,12 +1,19 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use super::Github;
-use crate::apis::{github::GitHubError, ApiError};
+use crate::{
+    apis::{github::GitHubError, ApiError},
+    loader::PlaidModule,
+};
 
 impl Github {
     /// Search for files with given name.
     /// See https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-code for more details
-    pub async fn search_for_file(&self, params: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn search_for_file(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 

--- a/runtime/plaid/src/apis/github/copilot.rs
+++ b/runtime/plaid/src/apis/github/copilot.rs
@@ -1,27 +1,41 @@
 use super::Github;
-use crate::apis::{github::GitHubError, ApiError};
+use crate::{
+    apis::{github::GitHubError, ApiError},
+    loader::PlaidModule,
+};
 use serde::{Deserialize, Serialize};
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 impl Github {
     /// List all seats in the Copilot subscription for an organization
     /// See https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#list-all-copilot-seat-assignments-for-an-organization for more details
-    pub async fn list_seats_in_org_copilot(&self, params: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn list_seats_in_org_copilot(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         let organization = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
-        let per_page: u8 = request.get("per_page").unwrap_or(&"50")
-            .parse::<u8>().map_err(|_| ApiError::BadRequest)?;
-        let page: u16 = request.get("page").unwrap_or(&"1")
-            .parse::<u16>().map_err(|_| ApiError::BadRequest)?;
+        let per_page: u8 = request
+            .get("per_page")
+            .unwrap_or(&"50")
+            .parse::<u8>()
+            .map_err(|_| ApiError::BadRequest)?;
+        let page: u16 = request
+            .get("page")
+            .unwrap_or(&"1")
+            .parse::<u16>()
+            .map_err(|_| ApiError::BadRequest)?;
 
         info!("List seats in Copilot subscription for org {organization}");
 
-        let address = format!("/orgs/{organization}/copilot/billing/seats?page={page}&per_page={per_page}");
+        let address =
+            format!("/orgs/{organization}/copilot/billing/seats?page={page}&per_page={per_page}");
 
-        match self.make_generic_get_request(address, &module).await {
+        match self.make_generic_get_request(address, module).await {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)
@@ -38,26 +52,35 @@ impl Github {
 
     /// Add users to the Copilot subscription for an organization
     /// See https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#add-users-to-the-copilot-subscription-for-an-organization for more details
-    pub async fn add_users_to_org_copilot(&self, params: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn add_users_to_org_copilot(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         #[derive(Deserialize, Serialize)]
         struct Request {
             #[serde(skip_serializing)]
             org: String,
             selected_usernames: Vec<String>,
         }
-        let request: Request =
-            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        let request: Request = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         let organization = self.validate_org(&request.org)?;
         for username in &request.selected_usernames {
             self.validate_username(&username)?;
         }
 
-        info!("Adding users {:?} to Copilot subscription for org {organization} as module {module}", request.selected_usernames);
+        info!(
+            "Adding users {:?} to Copilot subscription for org {organization} as module {module}",
+            request.selected_usernames
+        );
 
         let address = format!("/orgs/{organization}/copilot/billing/selected_users");
 
-        match self.make_generic_post_request(address, &request, &module).await {
+        match self
+            .make_generic_post_request(address, &request, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 201 {
                     Ok(body)
@@ -74,26 +97,35 @@ impl Github {
 
     /// Remove users from the Copilot subscription for an organization
     /// See https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#remove-users-from-the-copilot-subscription-for-an-organization for more details
-    pub async fn remove_users_from_org_copilot(&self, params: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn remove_users_from_org_copilot(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         #[derive(Deserialize, Serialize)]
         struct Request {
             #[serde(skip_serializing)]
             org: String,
             selected_usernames: Vec<String>,
         }
-        let request: Request =
-            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        let request: Request = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         let organization = self.validate_org(&request.org)?;
         for username in request.selected_usernames.iter() {
             self.validate_username(&username)?;
         }
 
-        info!("Remove users {:?} from Copilot subscription for org {organization}", request.selected_usernames);
+        info!(
+            "Remove users {:?} from Copilot subscription for org {organization}",
+            request.selected_usernames
+        );
 
         let address = format!("/orgs/{organization}/copilot/billing/selected_users");
 
-        match self.make_generic_delete_request(address, Some(&request), &module).await {
+        match self
+            .make_generic_delete_request(address, Some(&request), module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)

--- a/runtime/plaid/src/apis/github/environments.rs
+++ b/runtime/plaid/src/apis/github/environments.rs
@@ -1,8 +1,11 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use serde::Serialize;
 
-use crate::apis::{github::GitHubError, ApiError};
+use crate::{
+    apis::{github::GitHubError, ApiError},
+    loader::PlaidModule,
+};
 
 use super::Github;
 
@@ -56,7 +59,7 @@ impl Github {
     pub async fn create_environment_for_repo(
         &self,
         params: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
@@ -105,7 +108,7 @@ impl Github {
     pub async fn create_deployment_branch_protection_rule(
         &self,
         params: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;

--- a/runtime/plaid/src/apis/github/graphql.rs
+++ b/runtime/plaid/src/apis/github/graphql.rs
@@ -1,8 +1,11 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 
-use crate::apis::{github::GitHubError, ApiError};
+use crate::{
+    apis::{github::GitHubError, ApiError},
+    loader::PlaidModule,
+};
 
 use super::Github;
 
@@ -49,7 +52,7 @@ impl Github {
     async fn make_gql_request<T: Serialize>(
         &self,
         query: T,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         let request = self.client._post(GITHUB_GQL_API, Some(&query)).await;
 
@@ -81,7 +84,7 @@ impl Github {
     pub async fn make_graphql_query(
         &self,
         request: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         let request: Request = serde_json::from_str(request).map_err(|_| ApiError::BadRequest)?;
 
@@ -106,7 +109,7 @@ impl Github {
     pub async fn make_advanced_graphql_query(
         &self,
         request: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         let request: AdvancedRequest =
             serde_json::from_str(request).map_err(|_| ApiError::BadRequest)?;

--- a/runtime/plaid/src/apis/github/members.rs
+++ b/runtime/plaid/src/apis/github/members.rs
@@ -1,11 +1,18 @@
-use crate::apis::{ApiError, github::GitHubError};
-use std::collections::HashMap;
 use super::Github;
+use crate::{
+    apis::{github::GitHubError, ApiError},
+    loader::PlaidModule,
+};
+use std::{collections::HashMap, sync::Arc};
 
 impl Github {
     /// Check if a user belongs to an org
     /// See https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
-    pub async fn check_org_membership_of_user(&self, params: &str, module: &str) -> Result<bool, ApiError> {
+    pub async fn check_org_membership_of_user(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<bool, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 

--- a/runtime/plaid/src/apis/github/mod.rs
+++ b/runtime/plaid/src/apis/github/mod.rs
@@ -16,7 +16,9 @@ use octocrab::Octocrab;
 
 use serde::{Deserialize, Serialize};
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
+
+use crate::loader::PlaidModule;
 
 use super::ApiError;
 
@@ -97,7 +99,7 @@ impl Github {
     async fn make_generic_get_request(
         &self,
         uri: String,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<(u16, Result<String, ApiError>), ApiError> {
         info!("Making a get request to {uri} on behalf of {module}");
 
@@ -123,7 +125,7 @@ impl Github {
         &self,
         uri: String,
         body: T,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<(u16, Result<String, ApiError>), ApiError> {
         info!("Making a post request to {uri} on behalf of {module}");
 
@@ -149,7 +151,7 @@ impl Github {
         &self,
         uri: String,
         body: Option<&T>,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<(u16, Result<String, ApiError>), ApiError> {
         info!("Making a put request to {uri} on behalf of {module}");
 
@@ -175,7 +177,7 @@ impl Github {
         &self,
         uri: String,
         body: Option<&T>,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<(u16, Result<String, ApiError>), ApiError> {
         info!("Making a delete request to {uri} on behalf of {module}");
 

--- a/runtime/plaid/src/apis/github/pats.rs
+++ b/runtime/plaid/src/apis/github/pats.rs
@@ -1,8 +1,11 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 
-use crate::apis::{github::GitHubError, ApiError};
+use crate::{
+    apis::{github::GitHubError, ApiError},
+    loader::PlaidModule,
+};
 
 use super::Github;
 
@@ -11,7 +14,7 @@ impl Github {
     pub async fn list_fpat_requests_for_org(
         &self,
         params: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
@@ -37,7 +40,11 @@ impl Github {
     }
 
     /// List the repositories a fine-grained personal access token request is requesting access to.
-    pub async fn get_repos_for_fpat(&self, params: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn get_repos_for_fpat(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
@@ -70,7 +77,7 @@ impl Github {
     pub async fn review_fpat_requests_for_org(
         &self,
         params: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
         #[derive(Deserialize, Serialize)]
         struct Request {
@@ -107,7 +114,7 @@ impl Github {
         let address = format!("/orgs/{org}/personal-access-token-requests");
 
         match self
-            .make_generic_post_request(address, &request, &module)
+            .make_generic_post_request(address, &request, module.clone())
             .await
         {
             Ok((status, Ok(body))) => {

--- a/runtime/plaid/src/apis/github/repos.rs
+++ b/runtime/plaid/src/apis/github/repos.rs
@@ -1,15 +1,22 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use serde::Serialize;
 
-use crate::apis::{github::GitHubError, ApiError};
+use crate::{
+    apis::{github::GitHubError, ApiError},
+    loader::PlaidModule,
+};
 
 use super::Github;
 
 impl Github {
     /// Removes a collaborator from a repository.
     /// See https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#remove-a-repository-collaborator for more detail
-    pub async fn remove_user_from_repo(&self, params: &str, module: &str) -> Result<u32, ApiError> {
+    pub async fn remove_user_from_repo(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<u32, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
@@ -41,7 +48,11 @@ impl Github {
 
     /// Adds a collaborator to a repository.
     /// See https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#add-a-repository-collaborator for more detail
-    pub async fn add_user_to_repo(&self, params: &str, module: &str) -> Result<u32, ApiError> {
+    pub async fn add_user_to_repo(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<u32, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
@@ -85,7 +96,11 @@ impl Github {
 
     /// Returns the contents of a single commit reference.
     /// See https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit for more detail
-    pub async fn fetch_commit(&self, params: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn fetch_commit(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
@@ -115,7 +130,11 @@ impl Github {
 
     /// Returns a list of all Files in a Pull Request.
     /// See https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files for more detail
-    pub async fn list_files(&self, params: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn list_files(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
@@ -147,7 +166,11 @@ impl Github {
 
     /// Returns the contents of a file at a specific URI.
     /// See https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content for more detail
-    pub async fn fetch_file(&self, params: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn fetch_file(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
@@ -202,7 +225,7 @@ impl Github {
     pub async fn get_branch_protection_rules(
         &self,
         params: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
@@ -236,7 +259,7 @@ impl Github {
     pub async fn get_branch_protection_ruleset(
         &self,
         params: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
@@ -272,7 +295,7 @@ impl Github {
     pub async fn get_repository_collaborators(
         &self,
         params: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
@@ -320,7 +343,7 @@ impl Github {
     pub async fn update_branch_protection_rule(
         &self,
         params: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;

--- a/runtime/plaid/src/apis/github/teams.rs
+++ b/runtime/plaid/src/apis/github/teams.rs
@@ -1,13 +1,20 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use serde::Serialize;
 
 use super::Github;
-use crate::apis::{github::GitHubError, ApiError};
+use crate::{
+    apis::{github::GitHubError, ApiError},
+    loader::PlaidModule,
+};
 
 impl Github {
     /// Remove a user from a GitHub team.
-    pub async fn remove_user_from_team(&self, params: &str, module: &str) -> Result<u32, ApiError> {
+    pub async fn remove_user_from_team(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<u32, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
@@ -38,7 +45,11 @@ impl Github {
     }
 
     /// Add a user to a GitHub team.
-    pub async fn add_user_to_team(&self, params: &str, module: &str) -> Result<u32, ApiError> {
+    pub async fn add_user_to_team(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<u32, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 

--- a/runtime/plaid/src/apis/mod.rs
+++ b/runtime/plaid/src/apis/mod.rs
@@ -89,6 +89,7 @@ pub enum ApiError {
     SplunkError(splunk::SplunkError),
     YubikeyError(yubikey::YubikeyError),
     WebError(web::WebError),
+    TestMode,
 }
 
 impl Api {

--- a/runtime/plaid/src/apis/npm/npm_cli_client.rs
+++ b/runtime/plaid/src/apis/npm/npm_cli_client.rs
@@ -1,4 +1,4 @@
-use crate::apis::ApiError;
+use crate::{apis::ApiError, loader::PlaidModule};
 
 use super::{hashes, Npm, NpmError};
 
@@ -6,7 +6,7 @@ use flate2::{write::GzEncoder, Compression};
 use plaid_stl::npm::shared_structs::{PublishEmptyStubParams, RuntimeReturnValue};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 use tar::{Builder, Header};
 
 const REGISTRY_URL: &str = "https://registry.npmjs.org";
@@ -76,7 +76,11 @@ struct PkgManifest<'a> {
 
 impl Npm {
     /// Upload an empty package stub to the npm registry.
-    pub async fn publish_empty_stub(&self, params: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn publish_empty_stub(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         let params: PublishEmptyStubParams =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
         let package_name = self.validate_npm_package_name(&params.package_name)?;

--- a/runtime/plaid/src/apis/npm/npm_web_client.rs
+++ b/runtime/plaid/src/apis/npm/npm_web_client.rs
@@ -1,11 +1,11 @@
 use reqwest::{cookie::CookieStore, Response};
 use serde::Serialize;
 use serde_json::Value;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 use totp_rs::{Algorithm, Secret, TOTP};
 use url::Url;
 
-use crate::apis::ApiError;
+use crate::{apis::ApiError, loader::PlaidModule};
 
 use plaid_stl::npm::shared_structs::*;
 
@@ -262,7 +262,7 @@ impl Npm {
     pub async fn set_team_permission_on_package(
         &self,
         params: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         if let Err(e) = self.login().await {
             return Ok(RuntimeReturnValue::serialize_from_err(e));
@@ -313,7 +313,7 @@ impl Npm {
     pub async fn create_granular_token_for_packages(
         &self,
         params: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         if let Err(e) = self.login().await {
             return Ok(RuntimeReturnValue::serialize_from_err(e));
@@ -413,7 +413,7 @@ impl Npm {
     pub async fn delete_granular_token(
         &self,
         params: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         if let Err(e) = self.login().await {
             return Ok(RuntimeReturnValue::serialize_from_err(e));
@@ -452,7 +452,11 @@ impl Npm {
     /// Retrieve a list of granular tokens for the account whose credentials have been configured for this client.
     ///
     /// Note: only granular tokens are returned. Other types of tokens (publish, automation, etc.) are filtered out.
-    pub async fn list_granular_tokens(&self, _: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn list_granular_tokens(
+        &self,
+        _: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         info!("Listing npm granular tokens on behalf of [{module}]");
         if let Err(e) = self.login().await {
             return Ok(RuntimeReturnValue::serialize_from_err(e));
@@ -501,7 +505,11 @@ impl Npm {
     /// Note: The package name should be unscoped. If you are trying to delete
     /// @scope/package_name, then you should pass only "package_name". The scope is
     /// preconfigured in the client and will be added automatically.
-    pub async fn delete_package(&self, package: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn delete_package(
+        &self,
+        package: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         let package = self.validate_npm_package_name(package)?;
         info!("Deleting npm package [{package}] on behalf of [{module}]");
         if let Err(e) = self.login().await {
@@ -559,7 +567,11 @@ impl Npm {
     }
 
     /// Add a user to an npm team
-    pub async fn add_user_to_team(&self, params: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn add_user_to_team(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         if let Err(e) = self.login().await {
             return Ok(RuntimeReturnValue::serialize_from_err(e));
         }
@@ -603,7 +615,7 @@ impl Npm {
     pub async fn remove_user_from_team(
         &self,
         params: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         if let Err(e) = self.login().await {
             return Ok(RuntimeReturnValue::serialize_from_err(e));
@@ -645,7 +657,7 @@ impl Npm {
     pub async fn remove_user_from_organization(
         &self,
         user: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         let user = self.validate_npm_username(user)?;
         info!("Removing user [{user}] from npm organization on behalf of [{module}]");
@@ -684,7 +696,7 @@ impl Npm {
     pub async fn invite_user_to_organization(
         &self,
         params: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         if let Err(e) = self.login().await {
             return Ok(RuntimeReturnValue::serialize_from_err(e));
@@ -732,7 +744,11 @@ impl Npm {
     }
 
     /// Return all users in the npm organization
-    pub async fn get_org_user_list(&self, _: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn get_org_user_list(
+        &self,
+        _: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         info!("Listing all members of npm organization on behalf of [{module}]");
         if let Err(e) = self.login().await {
             return Ok(RuntimeReturnValue::serialize_from_err(e));
@@ -789,7 +805,7 @@ impl Npm {
     pub async fn get_org_users_without_2fa(
         &self,
         _: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         info!("Listing all members of npm organization without 2FA on behalf of [{module}]");
         if let Err(e) = self.login().await {
@@ -849,7 +865,7 @@ impl Npm {
     pub async fn list_packages_with_team_permission(
         &self,
         params: &str,
-        module: &str,
+        module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         let params: ListPackagesWithTeamPermissionParams =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
@@ -989,7 +1005,11 @@ impl Npm {
     }
 
     /// Return a JSON-encoded struct that contains details about a granular token
-    pub async fn get_token_details(&self, params: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn get_token_details(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         let params: GetTokenDetailsParams =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
         let token_id = self.validate_token_id(&params.token_id)?;

--- a/runtime/plaid/src/apis/okta/groups.rs
+++ b/runtime/plaid/src/apis/okta/groups.rs
@@ -1,28 +1,47 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
-use crate::apis::ApiError;
+use crate::{apis::ApiError, loader::PlaidModule};
 
 use super::{Okta, OktaError};
 
 impl Okta {
     /// Remove a user from an Okta group
-    pub async fn remove_user_from_group(&self, params: &str, _: &str) -> Result<u32, ApiError> {
-        let request: HashMap<&str, &str> = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+    pub async fn remove_user_from_group(
+        &self,
+        params: &str,
+        _: Arc<PlaidModule>,
+    ) -> Result<u32, ApiError> {
+        let request: HashMap<&str, &str> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         let user_id = request.get("user_id").ok_or(ApiError::BadRequest)?;
         let group_id = request.get("group_id").ok_or(ApiError::BadRequest)?;
 
-        let res = self.client.delete(format!("https://{}/api/v1/groups/{group_id}/users/{user_id}", &self.config.domain))
-            .header("Authorization", self.get_authorization_header(&super::OktaOperation::RemoveUserFromGroup).await.map_err(|e| ApiError::OktaError(e))?)
+        let res = self
+            .client
+            .delete(format!(
+                "https://{}/api/v1/groups/{group_id}/users/{user_id}",
+                &self.config.domain
+            ))
+            .header(
+                "Authorization",
+                self.get_authorization_header(&super::OktaOperation::RemoveUserFromGroup)
+                    .await
+                    .map_err(|e| ApiError::OktaError(e))?,
+            )
             .header("Content-Type", "application/json")
             .header("Accept", "application/json");
 
         match res.send().await {
-            Ok(r) => if r.status() == 204 {
-                Ok(0)
-            } else {
-                Err(ApiError::OktaError(OktaError::UnexpectedStatusCode(r.status().as_u16())))
-            },
+            Ok(r) => {
+                if r.status() == 204 {
+                    Ok(0)
+                } else {
+                    Err(ApiError::OktaError(OktaError::UnexpectedStatusCode(
+                        r.status().as_u16(),
+                    )))
+                }
+            }
             Err(e) => Err(ApiError::NetworkError(e)),
         }
     }

--- a/runtime/plaid/src/apis/okta/users.rs
+++ b/runtime/plaid/src/apis/okta/users.rs
@@ -1,17 +1,39 @@
-use crate::apis::{ApiError, okta::OktaError};
+use std::sync::Arc;
+
+use crate::{
+    apis::{okta::OktaError, ApiError},
+    loader::PlaidModule,
+};
 
 use super::{Okta, OktaOperation};
 
 impl Okta {
     /// Get user data by querying the Okta API
-    pub async fn get_user_data(&self, query: &str, _: &str) -> Result<String, ApiError> {
-        let res = self.client.get(format!("https://{}/api/v1/users/{}", &self.config.domain, query))
-            .header("Authorization", self.get_authorization_header(&OktaOperation::GetUserInfo).await.map_err(|e| ApiError::OktaError(e))?)
+    pub async fn get_user_data(
+        &self,
+        query: &str,
+        _: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
+        let res = self
+            .client
+            .get(format!(
+                "https://{}/api/v1/users/{}",
+                &self.config.domain, query
+            ))
+            .header(
+                "Authorization",
+                self.get_authorization_header(&OktaOperation::GetUserInfo)
+                    .await
+                    .map_err(|e| ApiError::OktaError(e))?,
+            )
             .header("Content-Type", "application/json")
             .header("Accept", "application/json");
-            
+
         let response = res.send().await.map_err(|e| ApiError::NetworkError(e))?;
-        let data = response.bytes().await.map_err(|e| ApiError::NetworkError(e))?;
+        let data = response
+            .bytes()
+            .await
+            .map_err(|e| ApiError::NetworkError(e))?;
 
         match String::from_utf8(data.to_vec()) {
             Ok(x) => Ok(x),

--- a/runtime/plaid/src/apis/pagerduty/trigger.rs
+++ b/runtime/plaid/src/apis/pagerduty/trigger.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 use super::{PagerDuty, PagerDutyError};
-use crate::apis::ApiError;
+use crate::{apis::ApiError, loader::PlaidModule};
 
 use serde::{Deserialize, Serialize};
 
@@ -40,7 +42,7 @@ impl PagerDuty {
     pub async fn trigger_incident(
         &self,
         request: &str,
-        module_name: &str,
+        module_name: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
         let request: TriggerRequest = match serde_json::from_str(request) {
             Ok(r) => r,

--- a/runtime/plaid/src/apis/rustica/mod.rs
+++ b/runtime/plaid/src/apis/rustica/mod.rs
@@ -1,8 +1,10 @@
 use rcgen::{Certificate, CertificateParams, DistinguishedName, DnType, KeyPair};
 use serde::{Deserialize, Serialize};
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 use time::{Duration, OffsetDateTime};
+
+use crate::loader::PlaidModule;
 
 use super::ApiError;
 
@@ -57,7 +59,11 @@ impl Rustica {
 
 impl Rustica {
     /// Create a new mTLS certificate and return a serialized `ServerConfiguration` object
-    pub async fn new_mtls_cert(&self, params: &str, _: &str) -> Result<String, ApiError> {
+    pub async fn new_mtls_cert(
+        &self,
+        params: &str,
+        _: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 

--- a/runtime/plaid/src/apis/slack/api.rs
+++ b/runtime/plaid/src/apis/slack/api.rs
@@ -1,8 +1,11 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 
-use crate::apis::{slack::SlackError, ApiError};
+use crate::{
+    apis::{slack::SlackError, ApiError},
+    loader::PlaidModule,
+};
 
 use super::Slack;
 
@@ -123,18 +126,22 @@ impl Slack {
 
     /// Open an arbitrary view for a configured bot. The view contents is defined by the caller but the bot
     /// must be configured in Plaid.
-    pub async fn views_open(&self, params: &str, _: &str) -> Result<u32, ApiError> {
+    pub async fn views_open(&self, params: &str, _: Arc<PlaidModule>) -> Result<u32, ApiError> {
         self.call_slack(params, Apis::ViewsOpen).await.map(|_| 0)
     }
 
     /// Call the Slack postMessage API. The message and location are defined by the module but the bot
     /// must be configured in Plaid.
-    pub async fn post_message(&self, params: &str, _: &str) -> Result<u32, ApiError> {
+    pub async fn post_message(&self, params: &str, _: Arc<PlaidModule>) -> Result<u32, ApiError> {
         self.call_slack(params, Apis::PostMessage).await.map(|_| 0)
     }
 
     /// Calls the Slack API to retrieve a user's Slack ID from their email address
-    pub async fn get_id_from_email(&self, params: &str, _: &str) -> Result<String, ApiError> {
+    pub async fn get_id_from_email(
+        &self,
+        params: &str,
+        _: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         self.call_slack(params, Apis::LookupByEmail).await
     }
 }

--- a/runtime/plaid/src/apis/slack/webhook.rs
+++ b/runtime/plaid/src/apis/slack/webhook.rs
@@ -1,16 +1,30 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
-use crate::apis::{ApiError, slack::SlackError};
+use crate::{
+    apis::{slack::SlackError, ApiError},
+    loader::PlaidModule,
+};
 
 use super::Slack;
 
 impl Slack {
     /// Make a post to a given slack webhook.
-    pub async fn post_to_arbitrary_webhook(&self, params: &str, _: &str) -> Result<u32, ApiError> {
-        let request: HashMap<String, String> = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+    pub async fn post_to_arbitrary_webhook(
+        &self,
+        params: &str,
+        _: Arc<PlaidModule>,
+    ) -> Result<u32, ApiError> {
+        let request: HashMap<String, String> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let hook = request.get("hook").ok_or(ApiError::MissingParameter("hook".to_string()))?.to_string();
-        let body = request.get("body").ok_or(ApiError::MissingParameter("body".to_string()))?.to_string();
+        let hook = request
+            .get("hook")
+            .ok_or(ApiError::MissingParameter("hook".to_string()))?
+            .to_string();
+        let body = request
+            .get("body")
+            .ok_or(ApiError::MissingParameter("body".to_string()))?
+            .to_string();
 
         let address = format!("https://hooks.slack.com/services/{}", hook);
 
@@ -20,24 +34,41 @@ impl Slack {
                 if status == 200 {
                     Ok(0)
                 } else {
-                    Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(status.as_u16())))
+                    Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(
+                        status.as_u16(),
+                    )))
                 }
-            },
+            }
             Err(e) => Err(ApiError::NetworkError(e)),
         }
     }
 
-
-
     /// Make a post to a preconfigured slack webhook. This should be preferred
     /// over the arbitrary API call
-    pub async fn post_to_named_webhook(&self, params: &str, module: &str) -> Result<u32, ApiError> {
-        let request: HashMap<String, String> = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+    pub async fn post_to_named_webhook(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<u32, ApiError> {
+        let request: HashMap<String, String> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let hook_name = request.get("hook_name").ok_or(ApiError::MissingParameter("hook_name".to_string()))?.to_string();
-        let body = request.get("body").ok_or(ApiError::MissingParameter("body".to_string()))?.to_string();
-        
-        let hook = self.config.webhooks.get(&hook_name).ok_or(ApiError::SlackError(SlackError::UnknownHook(hook_name.clone())))?;
+        let hook_name = request
+            .get("hook_name")
+            .ok_or(ApiError::MissingParameter("hook_name".to_string()))?
+            .to_string();
+        let body = request
+            .get("body")
+            .ok_or(ApiError::MissingParameter("body".to_string()))?
+            .to_string();
+
+        let hook = self
+            .config
+            .webhooks
+            .get(&hook_name)
+            .ok_or(ApiError::SlackError(SlackError::UnknownHook(
+                hook_name.clone(),
+            )))?;
 
         info!("Sending a message to a Slack webhook: {hook_name} on behalf of: {module}");
         let address = format!("https://hooks.slack.com/services/{}", hook);
@@ -48,9 +79,11 @@ impl Slack {
                 if status == 200 {
                     Ok(0)
                 } else {
-                    Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(status.as_u16())))
+                    Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(
+                        status.as_u16(),
+                    )))
                 }
-            },
+            }
             Err(e) => Err(ApiError::NetworkError(e)),
         }
     }

--- a/runtime/plaid/src/apis/splunk/mod.rs
+++ b/runtime/plaid/src/apis/splunk/mod.rs
@@ -2,9 +2,11 @@ use reqwest::Client;
 
 use serde::{Deserialize, Serialize};
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use std::collections::HashMap;
+
+use crate::loader::PlaidModule;
 
 use super::{default_timeout_seconds, ApiError};
 
@@ -51,7 +53,7 @@ impl Splunk {
 
     /// Make a post to a preconfigured slack webhook. This should be preferred
     /// over the arbitrary API call
-    pub async fn post_hec(&self, params: &str, module: &str) -> Result<u32, ApiError> {
+    pub async fn post_hec(&self, params: &str, module: Arc<PlaidModule>) -> Result<u32, ApiError> {
         let request: HashMap<String, String> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 

--- a/runtime/plaid/src/apis/web/mod.rs
+++ b/runtime/plaid/src/apis/web/mod.rs
@@ -1,7 +1,9 @@
 use jsonwebtoken::{encode, EncodingKey, Header};
 use serde::Deserialize;
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
+
+use crate::loader::PlaidModule;
 
 use super::ApiError;
 
@@ -51,7 +53,11 @@ impl Web {
     /// Create, sign, and encode a new JWT with the contents specified in `params`.
     /// This fails if `params` contains invalid values or if `module` is not allowed to
     /// use the key specified in `params`.
-    pub async fn issue_jwt(&self, params: &str, module: &str) -> Result<String, ApiError> {
+    pub async fn issue_jwt(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
         let mut request: HashMap<&str, serde_json::Value> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 

--- a/runtime/plaid/src/apis/yubikey/otp.rs
+++ b/runtime/plaid/src/apis/yubikey/otp.rs
@@ -1,8 +1,8 @@
 use super::{Yubikey, YubikeyError};
 
-use crate::apis::ApiError;
+use crate::{apis::ApiError, loader::PlaidModule};
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 use ring::{hmac, rand};
 
@@ -17,7 +17,7 @@ fn hex_encode<T: AsRef<[u8]>>(data: T) -> String {
 
 impl Yubikey {
     /// Verify an OTP is valid by checking it against the Yubico API
-    pub async fn verify_otp(&self, otp: &str, _: &str) -> Result<String, ApiError> {
+    pub async fn verify_otp(&self, otp: &str, _: Arc<PlaidModule>) -> Result<String, ApiError> {
         // Generate a random nonce to validate the OTP with
         let nonce: [u8; 16] = rand::generate(&self.rng)
             .map_err(|_| ApiError::YubikeyError(YubikeyError::RandError))?

--- a/runtime/plaid/src/functions/mod.rs
+++ b/runtime/plaid/src/functions/mod.rs
@@ -27,6 +27,7 @@ pub enum FunctionErrors {
     CouldNotGetAdequateMemory = -8,
     FailedToWriteGuestMemory = -9,
     StorageLimitReached = -10,
+    TestMode = -11,
 }
 
 #[derive(Debug)]

--- a/runtime/plaid/src/logging/mod.rs
+++ b/runtime/plaid/src/logging/mod.rs
@@ -37,6 +37,7 @@ pub enum Log {
     HostFunctionCall {
         module: String,
         function: String,
+        test_mode: bool,
     },
     TimeseriesPoint {
         measurement: String,
@@ -136,9 +137,18 @@ impl Logger {
             .map_err(|_| LoggingError::LoggingSystemDead)
     }
 
-    pub fn log_function_call(&self, module: String, function: String) -> Result<(), LoggingError> {
+    pub fn log_function_call(
+        &self,
+        module: String,
+        function: String,
+        test_mode: bool,
+    ) -> Result<(), LoggingError> {
         self.sender
-            .send(Log::HostFunctionCall { module, function })
+            .send(Log::HostFunctionCall {
+                module,
+                function,
+                test_mode,
+            })
             .map_err(|_| LoggingError::LoggingSystemDead)
     }
 

--- a/runtime/plaid/src/logging/stdout.rs
+++ b/runtime/plaid/src/logging/stdout.rs
@@ -23,8 +23,16 @@ impl PlaidLogger for StdoutLogger {
                 Severity::Warning => warn!("{}", message),
                 Severity::Info => info!("{}", message),
             },
-            Log::HostFunctionCall { module, function } => {
-                debug!("[{module}] is calling [{function}]")
+            Log::HostFunctionCall {
+                module,
+                function,
+                test_mode,
+            } => {
+                if *test_mode {
+                    debug!("TEST MODE [{module}] is calling [{function}]")
+                } else {
+                    debug!("[{module}] is calling [{function}]")
+                }
             }
             Log::ModuleExecutionError { module, error, log } => {
                 debug!("[{module}] errored with error [{error}]. Provided Log: {log}")


### PR DESCRIPTION
Add a way to prevent modules from having side effects at the runtime level. This allows you to run modules where all calls that could have side effects will be disabled by the runtime; allowing more safe testing of rules before production deployments.

Log backs, storage, cache, and Slack are exempt from these rules even though they have side effects.

MNRs are configurable on a case by case basis defaulting to not being allowed.