### PR TITLE
Support AWS DynamoDB for Plaid DB

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -31,7 +31,7 @@ jobs:
           name: secrets_manager
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         with:
           files: |
             config_check

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/modules/tests/test_db/harness/harness.sh
+++ b/modules/tests/test_db/harness/harness.sh
@@ -16,28 +16,50 @@ RH_PID=$!
 
 sleep 2
 # Call the webhook
-curl -d "get:some_key" http://$PLAID_LOCATION/webhook/$URL
-curl -d "insert:my_key:first_value" http://$PLAID_LOCATION/webhook/$URL
-curl -d "get:some_key" http://$PLAID_LOCATION/webhook/$URL
-curl -d "get:my_key" http://$PLAID_LOCATION/webhook/$URL
-curl -d "insert:my_key:second_value" http://$PLAID_LOCATION/webhook/$URL
-curl -d "get:some_key" http://$PLAID_LOCATION/webhook/$URL
-curl -d "get:my_key" http://$PLAID_LOCATION/webhook/$URL
-curl -d "delete:my_key" http://$PLAID_LOCATION/webhook/$URL
-curl -d "get:my_key" http://$PLAID_LOCATION/webhook/$URL
-curl -d "delete:another_key" http://$PLAID_LOCATION/webhook/$URL
-curl -d "get:another_key" http://$PLAID_LOCATION/webhook/$URL
+curl -d "get:some_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "insert:my_key:first_value" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "get:some_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "get:my_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "insert:my_key:second_value" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "get:some_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "get:my_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "delete:my_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "get:my_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "delete:another_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "get:another_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
 # At this point the DB is empty
-curl -d "insert:my_key:first_value" http://$PLAID_LOCATION/webhook/$URL
-curl -d "insert:a_key:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" http://$PLAID_LOCATION/webhook/$URL # too many bytes for the configured storage limit
-curl -d "get:a_key" http://$PLAID_LOCATION/webhook/$URL # Empty because insertion failed
-curl -d "insert:a_key:a" http://$PLAID_LOCATION/webhook/$URL # this is within the limit, so it's fine
-curl -d "get:a_key" http://$PLAID_LOCATION/webhook/$URL # a
-curl -d "delete:my_key" http://$PLAID_LOCATION/webhook/$URL
-curl -d "delete:a_key" http://$PLAID_LOCATION/webhook/$URL
+curl -d "insert:my_key:first_value" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+# too many bytes for the configured storage limit
+curl -d "insert:a_key:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+# empty because insertion failed
+curl -d "get:a_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+# this is within the limit, so it's fine
+curl -d "insert:a_key:a" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+# returns "a"
+curl -d "get:a_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "delete:my_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "delete:a_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
 # now the DB is empty, so we can insert the long key/value pair
-curl -d "insert:a_key:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" http://$PLAID_LOCATION/webhook/$URL
-curl -d "get:a_key" http://$PLAID_LOCATION/webhook/$URL
+curl -d "insert:a_key:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "get:a_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "delete:a_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+# the DB is empty
+curl -d "insert:my_key:a" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "insert:my_new_key:b" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "insert:a_key:c" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "list_keys:all:my_key|my_new_key|a_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "list_keys:prefix:my:my_key|my_new_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "delete:my_key" http://$PLAID_LOCATION/webhook/$URL
+curl -d "delete:my_new_key" http://$PLAID_LOCATION/webhook/$URL
+curl -d "delete:a_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+# the DB is empty
+curl -d "insert:some_key:a" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "insert_check_returned_data:some_key:a" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "delete:some_key" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+# the DB is empty
+curl -d "insert:some_key:a" http://$PLAID_LOCATION/webhook/$URL; sleep 0.5
+curl -d "delete_check_returned_data:some_key:a" http://$PLAID_LOCATION/webhook/$URL
+# the DB is empty
 
 sleep 2
 
@@ -54,8 +76,12 @@ kill $RH_PID 2>&1 > /dev/null
 # Empty
 # a
 # aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+# OK
+# OK
+# OK
+# OK
 
-echo -e "Empty\nEmpty\nfirst_value\nEmpty\nsecond_value\nEmpty\nEmpty\nEmpty\na\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" > expected.txt
+echo -e "Empty\nEmpty\nfirst_value\nEmpty\nsecond_value\nEmpty\nEmpty\nEmpty\na\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nOK\nOK\nOK\nOK" > expected.txt
 diff expected.txt $FILE
 RESULT=$?
 

