### PR TITLE
Add deployment name to AWS SM secret names

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -2960,7 +2960,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plaid"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "alkali",
  "async-trait",
@@ -3007,7 +3007,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
For multi-tenant deployments, where multiple Plaid instances are deployed on the same AWS account, it's important to distinguish secrets that belong to one deployment from the others. AWS Secrets Manager does not support the notion of "buckets" or "folders", so we use a name prefix as a way to segment secrets. This PR adds an item to the prefix: `deployment`.

Plaid secrets in AWS Secrets Manager will be called `plaid-<deployment>-<instance>-<secret_name>`. This way we can have
* `plaid-first_deployment-plaid-my_secret`
* `plaid-second_deployment-plaid-my_secret`
* `plaid-first_deployment-ingress-my_secret`
* `plaid-second_deployment-ingress-my_secret`

with no conflicts.

@obelisk It requires cutting a new release, so that we appropriately publish a new version of the secrets manager binary.