### PR TITLE
Implement module signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Artefacts
 /compiled_modules
 /runtime/performance-monitoring/*
+/module_signatures
 
 # Private items
 /runtime/plaid/private-resources

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3177,7 +3177,6 @@ dependencies = [
  "ring 0.17.14",
  "serde",
  "serde_json",
- "sha2",
  "sled",
  "sshcerts",
  "tar",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3177,7 +3177,9 @@ dependencies = [
  "ring 0.17.14",
  "serde",
  "serde_json",
+ "sha2",
  "sled",
+ "sshcerts",
  "tar",
  "time",
  "tokio",
@@ -4305,6 +4307,18 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sshcerts"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "752ad8923d32fb5c117b8a9983266e294edc072401133720aa9af3959d63248d"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "ring 0.17.14",
+ "zeroize",
 ]
 
 [[package]]

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -49,7 +49,6 @@ reqwest_cookie_store = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 sled = { version = "0.34.7", optional = true }
-sha2 = "0.10.8"
 sshcerts = { version = "0.13.2", default-features = false }
 tar = "0.4.41"
 time = "0.3"

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -49,6 +49,8 @@ reqwest_cookie_store = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 sled = { version = "0.34.7", optional = true }
+sha2 = "0.10.8"
+sshcerts = { version = "0.13.2", default-features = false }
 tar = "0.4.41"
 time = "0.3"
 tokio = { version = "1", features = ["full"] }

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -58,6 +58,7 @@ test_mode_exemptions = [
 # [loading.module_signing]
 # authorized_signers = [""]
 # signature_namespace = "SomeNamespace"
+# signatures_required = 1
 
 [loading.persistent_response_size]
 "test_persistent_response.wasm" = 1024

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -55,13 +55,11 @@ test_mode_exemptions = [
 
 
 # Uncomment this to require that all rules be signed by an authorized signer
-# [loading.module_signing]
-# authorized_signers = [
-#     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHkbe7gwx7s0dlApEEzpUyOAPrzPLy4czEZw/sh8m8rd me@home",
-# ]
-# signatures_required = 1
-# signature_namespace = "SomeNamespace" # Defaults to PlaidRule if not provided
-# signature_dir = "/path/to/signatures" # Defaults to ../module_signatures if not provided
+[loading.module_signing]
+authorized_signers = [
+    "{plaid-secret{public-key}}",
+]
+signatures_required = 1
 
 [loading.persistent_response_size]
 "test_persistent_response.wasm" = 1024

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -56,7 +56,9 @@ test_mode_exemptions = [
 
 # Uncomment this to require that all rules be signed by an authorized signer
 # [loading.module_signing]
-# authorized_signers = [""]
+# authorized_signers = [
+#     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHkbe7gwx7s0dlApEEzpUyOAPrzPLy4czEZw/sh8m8rd me@home",
+# ]
 # signature_namespace = "SomeNamespace"
 # signatures_required = 1
 

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -55,7 +55,7 @@ test_mode_exemptions = [
 
 
 # Uncomment this to require that all rules be signed by an authorized signer
-# [loading.rule_signing]
+# [loading.module_signing]
 # authorized_signers = [""]
 # signature_namespace = "SomeNamespace"
 

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -53,6 +53,12 @@ test_mode_exemptions = [
     "test_shared_db_rule_2.wasm",
 ]
 
+
+# Uncomment this to require that all rules be signed by an authorized signer
+# [loading.rule_signing]
+# authorized_signers = [""]
+# signature_namespace = "SomeNamespace"
+
 [loading.persistent_response_size]
 "test_persistent_response.wasm" = 1024
 "test_sshcerts_usage.wasm" = 1024

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -59,8 +59,9 @@ test_mode_exemptions = [
 # authorized_signers = [
 #     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHkbe7gwx7s0dlApEEzpUyOAPrzPLy4czEZw/sh8m8rd me@home",
 # ]
-# signature_namespace = "SomeNamespace"
 # signatures_required = 1
+# signature_namespace = "SomeNamespace" # Defaults to PlaidRule if not provided
+# signature_dir = "/path/to/signatures" # Defaults to ../module_signatures if not provided
 
 [loading.persistent_response_size]
 "test_persistent_response.wasm" = 1024

--- a/runtime/plaid/resources/secrets.example.json
+++ b/runtime/plaid/resources/secrets.example.json
@@ -1,3 +1,4 @@
 {
-    "{plaid-secret{test-secret}}": "This is a test secret"
+    "{plaid-secret{test-secret}}": "This is a test secret",
+    "{plaid-secret{public-key}}": "{CI_PUBLIC_KEY_PLACEHOLDER}"
 }

--- a/runtime/plaid/src/loader/errors.rs
+++ b/runtime/plaid/src/loader/errors.rs
@@ -6,5 +6,6 @@ pub enum Errors {
     ModuleCompilationFailure,
     SigningError(sshcerts::error::Error),
     UnauthorizedSigner,
-    MissingSignatureFile,
+    NotEnoughValidSignatures,
+    FileError(std::io::Error),
 }

--- a/runtime/plaid/src/loader/errors.rs
+++ b/runtime/plaid/src/loader/errors.rs
@@ -1,9 +1,10 @@
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum Errors {
     BadFilename,
     ModuleParseFailure,
     ModuleCompilationFailure,
-    SshCertsError(sshcerts::error::Error),
+    SigningError(sshcerts::error::Error),
     UnauthorizedSigner,
     MissingSignatureFile,
 }

--- a/runtime/plaid/src/loader/errors.rs
+++ b/runtime/plaid/src/loader/errors.rs
@@ -3,4 +3,7 @@ pub enum Errors {
     BadFilename,
     ModuleParseFailure,
     ModuleCompilationFailure,
+    SshCertsError(sshcerts::error::Error),
+    UnauthorizedSigner,
+    MissingSignatureFile,
 }

--- a/runtime/plaid/src/loader/errors.rs
+++ b/runtime/plaid/src/loader/errors.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 #[derive(Debug)]
 pub enum Errors {
-    BadFilename(String),
+    InvalidFileType(String, String),
     CompileError(wasmer::CompileError),
     SigningError(sshcerts::error::Error),
     NotEnoughValidSignatures(usize, usize),
@@ -12,9 +12,9 @@ pub enum Errors {
 impl Display for Errors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::BadFilename(extension) => write!(
+            Self::InvalidFileType(expected, received) => write!(
                 f,
-                "Invalid filename: file must have a '{extension}' extension."
+                "Invalid file type '{received}': expected a {expected} file "
             ),
             Self::CompileError(error) => write!(f, "Wasm compilation error: {error}"),
             Self::SigningError(error) => write!(f, "SshCerts error: {error}"),

--- a/runtime/plaid/src/loader/errors.rs
+++ b/runtime/plaid/src/loader/errors.rs
@@ -1,11 +1,28 @@
+use std::fmt::Display;
+
 #[derive(Debug)]
-#[allow(dead_code)]
 pub enum Errors {
-    BadFilename,
-    ModuleParseFailure,
-    ModuleCompilationFailure,
+    BadFilename(String),
+    CompileError(wasmer::CompileError),
     SigningError(sshcerts::error::Error),
-    UnauthorizedSigner,
-    NotEnoughValidSignatures,
+    NotEnoughValidSignatures(usize, usize),
     FileError(std::io::Error),
+}
+
+impl Display for Errors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadFilename(extension) => write!(
+                f,
+                "Invalid filename: file must have a '{extension}' extension."
+            ),
+            Self::CompileError(error) => write!(f, "Wasm compilation error: {error}"),
+            Self::SigningError(error) => write!(f, "SshCerts error: {error}"),
+            Self::NotEnoughValidSignatures(expected, received) => write!(
+                f,
+                "Expected {expected} valid signatures but only received {received}"
+            ),
+            Self::FileError(error) => write!(f, "IO error: {error}"),
+        }
+    }
 }

--- a/runtime/plaid/src/loader/mod.rs
+++ b/runtime/plaid/src/loader/mod.rs
@@ -165,9 +165,8 @@ where
         .iter()
         .filter_map(|key| {
             PublicKey::from_string(key)
-                .map_err(|e| {
+                .inspect_err(|e| {
                     error!("Invalid public key provided: {key} - skipping. Error: {e}");
-                    e
                 })
                 .ok()
         })

--- a/runtime/plaid/src/loader/mod.rs
+++ b/runtime/plaid/src/loader/mod.rs
@@ -130,14 +130,14 @@ pub struct Configuration {
     /// even if they have side effects.
     #[serde(default)]
     pub test_mode_exemptions: Vec<String>,
-    /// Configuration for rule signing. If defined, we require that ALL
-    /// rules are signed by an authorized signer
-    pub rule_signing: Option<RuleSigningConfiguration>,
+    /// Configuration for module signing. If defined, we require that ALL
+    /// module are signed by an authorized signer
+    pub module_signing: Option<ModuleSigningConfiguration>,
 }
 
-/// This structure defines the parameters required to validate signatures for rules.
+/// This structure defines the parameters required to validate signatures for modules.
 #[derive(Deserialize)]
-pub struct RuleSigningConfiguration {
+pub struct ModuleSigningConfiguration {
     /// A list of authorized signer key fingerprints.
     ///
     /// This list should contain the fingerprints of the keys belonging to the authorized signers,
@@ -375,7 +375,7 @@ pub async fn load(
         //
         // If ANY rule does not have a valid signature, we panic instead of continuing because this should be
         // considered a blocking issue and we do not want to continue booting the system
-        if let Some(signing) = &config.rule_signing {
+        if let Some(signing) = &config.module_signing {
             let signature =
                 fs::read_to_string(format!("{}/{filename}.sig", signing.signatures_dir))
                     .expect(&format!("Expected signature to be present for {filename}."));

--- a/runtime/plaid/src/loader/signing.rs
+++ b/runtime/plaid/src/loader/signing.rs
@@ -33,7 +33,7 @@ pub fn check_module_signatures(
 
     // If the number of available signature files does not exceed the required count,
     // return an error immediately to avoid unnecessary processing.
-    if module_signatures.len() <= signing.signatures_required {
+    if module_signatures.len() < signing.signatures_required {
         return Err(Errors::NotEnoughValidSignatures(
             0,
             signing.signatures_required,

--- a/runtime/plaid/src/loader/signing.rs
+++ b/runtime/plaid/src/loader/signing.rs
@@ -61,7 +61,7 @@ pub fn check_module_signatures(
         if !signing
             .authorized_signers
             .iter()
-            .any(|signer| *signer == pubkey)
+            .any(|signer| signer.fingerprint() == pubkey.fingerprint())
         {
             error!(
                 "{filename} was signed by an unexpected signer: {}",

--- a/runtime/plaid/src/loader/signing.rs
+++ b/runtime/plaid/src/loader/signing.rs
@@ -1,0 +1,118 @@
+use super::errors::Errors;
+use super::ModuleSigningConfiguration;
+
+use hex::ToHex;
+use ring::digest::{digest, SHA256};
+use sshcerts::ssh::{SshSignature, VerifiedSshSignature};
+use std::collections::HashSet;
+use std::fs::{self, DirEntry};
+
+/// Checks that a module has enough valid signatures.
+///
+/// Reads the module’s signature files from its designated subdirectory,
+/// verifies each signature against the module's SHA256 hash, and returns
+/// `Ok` if the number of valid signatures meets the required threshold.
+pub fn check_module_signatures(
+    signing: &ModuleSigningConfiguration,
+    filename: &str,
+    module_bytes: &[u8],
+) -> Result<(), Errors> {
+    // We expect each module's signatures to be located in a subdirectory of signatures_dir.
+    // This subdirectory should share its name with the module
+    let module_signatures = fs::read_dir(format!("{}/{filename}", signing.signatures_dir))
+        .map_err(|e| Errors::FileError(e))?;
+
+    // Hash file
+    let module_hash: String = digest(&SHA256, &module_bytes).encode_hex();
+    let module_hash = module_hash.as_bytes();
+
+    // We use a HashSet here to ensure that we don't allow the same key to produce multiple valid signatures
+    let mut valid_signatures = HashSet::new();
+    for signature in module_signatures {
+        let entry = match signature {
+            Ok(path) => path,
+            Err(e) => {
+                error!("Bad entry in signature directory for {filename} - skipping. Error: {e}");
+                continue;
+            }
+        };
+
+        if let Ok(fingerprint) = verify_signature_file(entry, module_hash, &signing, &filename) {
+            valid_signatures.insert(fingerprint);
+        }
+
+        // Return early once the threshold is met.
+        if valid_signatures.len() >= signing.signatures_required {
+            return Ok(());
+        }
+    }
+
+    error!(
+        "Not enough valid signatures provided for {filename}. Got {} but needed {}",
+        valid_signatures.len(),
+        signing.signatures_required
+    );
+    Err(Errors::NotEnoughValidSignatures)
+}
+
+/// Verifies a signature file against a module's hash and ensures it is signed by an authorized signer.
+fn verify_signature_file(
+    signature_path: DirEntry,
+    module_hash: &[u8],
+    signing: &ModuleSigningConfiguration,
+    module_name: &str,
+) -> Result<String, Errors> {
+    let signature = read_in_signature(signature_path)?;
+
+    // Parse and validate the signature.
+    let ssh_signature = match SshSignature::from_armored_string(&signature) {
+        Ok(sig) => sig,
+        Err(e) => {
+            error!("Invalid signature provided for {}", module_name);
+            return Err(Errors::SigningError(e));
+        }
+    };
+
+    let pubkey = ssh_signature.pubkey.clone();
+
+    // Check if the signature was made by an authorized signer.
+    if !signing.authorized_signers.iter().any(|s| *s == pubkey) {
+        error!(
+            "{} was signed by an unexpected signer: {}",
+            module_name,
+            pubkey.fingerprint()
+        );
+        return Err(Errors::UnauthorizedSigner);
+    }
+
+    // Verify the signature using the module hash.
+    let verified = VerifiedSshSignature::from_ssh_signature(
+        module_hash,
+        ssh_signature,
+        &signing.signature_namespace,
+        Some(pubkey),
+    )
+    .map_err(|e| Errors::SigningError(e))?;
+
+    Ok(verified.signature.pubkey.fingerprint().to_string())
+}
+
+/// Reads a signature file from the given directory entry.
+///
+/// Verifies the file ends with ".sig" and returns its content as a String,
+/// or an error if the file name is invalid or the file cannot be read.
+fn read_in_signature(signature_path: DirEntry) -> Result<String, Errors> {
+    let sig_filename = signature_path.file_name().to_string_lossy().to_string();
+    if !sig_filename.ends_with(".sig") {
+        return Err(Errors::BadFilename);
+    }
+
+    // Try to read the signature file.
+    std::fs::read_to_string(signature_path.path()).map_err(|e| {
+        error!(
+            "Failed to read signature at [{:?}]. Error: {}",
+            signature_path, e
+        );
+        Errors::FileError(e)
+    })
+}

--- a/runtime/plaid/src/loader/signing.rs
+++ b/runtime/plaid/src/loader/signing.rs
@@ -117,7 +117,7 @@ fn verify_signature_file(
 fn read_in_signature(signature_path: DirEntry) -> Result<String, Errors> {
     let sig_filename = signature_path.file_name().to_string_lossy().to_string();
     if !sig_filename.ends_with(".sig") {
-        return Err(Errors::BadFilename(".sig".to_string()));
+        return Err(Errors::InvalidFileType(".sig".to_string(), sig_filename));
     }
 
     // Try to read the signature file.

--- a/runtime/plaid/src/loader/utils.rs
+++ b/runtime/plaid/src/loader/utils.rs
@@ -18,7 +18,7 @@ pub fn read_and_parse_modules(path: &DirEntry) -> Result<(String, Vec<u8>), Erro
     // guarantees that strings that do _not_ terminate with .wasm can be used for other
     // things, like DBs shared across multiple rules.
     if !filename.ends_with(".wasm") {
-        return Err(Errors::BadFilename(".wasm".to_string()));
+        return Err(Errors::InvalidFileType(".wasm".to_string(), filename));
     }
 
     // Read in the bytes of the module

--- a/runtime/plaid/src/loader/utils.rs
+++ b/runtime/plaid/src/loader/utils.rs
@@ -18,7 +18,7 @@ pub fn read_and_parse_modules(path: &DirEntry) -> Result<(String, Vec<u8>), Erro
     // guarantees that strings that do _not_ terminate with .wasm can be used for other
     // things, like DBs shared across multiple rules.
     if !filename.ends_with(".wasm") {
-        return Err(Errors::BadFilename);
+        return Err(Errors::BadFilename(".wasm".to_string()));
     }
 
     // Read in the bytes of the module
@@ -26,7 +26,7 @@ pub fn read_and_parse_modules(path: &DirEntry) -> Result<(String, Vec<u8>), Erro
         Ok(b) => b,
         Err(e) => {
             error!("Failed to read module at [{:?}]. Error: {e}", path.path());
-            return Err(Errors::ModuleParseFailure);
+            return Err(Errors::FileError(e));
         }
     };
 

--- a/testing/integration.sh
+++ b/testing/integration.sh
@@ -5,7 +5,7 @@ PLATFORM=$(uname -a)
 
 # On macOS, we need to install a brew provided version of LLVM
 # so that we can compile WASM binaries.
-if  uname | grep -q Darwin; then
+if uname | grep -q Darwin; then
   echo "macOS detected so using LLVM from Homebrew for wasm32 compatibility"
   PATH="/opt/homebrew/opt/llvm/bin:$PATH"
 fi
@@ -25,6 +25,41 @@ cd ..
 echo "Copying Compiled Test Modules to compiled_modules"
 mkdir -p compiled_modules
 cp -r modules/target/wasm32-unknown-unknown/release/test_*.wasm compiled_modules/
+
+# Generate a new key without a passphrase
+ssh-keygen -t ed25519 -f plaidrules_key_ed25519 -N ""
+public_key=$(cat plaidrules_key_ed25519.pub | awk '{printf "%s %s %s", $1, $2, $3}')
+
+if uname | grep -q Darwin; then
+    # macOS (BSD sed)
+    sed -i '' "s|{CI_PUBLIC_KEY_PLACEHOLDER}|$public_key|g" ./runtime/plaid/resources/secrets.example.json
+else
+    # Linux (GNU sed)
+    sed -i "s|{CI_PUBLIC_KEY_PLACEHOLDER}|$public_key|g" ./runtime/plaid/resources/secrets.example.json
+fi
+
+# Create module signatures directory
+mkdir module_signatures
+
+# Iterate over all .wasm files in the target directory
+for wasm_file in ./modules/target/wasm32-unknown-unknown/release/test_*.wasm; do
+    # Extract the base filename (without extension)
+    base_name=$(basename "$wasm_file" .wasm)
+
+    mkdir module_signatures/"$base_name".wasm
+
+    # Compute SHA-256 hash without a trailing newline and assign it to a variable
+    shasum -a 256 "$wasm_file" | awk '{printf "%s", $1}' > "$base_name".sha256
+    
+    # Sign the computed hash using process substitution to feed the hash to ssh-keygen
+    ssh-keygen -Y sign -n PlaidRule -f plaidrules_key_ed25519 "$base_name.sha256"
+
+    mv "$base_name.sha256.sig" "./module_signatures/$base_name.wasm/$base_name.wasm.sig"
+
+    rm *.sha256
+done
+
+rm plaidrules_key_ed25519*
 
 echo "Starting Plaid In The Background and waiting for it to boot"
 cd runtime

--- a/testing/integration.sh
+++ b/testing/integration.sh
@@ -41,7 +41,7 @@ fi
 # Create module signatures directory
 mkdir module_signatures
 
-# Iterate over all .wasm files in the target directory
+# Iterate over all test_*.wasm files in the target directory
 for wasm_file in ./modules/target/wasm32-unknown-unknown/release/test_*.wasm; do
     # Extract the base filename (without extension)
     base_name=$(basename "$wasm_file" .wasm)
@@ -51,7 +51,7 @@ for wasm_file in ./modules/target/wasm32-unknown-unknown/release/test_*.wasm; do
     # Compute SHA-256 hash without a trailing newline and assign it to a variable
     shasum -a 256 "$wasm_file" | awk '{printf "%s", $1}' > "$base_name".sha256
     
-    # Sign the computed hash using process substitution to feed the hash to ssh-keygen
+    # Sign the computed hash
     ssh-keygen -Y sign -n PlaidRule -f plaidrules_key_ed25519 "$base_name.sha256"
 
     mv "$base_name.sha256.sig" "./module_signatures/$base_name.wasm/$base_name.wasm.sig"


### PR DESCRIPTION
  The PR implements a mechanism to require that rules be signed prior to loading them. In `plaid.toml` this looks like:
```toml
[loading.rule_signing]
authorized_signers = [""]
signature_namespace = "SomeNamespace"
signature_dir = "/path/to/signatures"
```
When `[loading.rule_signing]` is present in `plaid.toml`, we require that ALL rules are signed by an authorized signer. This all or nothing approach greatly simplifies rule signing. When rule signing is enabled, the loading system:
1. Fetches the rule's signature from `signature_dir`
2. Validates the signature and checks that it was produced by one of `authorized_signers`
3. Computes the hash of the rule
4. Validates the signature against the rule's hash

This PR is as much a process change in Plaid administration as it is a code change. In practice, Plaid administrators will need to sign every rule prior to deployment. Depending on the environment, this can be scripted to reduce manual effort on the admin and CI checks can be put in place to ensure that every rule is signed prior to merge. 