### PR TITLE
Improve the API for search code on GH

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -2716,7 +2716,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plaid"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "alkali",
  "async-trait",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/github/mod.rs
+++ b/runtime/plaid-stl/src/github/mod.rs
@@ -1349,7 +1349,7 @@ pub fn configure_secret(
     }
 }
 
-/// Search for files with given filename in GitHub.
+/// Search for code in GitHub.
 /// If additional selection criteria are given, these are used to decide whether
 /// results are selected or discarded.
 ///

--- a/runtime/plaid-stl/src/github/mod.rs
+++ b/runtime/plaid-stl/src/github/mod.rs
@@ -1354,18 +1354,30 @@ pub fn configure_secret(
 /// results are selected or discarded.
 ///
 /// **Arguments:**
-/// - `filename`: The name of the files to search, e.g., "README.md"
+/// - `filename`: The name of the files to search, e.g., "README"
+/// - `extension`: The extension of the files to search, e.g., "yml"
+/// - `path`: The path under which files are searched, e.g., "src"
 /// - `search_criteria`: An optional `CodeSearchCriteria` object with additional search criteria
-pub fn search_for_file(
-    filename: impl Display,
+pub fn search_code(
+    filename: Option<impl Display>,
+    extension: Option<impl Display>,
+    path: Option<impl Display>,
     search_criteria: Option<&CodeSearchCriteria>,
 ) -> Result<Vec<FileSearchResultItem>, PlaidFunctionError> {
     extern "C" {
-        new_host_function_with_error_buffer!(github, search_for_file);
+        new_host_function_with_error_buffer!(github, search_code);
     }
 
     let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("filename", filename.to_string());
+    if let Some(filename) = filename {
+        params.insert("filename", filename.to_string());
+    }
+    if let Some(extension) = extension {
+        params.insert("extension", extension.to_string());
+    }
+    if let Some(path) = path {
+        params.insert("path", path.to_string());
+    }
 
     // If we are given selection criteria, then we divide them between
     //
@@ -1406,7 +1418,7 @@ pub fn search_for_file(
         let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
         let res = unsafe {
-            github_search_for_file(
+            github_search_code(
                 request.as_bytes().as_ptr(),
                 request.as_bytes().len(),
                 return_buffer.as_mut_ptr(),

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/github/code.rs
+++ b/runtime/plaid/src/apis/github/code.rs
@@ -9,7 +9,7 @@ use crate::{
 impl Github {
     /// Search for files with given name.
     /// See https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-code for more details
-    pub async fn search_for_file(
+    pub async fn search_code(
         &self,
         params: &str,
         module: Arc<PlaidModule>,
@@ -17,8 +17,31 @@ impl Github {
         let request: HashMap<&str, &str> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let filename =
-            self.validate_filename(request.get("filename").ok_or(ApiError::BadRequest)?)?;
+        /*
+        The request can contain the following parameters:
+        - filename
+        - extension
+        - path
+        - org
+        - repo
+        NOTE - All params are optional and we do not do any validation on whether the request as a whole makes sense.
+        We simply validate individual parameters if present.
+        */
+
+        let filename = match request.get("filename") {
+            None => String::new(),
+            Some(filename) => format!("filename:{}", self.validate_filename(filename)?),
+        };
+
+        let extension = match request.get("extension") {
+            None => String::new(),
+            Some(extension) => format!("extension:{}", self.validate_extension(extension)?),
+        };
+
+        let path = match request.get("path") {
+            None => String::new(),
+            Some(path) => format!("path:{}", self.validate_path(path)?),
+        };
 
         // See if we were told to search only in a specific organization or repository
         let org = match request.get("org") {
@@ -30,45 +53,37 @@ impl Github {
             Some(repo) => Some(self.validate_repository_name(repo)?),
         };
 
+        // Assemble org and repo depending on what we received.
+        // NOTE - If we received both, we need to set repo:{org}/{repo} in the query
+        let org_and_repo = match (org, repo) {
+            (None, None) => String::new(),
+            (Some(org), Some(repo)) => format!("repo:{org}/{repo}"),
+            (Some(org), _) => format!("org:{org}"),
+            (_, Some(repo)) => format!("repo:{repo}"),
+        };
+
         let per_page: u8 = request
             .get("per_page")
             .unwrap_or(&"100")
             .parse::<u8>()
             .map_err(|_| ApiError::BadRequest)?;
+        if per_page > 100 {
+            // GitHub supports up to 100 results per page
+            return Err(ApiError::BadRequest);
+        }
+
         let page: u16 = request
             .get("page")
             .unwrap_or(&"1")
             .parse::<u16>()
             .map_err(|_| ApiError::BadRequest)?;
 
-        if per_page > 100 {
-            // GitHub supports up to 100 results per page
-            return Err(ApiError::BadRequest);
-        }
+        // Construct the query with the piece we have. Multiple spaces, if present, do not cause problems.
+        let query = format!("{filename} {extension} {path} {org_and_repo}");
 
         // Log what we are doing
-        match org {
-            None => info!(
-                "Finding all files called [{filename}] on behalf of [{module}]"
-            ),
-            Some(org) =>  match repo {
-                    None => info!(
-                        "Finding all files called [{filename}] in organization [{org}] on behalf of [{module}]"
-                    ),
-                    Some(repo) => info!(
-                        "Finding all files called [{filename}] in repository [{org}/{repo}] on behalf of [{module}]"
-                    ),
-                }
-        }
+        info!("Searching code in GH with query [{query}] on behalf of [{module}]");
 
-        // Build the search query
-        let query = match org {
-            None => format!("{filename} in:path"),
-            Some(org) => match repo {
-                None => format!("{filename} in:path org:{org}"),
-                Some(repo) => format!("{filename} in:path repo:{org}/{repo}"),
-            },
-        };
         let query = urlencoding::encode(&query).to_string();
 
         // !!! NOTE - This endpoint has a custom rate limitation !!!

--- a/runtime/plaid/src/apis/github/validators.rs
+++ b/runtime/plaid/src/apis/github/validators.rs
@@ -72,6 +72,8 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
     );
     define_regex_validator!(validators, "secret_name", r"^[A-Z][A-Z0-9_]*$");
     define_regex_validator!(validators, "filename", r"^[a-zA-Z0-9\.]{1,32}$");
+    define_regex_validator!(validators, "extension", r"^[a-zA-Z0-9]{1,5}$");
+    define_regex_validator!(validators, "path", r"^[a-zA-Z0-9\./]{1,64}$");
 
     define_regex_validator!(validators, "event_type", r"^[\w\-_]+$");
 
@@ -91,5 +93,7 @@ create_regex_validator_func!(branch_name);
 create_regex_validator_func!(environment_name);
 create_regex_validator_func!(secret_name);
 create_regex_validator_func!(filename);
+create_regex_validator_func!(extension);
+create_regex_validator_func!(path);
 create_regex_validator_func!(event_type);
 create_regex_validator_func!(contains_parent_directory_component);

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -315,7 +315,7 @@ impl_new_function_with_error_buffer!(github, fetch_file, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, get_branch_protection_rules, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, get_branch_protection_ruleset, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, get_repository_collaborators, ALLOW_IN_TEST_MODE);
-impl_new_function_with_error_buffer!(github, search_for_file, ALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(github, search_code, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, list_seats_in_org_copilot, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, add_users_to_org_copilot, DISALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, remove_users_from_org_copilot, DISALLOW_IN_TEST_MODE);
@@ -570,9 +570,7 @@ pub fn to_api_function(
             &env,
             github_create_deployment_branch_protection_rule,
         ),
-        "github_search_for_file" => {
-            Function::new_typed_with_env(&mut store, &env, github_search_for_file)
-        }
+        "github_search_code" => Function::new_typed_with_env(&mut store, &env, github_search_code),
         "github_add_users_to_org_copilot" => {
             Function::new_typed_with_env(&mut store, &env, github_add_users_to_org_copilot)
         }


### PR DESCRIPTION
Improve the API for search code on GH, supporting searches target to a filename, an extension, and/or a path.

## NOTE
This is a breaking change

@obelisk Let's bump the version depending on the order in which we merge PRs.