### PR TITLE
Fix deserialization of old logbacks

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3147,7 +3147,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "alkali",
  "async-trait",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -145,14 +145,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         // Create the message we're going to send into the execution system.
                         let mut message = Message::new(webhook_configuration.log_type.to_owned(), data[..].to_vec(), source, logbacks_allowed);
 
+                        let mut message_headers = HashMap::new();
                         for requested_header in webhook_configuration.headers.iter() {
                             // TODO: Investigate if this should be get_all?
                             // Without this we don't support receiving multiple headers with the same name
                             // I don't know if this is an issue or not, practically, or if there are security implications.
                             if let Some(value) = headers.get(requested_header) {
-                                message.headers.insert(requested_header.to_string(), value.as_bytes().to_vec());
+                                message_headers.insert(requested_header.to_string(), value.as_bytes().to_vec());
                             }
                         }
+                        message.headers = Some(message_headers);
 
                         // Webhook exists, buffer log
                         if let Err(e) = webhook_server_post_log_sender.try_send(message) {
@@ -265,8 +267,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 let message = Message {
                                     type_: name.to_string(),
                                     data: String::new().into_bytes(),
-                                    headers: HashMap::new(),
-                                    query_params: query.into_iter().map(|(k, v)| (k, v.into_bytes())).collect(),
+                                    headers: Some(HashMap::new()),
+                                    query_params: Some(query.into_iter().map(|(k, v)| (k, v.into_bytes())).collect()),
                                     source,
                                     logbacks_allowed,
                                     response_sender: Some(response_send),

--- a/runtime/plaid/src/executor/mod.rs
+++ b/runtime/plaid/src/executor/mod.rs
@@ -40,9 +40,9 @@ pub struct Message {
     /// The data passed to the module
     pub data: Vec<u8>,
     /// Any headers the module will have access to, while processing this message
-    pub headers: HashMap<String, Vec<u8>>,
+    pub headers: Option<HashMap<String, Vec<u8>>>,
     /// Any query parameters the module will have access to, while processing this message
-    pub query_params: HashMap<String, Vec<u8>>,
+    pub query_params: Option<HashMap<String, Vec<u8>>>,
     /// Where the message came from
     pub source: LogSource,
     /// If this message is allowed to trigger additional messages to the same
@@ -69,8 +69,8 @@ impl Message {
         Self {
             type_,
             data,
-            headers: HashMap::new(),
-            query_params: HashMap::new(),
+            headers: Some(HashMap::new()),
+            query_params: Some(HashMap::new()),
             source,
             logbacks_allowed,
             response_sender: None,

--- a/runtime/plaid/src/functions/message.rs
+++ b/runtime/plaid/src/functions/message.rs
@@ -156,7 +156,14 @@ macro_rules! generate_string_getter {
                     }
                 };
 
-                let $what = &env.data().message.$what;
+                let $what = match &env.data().message.$what {
+                    Some(v) => v,
+                    None => {
+                        // This should never happen. If the message doesn't have this data,
+                        // we should always have Some(empty_map).
+                        return crate::functions::FunctionErrors::InternalApiError as i32;
+                    }
+                };
 
                 let name = match safely_get_string(&memory_view, name_buf, name_len) {
                     Ok(x) => x,


### PR DESCRIPTION
## Problem
A [recent change](https://github.com/obelisk/plaid/pull/74) modified the structure of a `Message`, introducing fields for `headers` and `query_params` of type `HashMap<_, _>` in place of the old `accessory_data`.

However, a running system will likely have logbacks in its DB. Logbacks produced before that refactor are no longer deserializable because they follow the old structure.

Plaid logs will show something like this

```
Skipping log in storage system which could not be deserialized [missing field `headers` at line 1 column 588]: \"{\\\"type_\\\":\\\"***\\\",\\\"data\\\":[***],\\\"accessory_data\\\":{},\\\"module\\\":\\\"***\\\"}\"
```
Notice how it still shows the old `accessory_data`.


## Solution
Change the `Message` struct so that `headers` and `query_params` are `Option<HashMap<_, _>>`.
This way, `serde_json` will ignore the extra `accessory_data` it is given, and will not complain about the missing `headers` and `query_params`.

Going forward, this change is useless because we know (given how we construct it) that those fields are always populated, at least with an empty map. But this guarantees backwards compatibility and will allow for deserialization of old logbacks.

## Impact
On the bright side, Plaid [does not delete](https://github.com/obelisk/plaid/blob/main/runtime/plaid/src/data/internal/mod.rs#L87) logbacks that it cannot deserialize, so the data is not lost. After merging this PR and rebooting the system, old logbacks should be executed normally.
However, this might have caused unintended consequences if logbacks were time-sensitive.