### PR TITLE
Support DBs shared between rules

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -388,6 +388,24 @@ dependencies = [
 
 [[package]]
 name = "test_random"
+version = "0.1.0"
+dependencies = [
+ "plaid_stl",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "test_shared_db_rule_1"
+version = "0.1.0"
+dependencies = [
+ "plaid_stl",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "test_shared_db_rule_2"
 version = "0.1.0"
 dependencies = [
  "plaid_stl",

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -14,6 +14,8 @@ members = [
     "tests/test_sshcerts_usage",
     "tests/test_testmode",
     "tests/test_time",
+    "tests/test_shared_db_rule_1",
+    "tests/test_shared_db_rule_2",
 ]
 
 [profile.release]

--- a/modules/tests/test_shared_db_rule_1/Cargo.toml
+++ b/modules/tests/test_shared_db_rule_1/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "test_shared_db_rule_1"
+description = "Rule used to test the shared DB functionality."
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+plaid_stl = { path = "../../../runtime/plaid-stl" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+
+[lib]
+crate-type = ["cdylib"]

--- a/modules/tests/test_shared_db_rule_1/harness/harness.sh
+++ b/modules/tests/test_shared_db_rule_1/harness/harness.sh
@@ -27,10 +27,14 @@ curl -d "2" http://$PLAID_LOCATION/webhook/$URL2
 sleep 2
 curl -d "3" http://$PLAID_LOCATION/webhook/$URL1
 sleep 2
+curl -d "3" http://$PLAID_LOCATION/webhook/$URL2
+sleep 2
+curl -d "4" http://$PLAID_LOCATION/webhook/$URL2
+sleep 2
 
 kill $RH_PID 2>&1 > /dev/null
 
-echo -e "OK\nOK\nOK\nOK\nOK" > expected.txt
+echo -e "OK\nOK\nOK\nOK\nOK\nOK\nOK" > expected.txt
 diff expected.txt $FILE
 RESULT=$?
 

--- a/modules/tests/test_shared_db_rule_1/harness/harness.sh
+++ b/modules/tests/test_shared_db_rule_1/harness/harness.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Define what webhook within Plaid we're going to call
+URL1="testshareddb_1"
+FILE="received_data.$URL1.txt"
+URL2="testshareddb_2"
+
+# Start the webhook
+$REQUEST_HANDLER > $FILE &
+if [ $? -ne 0 ]; then
+  echo "Failed to start request handler"
+  rm $FILE
+  exit 1
+fi
+
+RH_PID=$!
+
+# Call the webhook
+sleep 2
+curl -d "1" http://$PLAID_LOCATION/webhook/$URL1
+sleep 2
+curl -d "1" http://$PLAID_LOCATION/webhook/$URL2
+sleep 2
+curl -d "2" http://$PLAID_LOCATION/webhook/$URL1
+sleep 2
+curl -d "2" http://$PLAID_LOCATION/webhook/$URL2
+sleep 2
+curl -d "3" http://$PLAID_LOCATION/webhook/$URL1
+sleep 2
+
+kill $RH_PID 2>&1 > /dev/null
+
+echo -e "OK\nOK\nOK\nOK\nOK" > expected.txt
+diff expected.txt $FILE
+RESULT=$?
+
+rm -f $FILE expected.txt
+
+exit $RESULT

--- a/modules/tests/test_shared_db_rule_1/harness/harness.sh
+++ b/modules/tests/test_shared_db_rule_1/harness/harness.sh
@@ -31,10 +31,12 @@ curl -d "3" http://$PLAID_LOCATION/webhook/$URL2
 sleep 2
 curl -d "4" http://$PLAID_LOCATION/webhook/$URL2
 sleep 2
+curl -d "5" http://$PLAID_LOCATION/webhook/$URL2
+sleep 2
 
 kill $RH_PID 2>&1 > /dev/null
 
-echo -e "OK\nOK\nOK\nOK\nOK\nOK\nOK" > expected.txt
+echo -e "OK\nOK\nOK\nOK\nOK\nOK\nOK\nOK" > expected.txt
 diff expected.txt $FILE
 RESULT=$?
 

--- a/modules/tests/test_shared_db_rule_1/src/lib.rs
+++ b/modules/tests/test_shared_db_rule_1/src/lib.rs
@@ -1,0 +1,54 @@
+use std::collections::HashMap;
+
+use plaid_stl::{entrypoint_with_source, messages::LogSource, network::make_named_request, plaid};
+
+entrypoint_with_source!();
+
+const SHARED_DB: &str = "shared_db_1";
+const RULE_NAME: &str = "test_shared_db_rule_1";
+
+fn main(log: String, _: LogSource) -> Result<(), i32> {
+    // Depending on the value of "log", we do different things
+    match log.as_str() {
+        "1" => {
+            plaid::print_debug_string(&format!("[{RULE_NAME}] Reading from DB..."));
+            let r = plaid::storage::get_shared(SHARED_DB, "my_key").unwrap();
+            plaid::print_debug_string(&format!("[{RULE_NAME}] Got {} bytes", r.len()));
+            if r.len() != 0 {
+                panic!()
+            }
+            plaid::print_debug_string(&format!(
+                "[{RULE_NAME}] Writing to DB (which is not allowed)..."
+            ));
+            match plaid::storage::insert_shared(SHARED_DB, "my_key", &vec![0u8, 1u8]) {
+                Ok(_) => panic!("This should have failed"),
+                Err(_) => {}
+            }
+            plaid::print_debug_string(&format!("[{RULE_NAME}] Failed as expected"));
+            make_named_request("test-response", "OK", HashMap::new()).unwrap();
+        }
+        "2" => {
+            // Meanwhile, another rule will have written 2 bytes to the shared DB
+            plaid::print_debug_string(&format!("[{RULE_NAME}] Reading from DB..."));
+            let r = plaid::storage::get_shared(SHARED_DB, "my_key").unwrap();
+            plaid::print_debug_string(&format!("[{RULE_NAME}] Got {} bytes", r.len()));
+            if r.len() != 2 {
+                panic!()
+            }
+            make_named_request("test-response", "OK", HashMap::new()).unwrap();
+        }
+        "3" => {
+            // Meanwhile, another rule will have deleted the key from the shared DB
+            plaid::print_debug_string(&format!("[{RULE_NAME}] Reading from DB..."));
+            let r = plaid::storage::get_shared(SHARED_DB, "my_key").unwrap();
+            plaid::print_debug_string(&format!("[{RULE_NAME}] Got {} bytes", r.len()));
+            if r.len() != 0 {
+                panic!()
+            }
+            make_named_request("test-response", "OK", HashMap::new()).unwrap();
+        }
+        _ => panic!("Got an unexpected log"),
+    }
+
+    Ok(())
+}

--- a/modules/tests/test_shared_db_rule_2/Cargo.toml
+++ b/modules/tests/test_shared_db_rule_2/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "test_shared_db_rule_2"
+description = "Rule used to test the shared DB functionality."
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+plaid_stl = { path = "../../../runtime/plaid-stl" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+
+[lib]
+crate-type = ["cdylib"]

--- a/modules/tests/test_shared_db_rule_2/src/lib.rs
+++ b/modules/tests/test_shared_db_rule_2/src/lib.rs
@@ -34,6 +34,32 @@ fn main(log: String, _: LogSource) -> Result<(), i32> {
             }
             make_named_request("test-response", "OK", HashMap::new()).unwrap();
         }
+        "3" => {
+            plaid::print_debug_string(&format!("[{RULE_NAME}] Filling up the shared DB..."));
+            plaid::storage::insert_shared(SHARED_DB, "my_key", &vec![0u8; 44]).unwrap();
+
+            plaid::print_debug_string(&format!("[{RULE_NAME}] Reading from DB..."));
+            let r = plaid::storage::get_shared(SHARED_DB, "my_key").unwrap();
+            plaid::print_debug_string(&format!(
+                "[{RULE_NAME}] Got {} bytes (+ {} bytes for the key)",
+                r.len(),
+                "my_key".as_bytes().len()
+            ));
+            make_named_request("test-response", "OK", HashMap::new()).unwrap();
+        }
+        "4" => {
+            plaid::print_debug_string(&format!(
+                "[{RULE_NAME}] Writing to a full shared DB, should fail..."
+            ));
+            match plaid::storage::insert_shared(SHARED_DB, "another_key", &vec![0u8]) {
+                Ok(_) => panic!("This should have failed"),
+                Err(_) => {
+                    plaid::print_debug_string(&format!("[{RULE_NAME}] Failed as expected"));
+                }
+            }
+
+            make_named_request("test-response", "OK", HashMap::new()).unwrap();
+        }
         _ => panic!("Got an unexpected log"),
     }
 

--- a/modules/tests/test_shared_db_rule_2/src/lib.rs
+++ b/modules/tests/test_shared_db_rule_2/src/lib.rs
@@ -1,0 +1,41 @@
+use std::collections::HashMap;
+
+use plaid_stl::{entrypoint_with_source, messages::LogSource, network::make_named_request, plaid};
+
+entrypoint_with_source!();
+
+const SHARED_DB: &str = "shared_db_1";
+const RULE_NAME: &str = "test_shared_db_rule_2";
+
+fn main(log: String, _: LogSource) -> Result<(), i32> {
+    // Depending on the value of "log", we do different things
+    match log.as_str() {
+        "1" => {
+            plaid::print_debug_string(&format!("[{RULE_NAME}] Writing to DB..."));
+            plaid::storage::insert_shared(SHARED_DB, "my_key", &vec![0u8, 1u8]).unwrap();
+
+            plaid::print_debug_string(&format!("[{RULE_NAME}] Reading from DB..."));
+            let r = plaid::storage::get_shared(SHARED_DB, "my_key").unwrap();
+            plaid::print_debug_string(&format!("[{RULE_NAME}] Got {} bytes", r.len()));
+            if r.len() != 2 {
+                panic!()
+            }
+            make_named_request("test-response", "OK", HashMap::new()).unwrap();
+        }
+        "2" => {
+            plaid::print_debug_string(&format!("[{RULE_NAME}] Deleting from DB..."));
+            plaid::storage::delete_shared(SHARED_DB, "my_key").unwrap();
+
+            plaid::print_debug_string(&format!("[{RULE_NAME}] Reading from DB..."));
+            let r = plaid::storage::get_shared(SHARED_DB, "my_key").unwrap();
+            plaid::print_debug_string(&format!("[{RULE_NAME}] Got {} bytes", r.len()));
+            if r.len() != 0 {
+                panic!()
+            }
+            make_named_request("test-response", "OK", HashMap::new()).unwrap();
+        }
+        _ => panic!("Got an unexpected log"),
+    }
+
+    Ok(())
+}

--- a/modules/tests/test_shared_db_rule_2/src/lib.rs
+++ b/modules/tests/test_shared_db_rule_2/src/lib.rs
@@ -57,7 +57,18 @@ fn main(log: String, _: LogSource) -> Result<(), i32> {
                     plaid::print_debug_string(&format!("[{RULE_NAME}] Failed as expected"));
                 }
             }
-
+            make_named_request("test-response", "OK", HashMap::new()).unwrap();
+        }
+        "5" => {
+            plaid::print_debug_string(&format!(
+                "[{RULE_NAME}] Writing to a non-existing shared DB, should fail..."
+            ));
+            match plaid::storage::insert_shared("this_does_not_exist", "some_key", &vec![0u8]) {
+                Ok(_) => panic!("This should have failed"),
+                Err(e) => {
+                    plaid::print_debug_string(&format!("[{RULE_NAME}] Failed as expected: {e}"));
+                }
+            }
             make_named_request("test-response", "OK", HashMap::new()).unwrap();
         }
         _ => panic!("Got an unexpected log"),

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -2716,7 +2716,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plaid"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "alkali",
  "async-trait",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/plaid/storage.rs
+++ b/runtime/plaid-stl/src/plaid/storage.rs
@@ -52,6 +52,76 @@ pub fn insert(key: &str, value: &[u8]) -> Result<Vec<u8>, PlaidFunctionError> {
     }
 }
 
+pub fn insert_shared(
+    namespace: &str,
+    key: &str,
+    value: &[u8],
+) -> Result<Vec<u8>, PlaidFunctionError> {
+    extern "C" {
+        /// Send a request to store this data in whatever persistence system Plaid has configured.
+        /// There may not be one which is not visible to services. This will be addressed in a
+        /// future update.
+        fn storage_insert_shared(
+            namespace: *const u8,
+            namespace_len: usize,
+            key: *const u8,
+            key_len: usize,
+            value: *const u8,
+            value_len: usize,
+            data: *const u8,
+            data_len: usize,
+        ) -> u32;
+
+        fn storage_get_shared(
+            namespace: *const u8,
+            namespace_len: usize,
+            key: *const u8,
+            key_len: usize,
+            data: *const u8,
+            data_len: usize,
+        ) -> i32;
+    }
+
+    let namespace_bytes = namespace.as_bytes().to_vec();
+    let key_bytes = key.as_bytes().to_vec();
+
+    let buffer_size = unsafe {
+        storage_get_shared(
+            namespace_bytes.as_ptr(),
+            namespace_bytes.len(),
+            key_bytes.as_ptr(),
+            key_bytes.len(),
+            vec![].as_mut_ptr(),
+            0,
+        )
+    };
+
+    if buffer_size < 0 {
+        return Err(buffer_size.into());
+    }
+
+    let mut data_buffer = vec![0; buffer_size as usize];
+    let copied_size = unsafe {
+        storage_insert_shared(
+            namespace_bytes.as_ptr(),
+            namespace_bytes.len(),
+            key_bytes.as_ptr(),
+            key_bytes.len(),
+            value.as_ptr(),
+            value.len(),
+            data_buffer.as_mut_ptr(),
+            buffer_size as usize,
+        )
+    };
+
+    if copied_size == buffer_size as u32 {
+        data_buffer.truncate(copied_size as usize);
+        Ok(data_buffer)
+    } else {
+        Err(PlaidFunctionError::ReturnBufferTooSmall)
+    }
+}
+
 pub fn get(key: &str) -> Result<Vec<u8>, PlaidFunctionError> {
     extern "C" {
         fn storage_get(key: *const u8, key_len: usize, data: *const u8, data_len: usize) -> i32;
@@ -83,11 +153,65 @@ pub fn get(key: &str) -> Result<Vec<u8>, PlaidFunctionError> {
     }
 }
 
+pub fn get_shared(namespace: &str, key: &str) -> Result<Vec<u8>, PlaidFunctionError> {
+    extern "C" {
+        fn storage_get_shared(
+            namespace: *const u8,
+            namespace_len: usize,
+            key: *const u8,
+            key_len: usize,
+            data: *const u8,
+            data_len: usize,
+        ) -> i32;
+    }
+
+    let namespace_bytes = namespace.as_bytes().to_vec();
+    let key_bytes = key.as_bytes().to_vec();
+
+    let buffer_size = unsafe {
+        storage_get_shared(
+            namespace_bytes.as_ptr(),
+            namespace_bytes.len(),
+            key_bytes.as_ptr(),
+            key_bytes.len(),
+            vec![].as_mut_ptr(),
+            0,
+        )
+    };
+
+    if buffer_size < 0 {
+        return Err(buffer_size.into());
+    }
+    let mut data_buffer = vec![0; buffer_size as usize];
+    let copied_size = unsafe {
+        storage_get_shared(
+            namespace_bytes.as_ptr(),
+            namespace_bytes.len(),
+            key_bytes.as_ptr(),
+            key_bytes.len(),
+            data_buffer.as_mut_ptr(),
+            buffer_size as usize,
+        )
+    };
+
+    if copied_size == buffer_size {
+        data_buffer.truncate(copied_size as usize);
+        Ok(data_buffer)
+    } else {
+        Err(PlaidFunctionError::ReturnBufferTooSmall)
+    }
+}
+
 /// List all the keys set by this rule in the runtime. An optional
 /// prefix can be provided so that only a subset of keys is returned
 pub fn list_keys(prefix: Option<impl Display>) -> Result<Vec<String>, PlaidFunctionError> {
     extern "C" {
-        fn storage_list_keys(prefix: *const u8, prefix_len: usize, data: *const u8, data_len: usize) -> i32;
+        fn storage_list_keys(
+            prefix: *const u8,
+            prefix_len: usize,
+            data: *const u8,
+            data_len: usize,
+        ) -> i32;
     }
 
     let prefix = match prefix {
@@ -97,8 +221,14 @@ pub fn list_keys(prefix: Option<impl Display>) -> Result<Vec<String>, PlaidFunct
 
     let prefix_bytes = prefix.as_bytes().to_vec();
 
-    let buffer_size =
-        unsafe { storage_list_keys(prefix_bytes.as_ptr(), prefix_bytes.len(), vec![].as_mut_ptr(), 0) };
+    let buffer_size = unsafe {
+        storage_list_keys(
+            prefix_bytes.as_ptr(),
+            prefix_bytes.len(),
+            vec![].as_mut_ptr(),
+            0,
+        )
+    };
 
     if buffer_size < 0 {
         return Err(buffer_size.into());
@@ -137,6 +267,55 @@ pub fn delete(key: &str) -> Result<Vec<u8>, PlaidFunctionError> {
     let mut data_buffer = vec![0; buffer_size as usize];
     let copied_size = unsafe {
         storage_delete(
+            key_bytes.as_ptr(),
+            key_bytes.len(),
+            data_buffer.as_mut_ptr(),
+            buffer_size as usize,
+        )
+    };
+
+    if copied_size == buffer_size {
+        data_buffer.truncate(copied_size as usize);
+        Ok(data_buffer)
+    } else {
+        Err(PlaidFunctionError::ReturnBufferTooSmall)
+    }
+}
+
+pub fn delete_shared(namespace: &str, key: &str) -> Result<Vec<u8>, PlaidFunctionError> {
+    extern "C" {
+        fn storage_delete_shared(
+            namespace: *const u8,
+            namespace_len: usize,
+            key: *const u8,
+            key_len: usize,
+            data: *const u8,
+            data_len: usize,
+        ) -> i32;
+    }
+
+    let namespace_bytes = namespace.as_bytes().to_vec();
+    let key_bytes = key.as_bytes().to_vec();
+
+    let buffer_size = unsafe {
+        storage_delete_shared(
+            namespace_bytes.as_ptr(),
+            namespace_bytes.len(),
+            key_bytes.as_ptr(),
+            key_bytes.len(),
+            vec![].as_mut_ptr(),
+            0,
+        )
+    };
+
+    if buffer_size < 0 {
+        return Err(buffer_size.into());
+    }
+    let mut data_buffer = vec![0; buffer_size as usize];
+    let copied_size = unsafe {
+        storage_delete_shared(
+            namespace_bytes.as_ptr(),
+            namespace_bytes.len(),
             key_bytes.as_ptr(),
             key_bytes.len(),
             data_buffer.as_mut_ptr(),

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -7,6 +7,11 @@ execution_threads = 2
 # file is written to /runtime/performance-monitoring/metrics.txt
 # output_file_path = "../somedirectory/file.txt" 
 
+[storage.shared_dbs."shared_db_1"]
+size_limit = "Unlimited"
+r = ["test_shared_db_rule_1.wasm"]
+rw = ["test_shared_db_rule_2.wasm"]
+
 [storage.sled]
 path = "/tmp/sled"
 
@@ -35,6 +40,8 @@ test_mode_exemptions = [
     "test_random.wasm",
     "test_sshcerts_usage.wasm",
     "test_time.wasm",
+    "test_shared_db_rule_1.wasm",
+    "test_shared_db_rule_2.wasm",
 ]
 
 [loading.persistent_response_size]
@@ -76,6 +83,8 @@ test_mode_exemptions = [
 "test_sshcerts_usage.wasm" = "test_sshcerts"
 "test_testmode.wasm" = "testmode"
 "test_time.wasm" = "time"
+"test_shared_db_rule_1.wasm" = "test_shareddb_1"
+"test_shared_db_rule_2.wasm" = "test_shareddb_2"
 
 # Configure the computation amount. See the loader module for more
 # information on how computation cost is calculated.
@@ -85,6 +94,8 @@ default = 55_000_000
 okta = 9_000_000
 [loading.computation_amount.module_overrides]
 "example_rule.wasm" = 5_000_000
+"test_shared_db_rule_1.wasm" = 1_000_000_000
+"test_shared_db_rule_2.wasm" = 1_000_000_000
 
 [loading.memory_page_count]
 default = 300
@@ -120,6 +131,8 @@ allowed_rules = [
     "test_random.wasm",
     "test_mnr.wasm",
     "test_get_everything.wasm",
+    "test_shared_db_rule_1.wasm",
+    "test_shared_db_rule_2.wasm",
 ]
 [apis."general"."network"."web_requests"."test-response"."headers"]
 testheader = "Some data here"
@@ -320,6 +333,14 @@ headers = []
 
 [webhooks."internal".webhooks."testfileopen"]
 log_type = "test_fileopen"
+headers = []
+
+[webhooks."internal".webhooks."testshareddb_1"]
+log_type = "test_shareddb_1"
+headers = []
+
+[webhooks."internal".webhooks."testshareddb_2"]
+log_type = "test_shareddb_2"
 headers = []
 
 [webhooks."internal".webhooks."testrandom"]

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -8,7 +8,7 @@ execution_threads = 2
 # output_file_path = "../somedirectory/file.txt" 
 
 [storage.shared_dbs."shared_db_1"]
-size_limit = "Unlimited"
+size_limit = { Limited = 50 }
 r = ["test_shared_db_rule_1.wasm"]
 rw = ["test_shared_db_rule_2.wasm"]
 

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             match &storage.shared_dbs {
                 None => info!("No shared DBs configured"),
                 Some(dbs) => {
-                    info!("Configured shared DBs: {:?}", dbs.keys().map(|v| v.clone()).collect::<Vec<String>>());
+                    info!("Configured shared DBs: {:?}", dbs.keys().collect::<Vec<&String>>());
                 }
             }
         }

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -429,8 +429,17 @@ pub fn to_api_function(
         }
         "get_time" => Function::new_typed(&mut store, super::internal::get_time),
         "storage_insert" => Function::new_typed_with_env(&mut store, &env, super::storage::insert),
+        "storage_insert_shared" => {
+            Function::new_typed_with_env(&mut store, &env, super::storage::insert_shared)
+        }
         "storage_get" => Function::new_typed_with_env(&mut store, &env, super::storage::get),
+        "storage_get_shared" => {
+            Function::new_typed_with_env(&mut store, &env, super::storage::get_shared)
+        }
         "storage_delete" => Function::new_typed_with_env(&mut store, &env, super::storage::delete),
+        "storage_delete_shared" => {
+            Function::new_typed_with_env(&mut store, &env, super::storage::delete_shared)
+        }
         "storage_list_keys" => {
             Function::new_typed_with_env(&mut store, &env, super::storage::list_keys)
         }

--- a/runtime/plaid/src/functions/mod.rs
+++ b/runtime/plaid/src/functions/mod.rs
@@ -28,6 +28,8 @@ pub enum FunctionErrors {
     FailedToWriteGuestMemory = -9,
     StorageLimitReached = -10,
     TestMode = -11,
+    OperationNotAllowed = -12,
+    SharedDbError = -13,
 }
 
 #[derive(Debug)]

--- a/runtime/plaid/src/functions/storage.rs
+++ b/runtime/plaid/src/functions/storage.rs
@@ -429,7 +429,7 @@ pub fn get_shared(
         }
     };
     if !allowed {
-        return FunctionErrors::ApiNotConfigured as i32; // TODO better error?
+        return FunctionErrors::OperationNotAllowed as i32;
     }
 
     safely_get_guest_string!(key, memory_view, key_buf, key_buf_len, env_data);
@@ -701,10 +701,6 @@ pub fn delete_shared(
     };
     if !allowed {
         return FunctionErrors::OperationNotAllowed as i32;
-    }
-
-    if !allowed {
-        return FunctionErrors::ApiNotConfigured as i32; // TODO better error?
     }
 
     // Get storage limit and counter for the shared DB

--- a/runtime/plaid/src/functions/storage.rs
+++ b/runtime/plaid/src/functions/storage.rs
@@ -1,8 +1,134 @@
-use wasmer::{AsStoreRef, FunctionEnvMut, WasmPtr};
+use std::sync::{Arc, RwLock};
 
-use crate::{executor::Env, functions::FunctionErrors, loader::LimitValue};
+use wasmer::{AsStoreRef, FunctionEnvMut, MemoryView, WasmPtr};
+
+use crate::{executor::Env, functions::FunctionErrors, loader::LimitValue, storage::Storage};
 
 use super::{get_memory, safely_get_memory, safely_get_string, safely_write_data_back};
+
+/// Code which is common to `insert` and `insert_shared`
+fn insert_common(
+    env_data: &Env,
+    storage: &Arc<Storage>,
+    namespace: String,
+    key: String,
+    value: Vec<u8>,
+    memory_view: MemoryView,
+    data_buffer: WasmPtr<u8>,
+    data_buffer_len: u32,
+    storage_limit: LimitValue,
+    storage_counter: &Arc<RwLock<u64>>,
+) -> i32 {
+    // ugly, but we are dealing with a couple of "async move"s
+    let storage_key = key.clone();
+    let namespace_clone = namespace.clone();
+
+    // The insertion proceeds differently depending on whether the storage is limited or not.
+    let insertion_result = match storage_limit {
+        LimitValue::Unlimited => {
+            // The storage is unlimited, so we don't check / update any counters and just proceed with the operation
+            env_data
+                .api
+                .clone()
+                .runtime
+                .block_on(async move { storage.insert(namespace, storage_key, value).await })
+        }
+        LimitValue::Limited(storage_limit) => {
+            // The storage is limited, so we need to check / update counters (with locks) because the operation might have to be rejected.
+
+            // Get a lock on the storage counter.
+            // This ensures no race conditions if multiple instances of the same module are running in parallel.
+            // The guard will go out of scope at the end of this block, thus releasing the lock. After this block, we won't touch the counter again.
+            let mut storage_current = match storage_counter.write() {
+                Ok(g) => g,
+                Err(e) => {
+                    error!("Critical error getting a lock on used storage: {:?}", e);
+                    return FunctionErrors::InternalApiError as i32;
+                }
+            };
+
+            // We check if this insert would overwrite some existing data. If so, we need to take that into account when
+            // computing the storage that would be occupied at the end of the insert operation.
+            // Note: if we have existing data, then we need to count the key's length as well. This is because at the end
+            // of a possible insertion, we would have only one key.
+            let get_key = key.clone();
+            let key_len = key.as_bytes().len();
+            let existing_data_size = match env_data
+                .api
+                .clone()
+                .runtime
+                .block_on(async move { storage.get(&namespace, &get_key).await })
+            {
+                Ok(data) => match data {
+                    None => 0u64,
+                    Some(d) => d.len() as u64 + key_len as u64,
+                },
+                Err(_) => {
+                    return FunctionErrors::InternalApiError as i32;
+                }
+            };
+
+            // Calculate the amount of storage that would be used after successfully inserting.
+            // Note: we _substract_ the size of existing data. If we were to insert the new data, the old data would be overwritten.
+            let would_be_used_storage =
+                *storage_current + key_len as u64 + value.len() as u64 - existing_data_size;
+            // no problem with underflowing because the result will never be negative (since *storage_current >= existing_data_size)
+
+            // If we would go above the limited storage, reject the insert
+            if would_be_used_storage > storage_limit {
+                error!("{}: Could not insert key/value with key {key} as that would bring us above the configured storage limit.", env_data.module.name);
+                return FunctionErrors::StorageLimitReached as i32;
+            }
+
+            let result =
+                env_data.api.clone().runtime.block_on(async move {
+                    storage.insert(namespace_clone, storage_key, value).await
+                });
+            // If the insertion went well, update counter for used storage.
+            // If the insertion failed for some reason, we don't update the counter and release the lock: no harm done.
+            if result.is_ok() {
+                *storage_current = would_be_used_storage;
+            }
+            result
+        }
+    };
+
+    // Process the insertion result and return info to the caller
+    match insertion_result {
+        Ok(data) => {
+            match data {
+                Some(data) => {
+                    // If the data is too large to fit in the buffer that was passed to us. Unfortunately this is a somewhat
+                    // unrecoverable state because we've overwritten the value already. We could fail insertion if the data
+                    // buffer passed is too small in future? That would mean doing a get call first, which the client can do
+                    // too.
+                    match safely_write_data_back(&memory_view, &data, data_buffer, data_buffer_len)
+                    {
+                        Ok(x) => x,
+                        Err(e) => {
+                            error!(
+                                "{}: Data write error in storage_insert: {:?}",
+                                env_data.module.name, e
+                            );
+                            e as i32
+                        }
+                    }
+                }
+                // This occurs when there is no such key so the number of bytes that have been copied back are 0
+                None => 0,
+            }
+        }
+        // If the storage system errors (for example a network problem if using a networked storage provider)
+        // the error is made opaque to the client here and we log what happened
+        Err(e) => {
+            error!(
+                "There was a storage system error when key [{key}] was accessed by [{}]: {e}",
+                env_data.module.name
+            );
+            return FunctionErrors::InternalApiError as i32;
+        }
+    }
+}
 
 /// Store data in the storage system if one is configured
 pub fn insert(
@@ -57,113 +183,163 @@ pub fn insert(
         }
     };
 
-    let storage_key = key.clone();
+    insert_common(
+        env_data,
+        storage,
+        env_data.module.name.clone(),
+        key,
+        value,
+        memory_view,
+        data_buffer,
+        data_buffer_len,
+        env_data.module.storage_limit.clone(),
+        &env_data.module.storage_current,
+    )
+}
 
-    // The insertion proceeds differently depending on whether the module's storage is limited or not.
-    let insertion_result = match env_data.module.storage_limit {
-        LimitValue::Unlimited => {
-            // The module has unlimited storage, so we don't check / update any counters and just proceed with the operation
-            env_data.api.clone().runtime.block_on(async move {
-                storage
-                    .insert(env_data.module.name.clone(), storage_key, value)
-                    .await
-            })
-        }
-        LimitValue::Limited(storage_limit) => {
-            // The module has limited storage, so we need to check / update counters (with locks) because the operation might have to be rejected.
+/// Store data in a shared namespace in the storage system, if one is configured
+pub fn insert_shared(
+    env: FunctionEnvMut<Env>,
+    namespace_buf: WasmPtr<u8>,
+    namespace_buf_len: u32,
+    key_buf: WasmPtr<u8>,
+    key_buf_len: u32,
+    value_buf: WasmPtr<u8>,
+    value_buf_len: u32,
+    data_buffer: WasmPtr<u8>,
+    data_buffer_len: u32,
+) -> i32 {
+    let store = env.as_store_ref();
+    let env_data = env.data();
 
-            // Get a lock on the storage counter for the module that is processing this message.
-            // This ensures no race conditions if multiple instances of the same module are running in parallel.
-            // The guard will go out of scope at the end of this block, thus releasing the lock. After this block, we won't touch the counter again.
-            let mut storage_current = match env_data.module.storage_current.write() {
-                Ok(g) => g,
-                Err(e) => {
-                    error!("Critical error getting a lock on used storage: {:?}", e);
-                    return FunctionErrors::InternalApiError as i32;
-                }
-            };
+    let storage = if let Some(storage) = &env_data.storage {
+        storage
+    } else {
+        return FunctionErrors::ApiNotConfigured as i32;
+    };
 
-            // We check if this insert would overwrite some existing data. If so, we need to take that into account when
-            // computing the storage that would be occupied at the end of the insert operation.
-            // Note: if we have existing data, then we need to count the key's length as well. This is because at the end
-            // of a possible insertion, we would have only one key.
-            let get_key = key.clone();
-            let key_len = key.as_bytes().len();
-            let existing_data_size = match env_data
-                .api
-                .clone()
-                .runtime
-                .block_on(async move { storage.get(&env_data.module.name, &get_key).await })
-            {
-                Ok(data) => match data {
-                    None => 0u64,
-                    Some(d) => d.len() as u64 + key_len as u64,
-                },
-                Err(_) => {
-                    return FunctionErrors::InternalApiError as i32;
-                }
-            };
-
-            // Calculate the amount of storage that would be used after successfully inserting.
-            // Note: we _substract_ the size of existing data. If we were to insert the new data, the old data would be overwritten.
-            let would_be_used_storage =
-                *storage_current + key_len as u64 + value.len() as u64 - existing_data_size;
-            // no problem with underflowing because the result will never be negative (since *storage_current >= existing_data_size)
-
-            // If we would go above the limited storage, reject the insert
-            if would_be_used_storage > storage_limit {
-                error!("{}: Could not insert key/value with key {storage_key} as that would bring us above the configured storage limit.", env_data.module.name);
-                return FunctionErrors::StorageLimitReached as i32;
-            }
-
-            let result = env_data.api.clone().runtime.block_on(async move {
-                storage
-                    .insert(env_data.module.name.clone(), storage_key, value)
-                    .await
-            });
-            // If the insertion went well, update counter for used storage.
-            // If the insertion failed for some reason, we don't update the counter and release the lock: no harm done.
-            if result.is_ok() {
-                *storage_current = would_be_used_storage;
-            }
-            result
+    let memory_view = match get_memory(&env, &store) {
+        Ok(memory_view) => memory_view,
+        Err(e) => {
+            error!(
+                "{}: Memory error in storage_insert_shared: {:?}",
+                env_data.module.name, e
+            );
+            return FunctionErrors::CouldNotGetAdequateMemory as i32;
         }
     };
 
-    // Process the insertion result and return info to the caller
-    match insertion_result {
-        Ok(data) => {
-            match data {
-                Some(data) => {
-                    // If the data is too large to fit in the buffer that was passed to us. Unfortunately this is a somewhat
-                    // unrecoverable state because we've overwritten the value already. We could fail insertion if the data
-                    // buffer passed is too small in future? That would mean doing a get call first, which the client can do
-                    // too.
-                    match safely_write_data_back(&memory_view, &data, data_buffer, data_buffer_len)
-                    {
-                        Ok(x) => x,
-                        Err(e) => {
-                            error!(
-                                "{}: Data write error in storage_insert: {:?}",
-                                env_data.module.name, e
-                            );
-                            e as i32
-                        }
-                    }
-                }
-                // This occurs when there is no such key so the number of bytes that have been copied back are 0
-                None => 0,
-            }
-        }
-        // If the storage system errors (for example a network problem if using a networked storage provider)
-        // the error is made opaque to the client here and we log what happened
+    let namespace = match safely_get_string(&memory_view, namespace_buf, namespace_buf_len) {
+        Ok(s) => s,
         Err(e) => {
             error!(
-                "There was a storage system error when key [{key}] was accessed by [{}]: {e}",
-                env_data.module.name
+                "{}: Namespace error in storage_insert_shared: {:?}",
+                env_data.module.name, e
             );
-            return FunctionErrors::InternalApiError as i32;
+            return FunctionErrors::ParametersNotUtf8 as i32;
         }
+    };
+
+    let key = match safely_get_string(&memory_view, key_buf, key_buf_len) {
+        Ok(s) => s,
+        Err(e) => {
+            error!(
+                "{}: Key error in storage_insert_shared: {:?}",
+                env_data.module.name, e
+            );
+            return FunctionErrors::ParametersNotUtf8 as i32;
+        }
+    };
+
+    // Get the storage data from the client's memory
+    let value = match safely_get_memory(&memory_view, value_buf, value_buf_len) {
+        Ok(d) => d,
+        Err(e) => {
+            error!(
+                "{}: Value error in storage_insert_shared: {:?}",
+                env_data.module.name, e
+            );
+            return FunctionErrors::CouldNotGetAdequateMemory as i32;
+        }
+    };
+
+    // Check if the rule can write to the shared DB.
+    // This is the case if the rule is in the "rw" section of the config.
+    let allowed = match &storage.shared_dbs {
+        None => false,
+        Some(dbs) => match dbs.get(&namespace) {
+            None => false,
+            Some(db) => db
+                .config
+                .rw
+                .as_ref()
+                .unwrap_or(&Vec::new())
+                .contains(&env_data.module.name),
+        },
+    };
+
+    if !allowed {
+        return FunctionErrors::ApiNotConfigured as i32; // TODO better error?
+    }
+
+    // Get storage limit and counter for the shared DB
+    let (storage_limit, storage_current) = match &storage.shared_dbs {
+        None => {
+            return FunctionErrors::ApiNotConfigured as i32;
+        }
+        Some(shared_dbs) => match shared_dbs.get(&namespace) {
+            None => {
+                return FunctionErrors::ApiNotConfigured as i32;
+            }
+            Some(db) => (db.config.size_limit.clone(), db.used_storage.clone()),
+        },
+    };
+
+    insert_common(
+        env_data,
+        storage,
+        namespace,
+        key,
+        value,
+        memory_view,
+        data_buffer,
+        data_buffer_len,
+        storage_limit,
+        &storage_current,
+    )
+}
+
+/// Code which is common to `get` and `get_shared`
+fn get_common(
+    env_data: &Env,
+    storage: &Arc<Storage>,
+    namespace: &str,
+    key: &str,
+    memory_view: MemoryView,
+    data_buffer: WasmPtr<u8>,
+    data_buffer_len: u32,
+) -> i32 {
+    let result = env_data
+        .api
+        .clone()
+        .runtime
+        .block_on(async move { storage.get(namespace, key).await });
+
+    match result {
+        Ok(Some(data)) => {
+            match safely_write_data_back(&memory_view, &data, data_buffer, data_buffer_len) {
+                Ok(x) => x,
+                Err(e) => {
+                    error!(
+                        "{}: Data write error in storage_get: {:?}",
+                        env_data.module.name, e
+                    );
+                    e as i32
+                }
+            }
+        }
+        Ok(None) => 0,
+        Err(_) => 0,
     }
 }
 
@@ -205,28 +381,105 @@ pub fn get(
             return FunctionErrors::ParametersNotUtf8 as i32;
         }
     };
-    let result = env_data
-        .api
-        .clone()
-        .runtime
-        .block_on(async move { storage.get(&env_data.module.name, &key).await });
 
-    match result {
-        Ok(Some(data)) => {
-            match safely_write_data_back(&memory_view, &data, data_buffer, data_buffer_len) {
-                Ok(x) => x,
-                Err(e) => {
-                    error!(
-                        "{}: Data write error in storage_get: {:?}",
-                        env_data.module.name, e
-                    );
-                    e as i32
-                }
-            }
+    get_common(
+        env_data,
+        storage,
+        &env_data.module.name,
+        &key,
+        memory_view,
+        data_buffer,
+        data_buffer_len,
+    )
+}
+
+/// Get data from a shared namespace in the storage system, if one is configured
+pub fn get_shared(
+    env: FunctionEnvMut<Env>,
+    namespace_buf: WasmPtr<u8>,
+    namespace_buf_len: u32,
+    key_buf: WasmPtr<u8>,
+    key_buf_len: u32,
+    data_buffer: WasmPtr<u8>,
+    data_buffer_len: u32,
+) -> i32 {
+    let store = env.as_store_ref();
+    let env_data = env.data();
+
+    let storage = if let Some(storage) = &env_data.storage {
+        storage
+    } else {
+        return FunctionErrors::ApiNotConfigured as i32;
+    };
+
+    let memory_view = match get_memory(&env, &store) {
+        Ok(memory_view) => memory_view,
+        Err(e) => {
+            error!(
+                "{}: Memory error in storage_get_shared: {:?}",
+                env_data.module.name, e
+            );
+            return FunctionErrors::CouldNotGetAdequateMemory as i32;
         }
-        Ok(None) => 0,
-        Err(_) => 0,
+    };
+
+    let namespace = match safely_get_string(&memory_view, namespace_buf, namespace_buf_len) {
+        Ok(s) => s,
+        Err(e) => {
+            error!(
+                "{}: Namespace error in storage_get_shared: {:?}",
+                env_data.module.name, e
+            );
+            return FunctionErrors::ParametersNotUtf8 as i32;
+        }
+    };
+
+    let key = match safely_get_string(&memory_view, key_buf, key_buf_len) {
+        Ok(s) => s,
+        Err(e) => {
+            error!(
+                "{}: Key error in storage_get_shared: {:?}",
+                env_data.module.name, e
+            );
+            return FunctionErrors::ParametersNotUtf8 as i32;
+        }
+    };
+
+    // Check if the rule can read from the shared DB.
+    // This is the case if the rule is in either the "r" or "rw" section of the config.
+    let allowed = match &storage.shared_dbs {
+        None => false,
+        Some(dbs) => match dbs.get(&namespace) {
+            None => false,
+            Some(db) => {
+                db.config
+                    .r
+                    .as_ref()
+                    .unwrap_or(&Vec::new())
+                    .contains(&env_data.module.name)
+                    || db
+                        .config
+                        .rw
+                        .as_ref()
+                        .unwrap_or(&Vec::new())
+                        .contains(&env_data.module.name)
+            }
+        },
+    };
+
+    if !allowed {
+        return FunctionErrors::ApiNotConfigured as i32; // TODO better error?
     }
+
+    get_common(
+        env_data,
+        storage,
+        &namespace,
+        &key,
+        memory_view,
+        data_buffer,
+        data_buffer_len,
+    )
 }
 
 /// Fetch all the keys from the storage system and filter for a prefix
@@ -313,6 +566,89 @@ pub fn list_keys(
     }
 }
 
+/// Code which is common to `delete` and `delete_shared`
+pub fn delete_common(
+    env_data: &Env,
+    storage: &Arc<Storage>,
+    namespace: String,
+    key: String,
+    memory_view: MemoryView,
+    data_buffer: WasmPtr<u8>,
+    data_buffer_len: u32,
+    storage_limit: LimitValue,
+    storage_counter: &Arc<RwLock<u64>>,
+) -> i32 {
+    let deletion_result = match data_buffer_len {
+        // This is a call just to get the size of the buffer, so we do storage.get and don't mess with storage counters
+        0 => env_data
+            .api
+            .clone()
+            .runtime
+            .block_on(async move { storage.get(&namespace, &key).await }),
+        // This is a call to delete the value, so we will do storage.delete, but first we need to check the storage limit
+        _ => match storage_limit {
+            LimitValue::Unlimited => {
+                // The storage is unlimited, so we don't update any counters and just proceed with the operation
+                env_data
+                    .api
+                    .clone()
+                    .runtime
+                    .block_on(async move { storage.delete(&namespace, &key).await })
+            }
+            LimitValue::Limited(_) => {
+                // for the "async move"
+                let storage_key = key.clone();
+
+                // The storage is limited, so we need to update counters (with locks)
+
+                // Get a lock on the storage counter.
+                // This ensures no race conditions if multiple instances of the same module are running in parallel.
+                // The guard will go out of scope at the end of this block, thus releasing the lock.  After this block, we won't touch the counter again.
+                let mut storage_current = match storage_counter.write() {
+                    Ok(g) => g,
+                    Err(e) => {
+                        error!("Critical error getting a lock on used storage: {:?}", e);
+                        return FunctionErrors::InternalApiError as i32;
+                    }
+                };
+
+                let result = env_data
+                    .api
+                    .clone()
+                    .runtime
+                    .block_on(async move { storage.delete(&namespace, &storage_key).await });
+                // If the deletion went well, update counter for used storage.
+                // If the deletion failed for some reason, we don't update the counter and release the lock: no harm done.
+                if let Ok(Some(ref data)) = result {
+                    let key_len = key.as_bytes().len() as u64;
+                    *storage_current = *storage_current - key_len - data.len() as u64;
+                }
+                result
+            }
+        },
+    };
+
+    // Process the deletion result and return info to the caller
+    match deletion_result {
+        Ok(data) => match data {
+            Some(data) => {
+                match safely_write_data_back(&memory_view, &data, data_buffer, data_buffer_len) {
+                    Ok(x) => x,
+                    Err(e) => {
+                        error!(
+                            "{}: Data write error in storage_delete: {:?}",
+                            env_data.module.name, e
+                        );
+                        e as i32
+                    }
+                }
+            }
+            None => 0,
+        },
+        Err(_) => 0,
+    }
+}
+
 /// Delete data from the storage system if one is configured
 pub fn delete(
     env: FunctionEnvMut<Env>,
@@ -351,71 +687,113 @@ pub fn delete(
             return FunctionErrors::ParametersNotUtf8 as i32;
         }
     };
-    let key_len = key.as_bytes().len();
 
-    let deletion_result = match data_buffer_len {
-        // This is a call just to get the size of the buffer, so we do storage.get and don't mess with storage counters
-        0 => env_data
-            .api
-            .clone()
-            .runtime
-            .block_on(async move { storage.get(&env_data.module.name, &key).await }),
-        // This is a call to delete the value, so we will do storage.delete, but first we need to check the storage limit
-        _ => match env_data.module.storage_limit {
-            LimitValue::Unlimited => {
-                // The module has unlimited storage, so we don't update any counters and just proceed with the operation
-                env_data
-                    .api
-                    .clone()
-                    .runtime
-                    .block_on(async move { storage.delete(&env_data.module.name, &key).await })
-            }
-            LimitValue::Limited(_) => {
-                // The module has limited storage, so we need to update counters (with locks)
+    delete_common(
+        env_data,
+        storage,
+        env_data.module.name.clone(),
+        key,
+        memory_view,
+        data_buffer,
+        data_buffer_len,
+        env_data.module.storage_limit.clone(),
+        &env_data.module.storage_current,
+    )
+}
 
-                // Get a lock on the storage counter for the module that is processing this message.
-                // This ensures no race conditions if multiple instances of the same module are running in parallel.
-                // The guard will go out of scope at the end of this block, thus releasing the lock.  After this block, we won't touch the counter again.
-                let mut storage_current = match env_data.module.storage_current.write() {
-                    Ok(g) => g,
-                    Err(e) => {
-                        error!("Critical error getting a lock on used storage: {:?}", e);
-                        return FunctionErrors::InternalApiError as i32;
-                    }
-                };
+/// Delete data from a shared namespace in the storage system, if one is configured
+pub fn delete_shared(
+    env: FunctionEnvMut<Env>,
+    namespace_buf: WasmPtr<u8>,
+    namespace_buf_len: u32,
+    key_buf: WasmPtr<u8>,
+    key_buf_len: u32,
+    data_buffer: WasmPtr<u8>,
+    data_buffer_len: u32,
+) -> i32 {
+    let store = env.as_store_ref();
+    let env_data = env.data();
 
-                let result = env_data
-                    .api
-                    .clone()
-                    .runtime
-                    .block_on(async move { storage.delete(&env_data.module.name, &key).await });
-                // If the deletion went well, update counter for used storage.
-                // If the deletion failed for some reason, we don't update the counter and release the lock: no harm done.
-                if let Ok(Some(ref data)) = result {
-                    *storage_current = *storage_current - key_len as u64 - data.len() as u64;
-                }
-                result
-            }
+    let storage = if let Some(storage) = &env_data.storage {
+        storage
+    } else {
+        return FunctionErrors::ApiNotConfigured as i32;
+    };
+
+    let memory_view = match get_memory(&env, &store) {
+        Ok(memory_view) => memory_view,
+        Err(e) => {
+            error!(
+                "{}: Memory error in storage_delete: {:?}",
+                env_data.module.name, e
+            );
+            return FunctionErrors::CouldNotGetAdequateMemory as i32;
+        }
+    };
+
+    let namespace = match safely_get_string(&memory_view, namespace_buf, namespace_buf_len) {
+        Ok(s) => s,
+        Err(e) => {
+            error!(
+                "{}: Namespace error in storage_insert_shared: {:?}",
+                env_data.module.name, e
+            );
+            return FunctionErrors::ParametersNotUtf8 as i32;
+        }
+    };
+
+    let key = match safely_get_string(&memory_view, key_buf, key_buf_len) {
+        Ok(s) => s,
+        Err(e) => {
+            error!(
+                "{}: Key error in storage_delete: {:?}",
+                env_data.module.name, e
+            );
+            return FunctionErrors::ParametersNotUtf8 as i32;
+        }
+    };
+
+    // Check if the rule can delete from the shared DB.
+    // This is the case if the rule is in the "rw" section of the config.
+    let allowed = match &storage.shared_dbs {
+        None => false,
+        Some(dbs) => match dbs.get(&namespace) {
+            None => false,
+            Some(db) => db
+                .config
+                .rw
+                .as_ref()
+                .unwrap_or(&Vec::new())
+                .contains(&env_data.module.name),
         },
     };
 
-    // Process the deletion result and return info to the caller
-    match deletion_result {
-        Ok(data) => match data {
-            Some(data) => {
-                match safely_write_data_back(&memory_view, &data, data_buffer, data_buffer_len) {
-                    Ok(x) => x,
-                    Err(e) => {
-                        error!(
-                            "{}: Data write error in storage_delete: {:?}",
-                            env_data.module.name, e
-                        );
-                        e as i32
-                    }
-                }
-            }
-            None => 0,
-        },
-        Err(_) => 0,
+    if !allowed {
+        return FunctionErrors::ApiNotConfigured as i32; // TODO better error?
     }
+
+    // Get storage limit and counter for the shared DB
+    let (storage_limit, storage_current) = match &storage.shared_dbs {
+        None => {
+            return FunctionErrors::ApiNotConfigured as i32;
+        }
+        Some(shared_dbs) => match shared_dbs.get(&namespace) {
+            None => {
+                return FunctionErrors::ApiNotConfigured as i32;
+            }
+            Some(db) => (db.config.size_limit.clone(), db.used_storage.clone()),
+        },
+    };
+
+    delete_common(
+        env_data,
+        storage,
+        namespace,
+        key,
+        memory_view,
+        data_buffer,
+        data_buffer_len,
+        storage_limit,
+        &storage_current,
+    )
 }

--- a/runtime/plaid/src/storage/mod.rs
+++ b/runtime/plaid/src/storage/mod.rs
@@ -49,7 +49,7 @@ pub struct Storage {
 }
 
 /// Errors encountered while trying to use Plaid's persistent storage.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum StorageError {
     NoStorageConfigured,
     CouldNotAccessStorage(String),

--- a/runtime/plaid/src/storage/mod.rs
+++ b/runtime/plaid/src/storage/mod.rs
@@ -120,9 +120,9 @@ impl Storage {
             _ => return Err(StorageError::NoStorageConfigured),
         };
 
-        let shared_dbs = match config.shared_dbs {
-            None => None,
-            Some(shared_dbs) => Some(
+        let shared_dbs = config
+            .shared_dbs
+            .map(async |shared_dbs| {
                 join_all(shared_dbs.into_iter().map(async |(db_name, db_config)| {
                     if db_name.to_string().ends_with(".wasm") {
                         return Err(StorageError::SharedDbError(
@@ -145,9 +145,13 @@ impl Storage {
                 }))
                 .await
                 .into_iter()
-                .collect::<Result<HashMap<_, _>, _>>()?,
-            ),
-        };
+                .collect::<Result<HashMap<_, _>, _>>()
+            })
+            .ok_or(StorageError::SharedDbError(
+                "Error while configuring shared storage".to_string(),
+            ))?
+            .await
+            .ok();
 
         Ok(Storage {
             database,

--- a/runtime/plaid/src/storage/mod.rs
+++ b/runtime/plaid/src/storage/mod.rs
@@ -1,18 +1,48 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
 use async_trait::async_trait;
 
 mod sled;
 
 use serde::Deserialize;
 
+use crate::loader::LimitValue;
+
+/// Config of a shared DB
+#[derive(Deserialize)]
+pub struct SharedDbConfig {
+    /// The max size of this shared DB
+    pub size_limit: LimitValue,
+    /// List of rules that can read from the DB
+    pub r: Option<Vec<String>>,
+    /// List of rules that can read from and write to the DB
+    pub rw: Option<Vec<String>>,
+}
+
+/// Represents a shared DB in the system
+pub struct SharedDb {
+    /// Configuration for the shared DB
+    pub config: SharedDbConfig,
+    /// Counter for the storage used by the shared DB
+    pub used_storage: Arc<RwLock<u64>>,
+}
+
 /// Plaid's storage configuration
 #[derive(Deserialize)]
 pub struct Config {
     pub sled: Option<sled::Config>,
+    /// Map `{ db_name --> db_config }`  
+    /// Note - `db_name` must not terminate with ".wasm" to avoid confusing it with a rule-specific namespace
+    pub shared_dbs: Option<HashMap<String, SharedDbConfig>>,
 }
 
 /// The storage that underpins Plaid
 pub struct Storage {
     database: Box<dyn StorageProvider + Send + Sync>,
+    pub shared_dbs: Option<HashMap<String, SharedDb>>,
 }
 
 /// Errors encountered while trying to use Plaid's persistent storage.
@@ -21,6 +51,7 @@ pub enum StorageError {
     NoStorageConfigured,
     CouldNotAccessStorage(String),
     Access(String),
+    SharedDbError(String),
 }
 
 impl std::fmt::Display for StorageError {
@@ -32,7 +63,10 @@ impl std::fmt::Display for StorageError {
             Self::CouldNotAccessStorage(ref e) => {
                 write!(f, "Access the storage datastore was not possible: {e}")
             }
-            StorageError::Access(ref e) => write!(f, "There was a failure accessing a key: {e}"),
+            Self::Access(ref e) => write!(f, "There was a failure accessing a key: {e}"),
+            Self::SharedDbError(ref e) => {
+                write!(f, "Error while attempting an operation on a shared DB: {e}")
+            }
         }
     }
 }
@@ -77,13 +111,44 @@ pub trait StorageProvider {
 }
 
 impl Storage {
-    pub fn new(config: Config) -> Result<Self, StorageError> {
+    pub async fn new(config: Config) -> Result<Self, StorageError> {
         let database = match config.sled {
             Some(sled) => Box::new(sled::Sled::new(sled)?),
             _ => return Err(StorageError::NoStorageConfigured),
         };
 
-        Ok(Storage { database })
+        let shared_dbs = match config.shared_dbs {
+            None => None,
+            Some(shared_dbs) => {
+                let mut dbs: HashMap<String, SharedDb> = HashMap::new();
+                for (db_name, db_config) in shared_dbs {
+                    if db_name.ends_with(".wasm") {
+                        return Err(StorageError::SharedDbError(
+                            "The name of a shared DB must not end with .wasm".to_string(),
+                        ));
+                    }
+                    let used_storage = match database.get_namespace_byte_size(&db_name).await {
+                        Ok(r) => r,
+                        Err(_) => {
+                            return Err(StorageError::SharedDbError(
+                                "Could not count used storage in shared DB".to_string(),
+                            ))
+                        }
+                    };
+                    let db = SharedDb {
+                        config: db_config,
+                        used_storage: Arc::new(RwLock::new(used_storage)),
+                    };
+                    dbs.insert(db_name, db);
+                }
+                Some(dbs)
+            }
+        };
+
+        Ok(Storage {
+            database,
+            shared_dbs,
+        })
     }
 
     pub async fn insert(


### PR DESCRIPTION
Sometimes it makes sense for rules to share a common database, so that data written by a rule can be read by another one. For example, this can remove the need for log-backs in case we need to pass information from rule A to rule B and the synchronization is already handled somewhere else.

This PR introduces support for shared DBs in a fully backward-compatible way. We add new APIs like `insert_shared`, `get_shared`, `delete_shared` that also take a namespace, which represents the shared DB.
Moreover, at the config level, we can specify which rules have read-only access and which rules can read/write.
Note: write-only is not currently supported because a write op inherently requires a read op to fetch existing data under the same key. This could change in the future.