--- a/modules/tests/test_db/src/lib.rs
+++ b/modules/tests/test_db/src/lib.rs
@@ -29,6 +29,48 @@ fn handle_post(log: &str) -> Result<(), i32> {
         "delete" => {
             plaid::storage::delete(parts[1]).unwrap();
         }
+        "list_keys" => match parts[1] {
+            "all" => {
+                // list_keys:all:key1|key2|key3
+                let keys = plaid::storage::list_keys(None::<String>).unwrap();
+                if are_vectors_equal(parts[2], keys) {
+                    make_named_request("test-response", "OK", HashMap::new()).unwrap();
+                } else {
+                    panic!();
+                }
+            }
+            "prefix" => {
+                // list_keys:prefix:the_prefix:key1|key2|key3
+                let keys = plaid::storage::list_keys(Some(parts[2])).unwrap();
+                if are_vectors_equal(parts[3], keys) {
+                    make_named_request("test-response", "OK", HashMap::new()).unwrap();
+                } else {
+                    panic!();
+                }
+            }
+            _ => panic!(),
+        },
+        "insert_check_returned_data" => {
+            let key = parts[1];
+            // The data we are overwriting
+            let initial_data = parts[2].as_bytes();
+            let new_data = vec![42u8];
+            let res = plaid::storage::insert(key, &new_data).unwrap();
+            if res != initial_data {
+                panic!();
+            }
+            make_named_request("test-response", "OK", HashMap::new()).unwrap();
+        }
+        "delete_check_returned_data" => {
+            let key = parts[1];
+            // The data we are deleting
+            let initial_data = parts[2].as_bytes();
+            let res = plaid::storage::delete(key).unwrap();
+            if res != initial_data {
+                panic!();
+            }
+            make_named_request("test-response", "OK", HashMap::new()).unwrap();
+        }
         _ => panic!(),
     }
     Ok(())
@@ -39,4 +81,19 @@ fn main(log: String, source: LogSource) -> Result<(), i32> {
         LogSource::WebhookPost(_) => handle_post(&log),
         _ => panic!(),
     }
+}
+
+/// Compare two vectors, one of which is given encoded in pipe-delimited format.
+/// The elements are not necessarily ordered the same way.
+///
+/// `assert!(are_vectors_equal("second|first|third", vec!["first".to_string(), "second".to_string(), "third".to_string()]))`
+fn are_vectors_equal(pipe_delimited: &str, v: Vec<String>) -> bool {
+    let mut v1 = pipe_delimited
+        .split("|")
+        .map(|v| v.to_string())
+        .collect::<Vec<String>>();
+    v1.sort();
+    let mut v2 = v.clone();
+    v2.sort();
+    v1 == v2
 }

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -180,6 +180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,7 +214,7 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -228,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
+checksum = "4471bef4c22a06d2c7a1b6492493d3fdf24a805323109d6874f9c94d5906ac14"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -239,15 +245,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-runtime"
-version = "1.5.5"
+name = "aws-lc-rs"
+version = "1.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76dd04d39cc12844c0994f2c9c5a6f5184c22e9188ec1ff723de41910a21dcad"
+checksum = "dabb68eb3a7aa08b46fddfd59a3d55c978243557a90ab804769f7e20e67d2b01"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77926887776171ced7d662120a75998e444d3750c951abfe07f90da130514b1f"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aff45ffe35196e593ea3b9dd65b320e51e2dda95aff4390bc459e461d09c6ad"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -264,6 +293,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-dynamodb"
+version = "1.69.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f454f50a050aaa3f3d200a3ac072e48c18c4bb5356c38be7eee1da1439a43"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.0",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-kms"
 version = "1.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,7 +324,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -294,7 +346,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -317,7 +369,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -339,7 +391,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -361,7 +413,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -377,12 +429,12 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.9"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bfe75fad52793ce6dec0dc3d4b1f388f038b5eb866c8d4d7f3a8e21b5ea5051"
