### PR TITLE
Add runtime API to delete GH deploy keys

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -2716,7 +2716,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plaid"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "alkali",
  "async-trait",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/github/deploy_keys.rs
+++ b/runtime/plaid/src/apis/github/deploy_keys.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use plaid_stl::github::DeleteDeployKeyParams;
+
+use crate::{
+    apis::{github::GitHubError, ApiError},
+    loader::PlaidModule,
+};
+
+use super::Github;
+
+impl Github {
+    /// Remove a deploy key with a given ID from a given repository.
+    /// For more details, see https://docs.github.com/en/rest/deploy-keys/deploy-keys?apiVersion=2022-11-28#delete-a-deploy-key
+    pub async fn delete_deploy_key(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<u32, ApiError> {
+        let request: DeleteDeployKeyParams =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        let owner = self.validate_username(&request.owner)?;
+        let repo = self.validate_repository_name(&request.repo)?;
+        let key_id = request.key_id; // this is implicitly validated because it's a u64
+
+        info!("Removing deploy key with ID {key_id} from repo {owner}/{repo}");
+
+        let address = format!("/repos/{owner}/{repo}/keys/{key_id}");
+
+        match self
+            .make_generic_delete_request(address, None::<&String>, module)
+            .await
+        {
+            Ok((status, Ok(_))) => {
+                if status == 204 {
+                    Ok(0)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/runtime/plaid/src/apis/github/mod.rs
+++ b/runtime/plaid/src/apis/github/mod.rs
@@ -1,6 +1,7 @@
 mod actions;
 mod code;
 mod copilot;
+mod deploy_keys;
 mod environments;
 mod graphql;
 mod members;

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -305,6 +305,7 @@ impl_new_function!(
 );
 impl_new_function!(github, trigger_repo_dispatch, DISALLOW_IN_TEST_MODE);
 impl_new_function!(github, check_org_membership_of_user, ALLOW_IN_TEST_MODE);
+impl_new_function!(github, delete_deploy_key, DISALLOW_IN_TEST_MODE);
 
 impl_new_function_with_error_buffer!(github, make_graphql_query, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, make_advanced_graphql_query, ALLOW_IN_TEST_MODE);
@@ -583,6 +584,9 @@ pub fn to_api_function(
         }
         "github_check_org_membership_of_user" => {
             Function::new_typed_with_env(&mut store, &env, github_check_org_membership_of_user)
+        }
+        "github_delete_deploy_key" => {
+            Function::new_typed_with_env(&mut store, &env, github_delete_deploy_key)
         }
 
         // Slack Calls


### PR DESCRIPTION
Add runtime API to delete GH deploy keys. The API requires the caller to specify the repo owner, the repo name, and the deploy key's ID.