+checksum = "69d03c3c05ff80d54ff860fe38c726f6f494c639ae975203a101335f223386db"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.0",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -400,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa59d1327d8b5053c54bf2eaae63bf629ba9e904434d0835a28ed3c0ed0a614e"
+checksum = "1e190749ea56f8c42bf15dd76c65e14f8f765233e6df9b0506d9d934ebef867c"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -430,10 +482,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-json"
-version = "0.61.2"
+name = "aws-smithy-http"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "623a51127f24c30776c8b374295f2df78d92517386f77ba30773f15a30ce1422"
+checksum = "c5949124d11e538ca21142d1fba61ab0a2a2c1bc3ed323cdb3e4b878bfb83166"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.2.0",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0497ef5d53065b7cd6a35e9c1654bd1fefeae5c52900d91d1b188b0af0f29324"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.4.8",
+ "http 0.2.12",
+ "http 1.2.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.6.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.5",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.23",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
+ "tokio",
+ "tower 0.5.2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92144e45819cae7dc62af23eac5a038a58aa544432d2102609654376a900bd07"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -450,36 +551,33 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.8"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d526a12d9ed61fadefda24abe2e682892ba288c2018bcb38b1b4c111d13f6d92"
+checksum = "f6328865e36c6fd970094ead6b05efd047d3a80ec5fc3be5e743910da9f2ebf8"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.0",
+ "aws-smithy-http-client",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "fastrand",
- "h2",
  "http 0.2.12",
+ "http 1.2.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
- "httparse",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls 0.21.12",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.7.3"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92165296a47a812b267b4f41032ff8069ab7ff783696d217f0994a0d7ab585cd"
+checksum = "3da37cf5d57011cb1753456518ec76e31691f1f474b73934a284eb2a1c76510f"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -494,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.13"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b8a53819e42f10d0821f56da995e1470b199686a1809168db6ca485665f042"
+checksum = "836155caafba616c0ff9b07944324785de2ab016141c3550bd1c07882f8cee8f"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -529,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbd0a668309ec1f66c0f6bda4840dd6d4796ae26d699ebc266d7cc95c6d040f"
+checksum = "3873f8deed8927ce8d04487630dc9ff73193bab64742a61d050e57a68dec4125"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -601,6 +699,29 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.8.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.98",
+ "which",
+]
 
 [[package]]
 name = "binstring"
@@ -708,7 +829,18 @@ version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -739,6 +871,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +905,15 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "coarsetime"
@@ -826,6 +978,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1180,6 +1342,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,6 +1553,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,6 +1704,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,6 +1732,25 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
+ "indexmap 2.7.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.2.0",
  "indexmap 2.7.1",
  "slab",
  "tokio",
@@ -1677,6 +1876,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,7 +1968,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1783,6 +1991,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.8",
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
@@ -1839,6 +2048,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "rustls 0.23.23",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
@@ -2092,10 +2302,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2172,6 +2400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2205,6 +2439,16 @@ dependencies = [
  "core2",
  "hashbrown 0.14.5",
  "rle-decode-fast",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2721,6 +2965,7 @@ dependencies = [
  "alkali",
  "async-trait",
  "aws-config",
+ "aws-sdk-dynamodb",
  "aws-sdk-kms",
  "aws-sdk-secretsmanager",
  "base64 0.13.1",
@@ -2785,6 +3030,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2875,7 +3130,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls 0.23.23",
  "socket2",
  "thiserror 2.0.11",
@@ -2893,7 +3148,7 @@ dependencies = [
  "getrandom",
  "rand",
  "ring 0.17.9",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls 0.23.23",
  "rustls-pki-types",
  "slab",
@@ -3242,6 +3497,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -3309,6 +3570,7 @@ version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring 0.17.9",
  "rustls-pki-types",
@@ -3326,7 +3588,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -3339,7 +3601,19 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -3385,6 +3659,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.9",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -3469,7 +3744,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.8.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.8.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4632,6 +4920,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -2960,7 +2960,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plaid"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "alkali",
  "async-trait",
@@ -3007,7 +3007,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -12,6 +12,9 @@ aws = ["aws-sdk-kms", "aws-config"]
 [dependencies]
 alkali = "0.3.0"
 async-trait = "0.1.56"
+aws-config = { version = "1.5.5", optional = true }
+aws-sdk-dynamodb = "1.69.0"
+aws-sdk-kms = { version = "1.41.0", optional = true }
 aws-sdk-secretsmanager = "1.57.0"
 base64 = "0.13"
 clap = { version = "4", default-features = false, features = [
@@ -22,8 +25,10 @@ clap = { version = "4", default-features = false, features = [
 crossbeam-channel = "0.5"
 env_logger = "0.8"
 flate2 = "1.0"
+futures-util = "0.3.30"
 hex = "0.4.3"
 http = "1"
+jsonwebtoken = { version = "9.2" }
 jwt-simple = { version = "0.12.10", default-features = false, features = [
     "pure-rust",
 ] }
@@ -58,10 +63,6 @@ urlencoding = "2.1.3"
 warp = { version = "0.3", features = ["tls"] }
 wasmer = { version = "4", default-features = false, features = ["cranelift"] }
 wasmer-middlewares = "4"
-jsonwebtoken = { version = "9.2" }
-futures-util = "0.3.30"
-aws-sdk-kms = { version = "1.41.0", optional = true }
-aws-config = { version = "1.5.5", optional = true }
 
 [[example]]
 name = "github-tailer"

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "plaid"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 default = ["aws"]
-aws = ["aws-sdk-kms", "aws-config"]
+aws = ["aws-sdk-kms", "aws-sdk-dynamodb"]
 
 [dependencies]
 alkali = "0.3.0"
 async-trait = "0.1.56"
-aws-config = { version = "1.5.5", optional = true }
-aws-sdk-dynamodb = "1.69.0"
+aws-config = "1.5.5"
+aws-sdk-dynamodb = { version = "1.69.0", optional = true }
 aws-sdk-kms = { version = "1.41.0", optional = true }
 aws-sdk-secretsmanager = "1.57.0"
 base64 = "0.13"

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -13,7 +13,7 @@ r = ["test_shared_db_rule_1.wasm"]
 rw = ["test_shared_db_rule_2.wasm"]
 
 [storage.db]
-path = "/tmp/sled"
+sled_path = "/tmp/sled"
 
 # [storage.db]
 # table_name = "test-plaid"

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -12,8 +12,17 @@ size_limit = { Limited = 50 }
 r = ["test_shared_db_rule_1.wasm"]
 rw = ["test_shared_db_rule_2.wasm"]
 
-[storage.sled]
+[storage.db]
 path = "/tmp/sled"
+
+# [storage.db]
+# table_name = "test-plaid"
+
+# [storage.db.authentication]
+# access_key_id = "value here"
+# secret_access_key = "value here"
+# session_token = "value here"
+# region = "value here"
 
 # Configure the logging system. In this case we only configure the
 # stdout logger

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (els, _logging_handler) = Logger::start(config.logging);
     info!("Logging subsystem started");
 
-    // Create the storage system is one is configured
+    // Create the storage system if one is configured
     let storage = match config.storage {
         Some(config) => Some(Arc::new(Storage::new(config).await?)),
         None => None,

--- a/runtime/plaid/src/executor/mod.rs
+++ b/runtime/plaid/src/executor/mod.rs
@@ -173,7 +173,7 @@ impl std::fmt::Display for ModuleExecutionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ModuleExecutionError::ComputationExhausted(limit) => {
-                write!(f, "Computation Exhaused. Limit: [{limit}]")
+                write!(f, "Computation Exhausted. Limit: [{limit}]")
             }
             ModuleExecutionError::ModuleError(context) => {
                 write!(

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -208,6 +208,7 @@ macro_rules! impl_new_function_with_error_buffer {
 /// - `FunctionErrors::InternalApiError`: For internal API-related errors.
 /// - `FunctionErrors::ApiNotConfigured`: If the API is not configured.
 /// - `FunctionErrors::ReturnBufferTooSmall`: If the provided return buffer is too small to hold the result.
+#[allow(unused_macros)] // not to have a warning when compiling without the `aws` feature
 macro_rules! impl_new_sub_module_function_with_error_buffer {
     ($api:ident, $sub_module:ident, $function_name:ident, $allow_in_test_mode:expr) => {
         paste::item! {

--- a/runtime/plaid/src/functions/storage.rs
+++ b/runtime/plaid/src/functions/storage.rs
@@ -106,7 +106,7 @@ fn insert_common(
 
             // If we would go above the limited storage, reject the insert
             if would_be_used_storage > storage_limit {
-                error!("{}: Could not insert key/value with key {key} as that would bring us above the configured storage limit.", env_data.module.name);
+                error!("{}: Could not insert key/value with key [{key}] as that would bring us above the configured storage limit.", env_data.module.name);
                 let _ = env_data.external_logging_system.log_module_error(
                     env_data.module.name.clone(),
                     "Could not insert key/value as that would bring us above the configured storage limit.".to_string(),

--- a/runtime/plaid/src/lib.rs
+++ b/runtime/plaid/src/lib.rs
@@ -1,6 +1,7 @@
+#[cfg(feature = "aws")]
 use aws_config::{BehaviorVersion, Region, SdkConfig};
+#[cfg(feature = "aws")]
 use aws_sdk_kms::config::Credentials;
-use serde::Deserialize;
 
 #[macro_use]
 extern crate log;
@@ -16,7 +17,8 @@ pub mod performance;
 pub mod storage;
 
 /// Defines methods to authenticate to AWS with
-#[derive(Deserialize)]
+#[cfg(feature = "aws")]
+#[derive(serde::Deserialize)]
 #[serde(untagged)]
 pub enum AwsAuthentication {
     ApiKey {
@@ -29,6 +31,7 @@ pub enum AwsAuthentication {
 }
 
 /// Get an `SdkConfig` to be used when interacting with AWS services
+#[cfg(feature = "aws")]
 pub async fn get_aws_sdk_config(authentication: AwsAuthentication) -> SdkConfig {
     match authentication {
         AwsAuthentication::ApiKey {

--- a/runtime/plaid/src/lib.rs
+++ b/runtime/plaid/src/lib.rs
@@ -1,3 +1,7 @@
+use aws_config::{BehaviorVersion, Region, SdkConfig};
+use aws_sdk_kms::config::Credentials;
+use serde::Deserialize;
+
 #[macro_use]
 extern crate log;
 
@@ -10,3 +14,47 @@ pub mod loader;
 pub mod logging;
 pub mod performance;
 pub mod storage;
+
+/// Defines methods to authenticate to AWS with
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub enum AwsAuthentication {
+    ApiKey {
+        access_key_id: String,
+        secret_access_key: String,
+        session_token: Option<String>,
+        region: String,
+    },
+    Iam {},
+}
+
+/// Get an `SdkConfig` to be used when interacting with AWS services
+pub async fn get_aws_sdk_config(authentication: AwsAuthentication) -> SdkConfig {
+    match authentication {
+        AwsAuthentication::ApiKey {
+            access_key_id,
+            secret_access_key,
+            session_token,
+            region,
+        } => {
+            info!("Using API keys for AWS authentication");
+            let credentials = Credentials::new(
+                access_key_id,
+                secret_access_key,
+                session_token,
+                None,
+                "Plaid",
+            );
+
+            aws_config::defaults(BehaviorVersion::latest())
+                .region(Region::new(region.clone()))
+                .credentials_provider(credentials)
+                .load()
+                .await
+        }
+        AwsAuthentication::Iam {} => {
+            info!("Using IAM role assigned to environment for AWS authentication");
+            aws_config::load_defaults(BehaviorVersion::latest()).await
+        }
+    }
+}

--- a/runtime/plaid/src/storage/dynamodb/mod.rs
+++ b/runtime/plaid/src/storage/dynamodb/mod.rs
@@ -1,0 +1,297 @@
+//! This module provides a way for Plaid to use AWS DynamoDB as a DB for persistent storage.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+
+use aws_sdk_dynamodb::{types::AttributeValue, Client};
+use serde::Deserialize;
+
+use crate::{get_aws_sdk_config, AwsAuthentication};
+
+use super::{StorageError, StorageProvider};
+
+const NAMESPACE: &str = "namespace";
+const KEY: &str = "key";
+const VALUE: &str = "value";
+
+/// Configuration for DynamoDB
+#[derive(Deserialize)]
+pub struct Config {
+    /// How to authenticate to AWS
+    authentication: AwsAuthentication,
+    /// The name of DynamoDB table used for Plaid's DB
+    table_name: String,
+}
+
+/// A wrapper for DynamoDB
+pub struct DynamoDb {
+    client: Client,
+    table_name: String,
+}
+
+impl DynamoDb {
+    pub async fn new(config: Config) -> Self {
+        let sdk_config = get_aws_sdk_config(config.authentication).await;
+        let client = aws_sdk_dynamodb::Client::new(&sdk_config);
+
+        Self {
+            client,
+            table_name: config.table_name,
+        }
+    }
+}
+
+#[async_trait]
+impl StorageProvider for DynamoDb {
+    async fn insert(
+        &self,
+        namespace: String,
+        key: String,
+        value: Vec<u8>,
+    ) -> Result<Option<Vec<u8>>, StorageError> {
+        let response = self
+            .client
+            .put_item()
+            .table_name(&self.table_name)
+            .item(NAMESPACE, AttributeValue::S(namespace))
+            .item(KEY, AttributeValue::S(key))
+            .item(VALUE, AttributeValue::B(value.into()))
+            .return_values(aws_sdk_dynamodb::types::ReturnValue::AllOld)
+            .send()
+            .await
+            .map_err(|e| StorageError::Access(format!("Could not insert to storage: {e}")))?;
+        // Return the previous entry, if any
+        Ok(response
+            .attributes
+            .and_then(|attr| Some(attr.get(VALUE)?.as_b().ok()?.clone()))
+            .and_then(|v| Some(v.into_inner())))
+    }
+
+    async fn get(&self, namespace: &str, key: &str) -> Result<Option<Vec<u8>>, StorageError> {
+        let response = self
+            .client
+            .get_item()
+            .consistent_read(true)
+            .table_name(&self.table_name)
+            .key(NAMESPACE, AttributeValue::S(namespace.to_string()))
+            .key(KEY, AttributeValue::S(key.to_string()))
+            .send()
+            .await
+            .map_err(|e| StorageError::Access(format!("Could not get from storage: {e}")))?;
+        Ok(response
+            .item
+            .and_then(|attr| Some(attr.get(VALUE)?.as_b().ok()?.clone()))
+            .and_then(|v| Some(v.into_inner())))
+    }
+
+    async fn delete(&self, namespace: &str, key: &str) -> Result<Option<Vec<u8>>, StorageError> {
+        let response = self
+            .client
+            .delete_item()
+            .table_name(&self.table_name)
+            .key(NAMESPACE, AttributeValue::S(namespace.to_string()))
+            .key(KEY, AttributeValue::S(key.to_string()))
+            .return_values(aws_sdk_dynamodb::types::ReturnValue::AllOld)
+            .send()
+            .await
+            .map_err(|e| StorageError::Access(format!("Could not delete from storage: {e}")))?;
+        Ok(response
+            .attributes
+            .and_then(|attr| Some(attr.get(VALUE)?.as_b().ok()?.clone()))
+            .and_then(|v| Some(v.into_inner())))
+    }
+
+    async fn list_keys(
+        &self,
+        namespace: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<String>, StorageError> {
+        let mut all_keys = vec![];
+
+        let items = dynamodb_query(&self.client, &self.table_name, namespace, prefix, KEY).await?;
+
+        // Add retrieved items to our growing list
+        for item in &items {
+            all_keys.push(
+                item.get(KEY)
+                    .ok_or(StorageError::Access(
+                        "Could not list storage contents".to_string(),
+                    ))?
+                    .as_s()
+                    .map_err(|_| {
+                        StorageError::Access("Could not list storage contents".to_string())
+                    })?
+                    .clone(),
+            );
+        }
+
+        Ok(all_keys)
+    }
+
+    async fn fetch_all(
+        &self,
+        namespace: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<(String, Vec<u8>)>, StorageError> {
+        let mut everything = vec![];
+
+        let items = dynamodb_query(
+            &self.client,
+            &self.table_name,
+            namespace,
+            prefix,
+            "key,value",
+        )
+        .await?;
+
+        // Add retrieved items to our growing list
+        for item in &items {
+            everything.push((
+                item.get(KEY)
+                    .ok_or(StorageError::Access(
+                        "Could not list storage contents".to_string(),
+                    ))?
+                    .as_s()
+                    .map_err(|_| {
+                        StorageError::Access("Could not list storage contents".to_string())
+                    })?
+                    .clone(),
+                item.get(VALUE)
+                    .ok_or(StorageError::Access(
+                        "Could not list storage contents".to_string(),
+                    ))?
+                    .as_b()
+                    .map_err(|_| {
+                        StorageError::Access("Could not list storage contents".to_string())
+                    })?
+                    .clone()
+                    .into_inner(),
+            ));
+        }
+
+        Ok(everything)
+    }
+
+    async fn get_namespace_byte_size(&self, namespace: &str) -> Result<u64, StorageError> {
+        let all = self.fetch_all(namespace, None).await?;
+        let mut counter = 0u64;
+        for item in all {
+            // Count bytes for keys and values
+            counter = counter + item.0.as_bytes().len() as u64 + item.1.len() as u64;
+        }
+        Ok(counter)
+    }
+}
+
+/// Perform a query on DynamoDB.
+///
+/// Args:  
+/// `client` - a DynamoDB Client  
+/// `table_name` - the name of the DynamoDB table  
+/// `namespace` - the namespace we want to query  
+/// `prefix` - [Optional] a prefix that keys must have in order to be returned by this query  
+/// `attributes_to_get` - A comma-separated list of attributes to get from DynamoDB
+async fn dynamodb_query(
+    client: &Client,
+    table_name: &str,
+    namespace: &str,
+    prefix: Option<&str>,
+    attributes_to_get: &str,
+) -> Result<Vec<HashMap<String, AttributeValue>>, StorageError> {
+    // This is necessary because the STL is converting a None prefix to an empty string,
+    // which would result in passing an empty string to DynamoDB, which then complains.
+    // So here we re-convert an empty string to a None prefix.
+    let prefix = match prefix {
+        Some(x) if !x.is_empty() => Some(x),
+        _ => None,
+    };
+
+    let mut output: Vec<HashMap<String, AttributeValue>> = vec![];
+
+    // For pagination
+    let mut last_evaluated_key: Option<HashMap<String, AttributeValue>> = None;
+
+    // Prepare the projection expression
+    let attributes: Vec<&str> = attributes_to_get.split(",").collect();
+    // Alias all attributes by prepending with a #, to address the case where the attribute name is a reserved DynamoDB keyword
+    let aliased: Vec<String> = attributes.iter().map(|v| format!("#{v}")).collect();
+    // Now that everything is aliased, we can have a "safe" projection expression
+    let projection_expression = aliased.join(",");
+
+    // Start filling in the mappings for names and attributes (to go back from aliased to real names)
+    let mut expression_attribute_names = vec![];
+    for (index, attribute) in attributes.iter().enumerate() {
+        expression_attribute_names.push((aliased[index].to_string(), attribute.to_string()));
+    }
+    expression_attribute_names.push(("#pk".to_string(), NAMESPACE.to_string()));
+
+    let mut expression_attribute_values = vec![];
+    expression_attribute_values.push((
+        ":pk_val".to_string(),
+        AttributeValue::S(namespace.to_string()),
+    ));
+
+    // Prepare the key condition expression, with the side-effect of adding items to the aliased->real mapping, if necessary
+    let key_condition_expression = match prefix {
+        None => "#pk = :pk_val",
+        Some(prefix) => {
+            expression_attribute_names.push(("#sk".to_string(), KEY.to_string()));
+            expression_attribute_values.push((
+                ":sk_prefix".to_string(),
+                AttributeValue::S(prefix.to_string()),
+            ));
+            "#pk = :pk_val AND begins_with(#sk, :sk_prefix)"
+        }
+    }
+    .to_string();
+
+    loop {
+        let mut request = client
+            .query()
+            .consistent_read(true)
+            .table_name(table_name)
+            .projection_expression(projection_expression.clone());
+
+        // Set in the request the key condition expression, expression attribute names and expression attribute values
+        // that we had prepared above
+        request = request
+            .set_key_condition_expression(Some(key_condition_expression.clone()))
+            .set_expression_attribute_names(Some(
+                expression_attribute_names.clone().into_iter().collect(),
+            ))
+            .set_expression_attribute_values(Some(
+                expression_attribute_values.clone().into_iter().collect(),
+            ));
+
+        // If we are continuing a previous query, start from where we had left off
+        if let Some(lek) = last_evaluated_key {
+            request = request.set_exclusive_start_key(Some(lek));
+        }
+
+        let response = request.send().await.map_err(|e| {
+            let raw_response = match e.raw_response() {
+                Some(resp) => format!("{:?}", resp),
+                None => "raw response not available".to_string(),
+            };
+            StorageError::Access(format!(
+                "Could not list storage contents: {e} {raw_response}"
+            ))
+        })?;
+
+        // Add retrieved items to our growing list
+        if let Some(items) = response.items {
+            output.extend(items);
+        }
+
+        // Set up for next iteration
+        last_evaluated_key = response.last_evaluated_key;
+
+        // Stop when there's no more data
+        if last_evaluated_key.is_none() {
+            break;
+        }
+    }
+
+    Ok(output)
+}

--- a/runtime/plaid/src/storage/sled/mod.rs
+++ b/runtime/plaid/src/storage/sled/mod.rs
@@ -145,7 +145,7 @@ impl StorageProvider for Sled {
         let mut counter = 0u64;
         for item in all {
             // Count bytes for keys and values
-            counter = counter + item.0.as_bytes().len() as u64 + item.1.len() as u64;
+            counter += item.0.as_bytes().len() as u64 + item.1.len() as u64;
         }
         Ok(counter)
     }

--- a/runtime/plaid/src/storage/sled/mod.rs
+++ b/runtime/plaid/src/storage/sled/mod.rs
@@ -11,7 +11,7 @@ use super::{StorageError, StorageProvider};
 /// Configuration for a Sled DB
 #[derive(Deserialize)]
 pub struct Config {
-    path: String,
+    sled_path: String,
 }
 
 /// A wrapper around a Sled DB object
@@ -21,7 +21,7 @@ pub struct Sled {
 
 impl Sled {
     pub fn new(config: Config) -> Result<Self, StorageError> {
-        let db: sled::Db = sled::open(&config.path)
+        let db: sled::Db = sled::open(&config.sled_path)
             .map_err(|e| StorageError::CouldNotAccessStorage(e.to_string()))?;
         Ok(Self { db })
     }

--- a/testing/integration.sh
+++ b/testing/integration.sh
@@ -10,6 +10,16 @@ if  uname | grep -q Darwin; then
   PATH="/opt/homebrew/opt/llvm/bin:$PATH"
 fi
 
+echo "Building Plaid Runtime Without Default Features"
+cd runtime
+cargo build --all --release --no-default-features
+if [ $? -ne 0 ]; then
+  echo "Failed to build Plaid without default features"
+  # Exit with an error
+  exit 1
+fi
+cd ..
+
 echo "Building Plaid Runtime"
 cd runtime
 cargo build --all --release


### PR DESCRIPTION
This PR adds support for AWS DynamoDB as Plaid's DB layer.

Some points to note:
* DynamoDB is very fast but still slower than a local DB on file. This is why we had to add `sleep ...` in the DB test, which would otherwise fail for ~unclear reasons. To be investigated more thoroughly, but this is likely due to network latency or consistency.~ reasons explained in the comment below.
* The mechanism to authenticate to AWS (either via API key or IAM role) has been refactored out of the KMS submodule, since it's generic enough to be reused. This does not prevent KMS and DynamoDB from using different authentications.
* We could consider gating DynamoDB support behind a feature with optional dependencies.
* ~There is a TODO in the code for further consideration. When fetching all the keys, we currently fetch the entire namespace (keys and values) and then discard the values. This works but is suboptimal.~ Fixed with some DynamoDB magic ✅ 

Open tasks:
- [x] Investigate performance (see point above about `sleep`)
- [x] Use constants instead of hardcoded strings for "namespace", "key", "value"
- [x] Write more tests
  - [x] Listing keys or key/value pairs _with prefix_
  - [x] Inserting on top of an existing value returns the old value
  - [x] Deleting an existing value returns the old value
- [x] Put DynamoDB behind an `aws` feature together with KMS
- [x] Add tests to verify everything compiles with and without `aws` feature

## Breaking changes
### Config

The format for the DB config becomes as follows:
```
[storage.db]
sled_path = "/tmp/sled"

# [storage.db]
# table_name = "test-plaid"

# [storage.db.authentication]
# access_key_id = "value here"
# secret_access_key = "value here"
# session_token = "value here"
# region = "value here"
```
where one sets either Sled (with the path) or DynamoDB (with table name and auth) as the DB layer.