### PR TITLE
Add Message::id and change logbacks' persistence

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -180,7 +180,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -52,9 +52,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "shlex",
 ]
@@ -180,7 +180,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3246,6 +3246,7 @@ dependencies = [
  "totp-rs",
  "url",
  "urlencoding",
+ "uuid",
  "warp",
  "wasmer",
  "wasmer-middlewares",
@@ -4952,6 +4953,9 @@ name = "uuid"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.2",
+]
 
 [[package]]
 name = "vcpkg"

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -1362,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -2616,14 +2616,14 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.10",
+ "redox_syscall 0.5.11",
 ]
 
 [[package]]
 name = "libsodium-sys-stable"
-version = "1.22.2"
+version = "1.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7717550bb3ec725f7b312848902d1534f332379b1d575d2347ec265c8814566"
+checksum = "b023d38f2afdfe36f81e15a9d7232097701d7b107e3a93ba903083985e235239"
 dependencies = [
  "cc",
  "libc",
@@ -3089,7 +3089,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.10",
+ "redox_syscall 0.5.11",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3205,7 +3205,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "alkali",
  "async-trait",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -3567,9 +3567,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -4588,9 +4588,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3205,7 +3205,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "alkali",
  "async-trait",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.22.1"
+version = "0.22.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -61,6 +61,7 @@ tokio-tungstenite = { version = "0.23.1", features = [
 ] }
 toml = "0.5"
 totp-rs = "5.6.0"
+uuid = { version = "1", features = ["v4"] }
 url = "2.5.2"
 urlencoding = "2.1.3"
 warp = { version = "0.3", features = ["tls"] }

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.22.1"
+version = "0.22.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -91,4 +91,9 @@ path = "src/bin/secrets_manager.rs"
 [[bin]]
 name = "sled_ddb_migrator"
 path = "src/bin/sled_ddb_migrator.rs"
+required-features = ["sled", "aws"]
+
+[[bin]]
+name = "db_migrator"
+path = "src/bin/db_migrator.rs"
 required-features = ["sled", "aws"]

--- a/runtime/plaid/src/bin/db_migrator.rs
+++ b/runtime/plaid/src/bin/db_migrator.rs
@@ -1,0 +1,192 @@
+use clap::{Arg, Command};
+use plaid::{data::DelayedMessage, executor::Message, storage::StorageProvider};
+use serde_json::Value;
+
+/// This function takes additional parameters and produces the function that defines the data migration.
+/// We use this pattern to be able to take arbitrary parameters that would not fit in the migration
+/// function's signature.
+fn create_migration_function(
+    log_source_if_missing: String,
+) -> Box<dyn Fn(String, Vec<u8>) -> (String, Vec<u8>) + Send + Sync> {
+    Box::new(move |key, value| {
+        // First, try to deserialize the value as a DelayedMessage. If this succeeds,
+        // then this entry is in the newest format and we leave it untouched.
+        if serde_json::from_slice::<DelayedMessage>(&value).is_ok() {
+            // This is a message in the new format: leave it untouched
+            println!(
+                "Found log in the newest format. [{key}]: [{}]",
+                String::from_utf8(value.clone()).unwrap()
+            );
+            return (key, value);
+        }
+        // Try to deserialize `key` as a JSON value with a `data` field.
+        // If the `data` field is not there, then we assume we have a UUID:
+        // this means the log is already serialized in the new format.
+        // In this case, we leave the entry untouched.
+        // If deserialization to a Value fails, then we don't know what to do and
+        // leave everything untouched.
+        match serde_json::from_str::<Value>(&key) {
+            Err(_) => (key, value), // identity mapping
+            Ok(mut v) => {
+                if v.get("data").is_none() {
+                    // `data` is missing: this is probably just a UUID: leave it
+                    // Note - This shouldn't really be possible, but it does not hurt
+                    return (key, value); // identity mapping
+                }
+                // We managed to deserialize, so now we look at the JSON fields
+                if v.get("source").is_none() {
+                    // `source` is missing: we add it
+                    v.as_object_mut().unwrap().insert(
+                        "source".to_string(),
+                        serde_json::to_value(plaid_stl::messages::LogSource::Logback(
+                            log_source_if_missing.clone(),
+                        ))
+                        .unwrap(),
+                    );
+                }
+                if v.get("accessory_data").is_some() {
+                    // `accessory_data` is present: we remove it and add `headers` and `query_params`
+                    v.as_object_mut().unwrap().remove("accessory_data");
+                    v.as_object_mut()
+                        .unwrap()
+                        .insert("headers".to_string(), Value::Object(serde_json::Map::new()));
+                    v.as_object_mut().unwrap().insert(
+                        "query_params".to_string(),
+                        Value::Object(serde_json::Map::new()),
+                    );
+                }
+                let id = uuid::Uuid::new_v4().to_string(); // new ID for the logback
+                                                           // Insert the ID into the Map
+                v.as_object_mut()
+                    .unwrap()
+                    .insert("id".to_string(), serde_json::to_value(id.clone()).unwrap());
+
+                // With the changes we have made above, the value v is now basically a serialized Message.
+                // We deserialize it because we need the Message itself
+                let message = serde_json::from_value::<Message>(v).unwrap();
+
+                // Now we deserialize the old value, which used to contain the delay (u64)
+                let time: [u8; 8] = value.try_into().unwrap();
+                let delay = u64::from_be_bytes(time);
+                // We construct the DelayedMessage which will be the new value
+                let delayed_message = DelayedMessage::new(delay, message);
+                // Finally we serialize the DelayedMessage, ready for insertion in the DB
+                let delayed_message = serde_json::to_vec(&delayed_message).unwrap();
+                return (id, delayed_message);
+
+                // match serde_json::from_slice::<u64>(&value) {
+                //     Err(_) => {
+                //         // Something went wrong: this is very strange. We leave the pair untouched but it should not happen
+                //         return (key, value);
+                //     }
+                //     Ok(delay) => {
+                //         // We construct the DelayedMessage which will be the new value
+                //         let delayed_message = DelayedMessage::new(delay, message);
+                //         // Finally we serialize the DelayedMessage, ready for insertion in the DB
+                //         let delayed_message = serde_json::to_vec(&delayed_message).unwrap();
+                //         return (id, delayed_message);
+                //     }
+                // }
+            }
+        }
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), ()> {
+    let matches = Command::new("plaid_db_migrator")
+        .version("0.22.2")
+        .about("Tool to apply a data migration (written as a Rust function) to a Plaid DB")
+        .arg(
+            Arg::new("db_type")
+                .long("db")
+                .help("The type of DB to apply the migration on")
+                .value_parser(["sled", "dynamodb"])
+                .value_name("TYPE")
+                .required(true)
+                .num_args(1),
+        )
+        .arg(
+            Arg::new("sled_db_path")
+                .long("path")
+                .value_name("PATH")
+                .help("Path to the sled database")
+                .required_if_eq("db_type", "sled"),
+        )
+        .arg(
+            Arg::new("dynamo_table_name")
+                .long("table-name")
+                .value_name("TABLE")
+                .help("DynamoDB table name")
+                .required_if_eq("db_type", "dynamodb")
+                .conflicts_with("sled_db_path"),
+        )
+        .arg(
+            Arg::new("namespace")
+                .long("namespace")
+                .help("DB namespace to apply the migration on")
+                .value_name("NS")
+                .required(true),
+        )
+        .arg(
+            Arg::new("logsource")
+                .long("logsource")
+                .help("Log source to use if missing in the DB")
+                .value_name("SOURCE"),
+        )
+        .get_matches();
+
+    let db_type = matches.get_one::<String>("db_type").unwrap();
+    let namespace = matches.get_one::<String>("namespace").unwrap();
+    let missing_logsource = "missing_logsource".to_string();
+    let logsource = matches
+        .get_one::<String>("logsource")
+        .unwrap_or(&missing_logsource);
+
+    match db_type.as_str() {
+        "sled" => {
+            let sled_path = matches.get_one::<String>("sled_db_path").unwrap();
+            apply_sled_migration(sled_path, namespace, logsource)
+                .await
+                .unwrap();
+        }
+        "dynamodb" => {
+            let table_name = matches.get_one::<String>("dynamo_table_name").unwrap();
+            apply_dynamodb_migration(table_name, namespace, logsource)
+                .await
+                .unwrap();
+        }
+        _ => unreachable!("Unknown DB type {db_type}"),
+    }
+
+    println!("Migration complete.");
+    Ok(())
+}
+
+async fn apply_sled_migration(path: &str, namespace: &str, logsource: &str) -> Result<(), ()> {
+    let config = plaid::storage::sled::Config {
+        sled_path: path.to_string(),
+    };
+    let sled = plaid::storage::sled::Sled::new(config).unwrap();
+    sled.apply_migration(namespace, create_migration_function(logsource.to_string()))
+        .await
+        .unwrap();
+    Ok(())
+}
+
+async fn apply_dynamodb_migration(
+    table_name: &str,
+    namespace: &str,
+    logsource: &str,
+) -> Result<(), ()> {
+    let config = plaid::storage::dynamodb::Config {
+        authentication: plaid::AwsAuthentication::Iam {},
+        table_name: table_name.to_string(),
+    };
+    let dynamodb = plaid::storage::dynamodb::DynamoDb::new(config).await;
+    dynamodb
+        .apply_migration(namespace, create_migration_function(logsource.to_string()))
+        .await
+        .unwrap();
+    Ok(())
+}

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -145,16 +145,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         // Create the message we're going to send into the execution system.
                         let mut message = Message::new(webhook_configuration.log_type.to_owned(), data[..].to_vec(), source, logbacks_allowed);
 
-                        let mut message_headers = HashMap::new();
                         for requested_header in webhook_configuration.headers.iter() {
                             // TODO: Investigate if this should be get_all?
                             // Without this we don't support receiving multiple headers with the same name
                             // I don't know if this is an issue or not, practically, or if there are security implications.
                             if let Some(value) = headers.get(requested_header) {
-                                message_headers.insert(requested_header.to_string(), value.as_bytes().to_vec());
+                                message.headers.insert(requested_header.to_string(), value.as_bytes().to_vec());
                             }
                         }
-                        message.headers = Some(message_headers);
 
                         // Webhook exists, buffer log
                         if let Err(e) = webhook_server_post_log_sender.try_send(message) {
@@ -269,8 +267,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     String::new().into_bytes(),
                                     source,
                                     logbacks_allowed,
-                                    Some(HashMap::new()),
-                                    Some(query.into_iter().map(|(k, v)| (k, v.into_bytes())).collect()),
+                                    HashMap::new(),
+                                    query.into_iter().map(|(k, v)| (k, v.into_bytes())).collect(),
                                     Some(response_send),
                                     Some(rule.clone()));
 

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -264,16 +264,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 let (response_send, response_recv) = tokio::sync::oneshot::channel();
 
                                 // Construct a message to send to the rule
-                                let message = Message {
-                                    type_: name.to_string(),
-                                    data: String::new().into_bytes(),
-                                    headers: Some(HashMap::new()),
-                                    query_params: Some(query.into_iter().map(|(k, v)| (k, v.into_bytes())).collect()),
+                                let message = Message::new_detailed(
+                                    name.to_string(),
+                                    String::new().into_bytes(),
                                     source,
                                     logbacks_allowed,
-                                    response_sender: Some(response_send),
-                                    module: Some(rule.clone()),
-                                };
+                                    Some(HashMap::new()),
+                                    Some(query.into_iter().map(|(k, v)| (k, v.into_bytes())).collect()),
+                                    Some(response_send),
+                                    Some(rule.clone()));
 
                                 // Put the message into the standard message queue
                                 if let Err(e) = log_sender.try_send(message) {

--- a/runtime/plaid/src/data/internal/mod.rs
+++ b/runtime/plaid/src/data/internal/mod.rs
@@ -65,9 +65,6 @@ pub struct Internal {
     storage: Option<Arc<Storage>>,
 }
 
-#[derive(Deserialize, Serialize)]
-struct InternalLog {}
-
 impl Internal {
     pub async fn new(
         config: InternalConfig,
@@ -84,22 +81,41 @@ impl Internal {
                 .await
                 .map_err(|e| DataError::StorageError(e))?;
 
-            for (message, time) in previous_logs {
-                let message: Message = match serde_json::from_str(message.as_str()) {
-                    Ok(msg) => msg,
-                    Err(e) => {
-                        warn!(
-                            "Skipping log in storage system which could not be deserialized [{e}]: {:X?}",
-                            message
-                        );
-                        continue;
+            for (key, value) in previous_logs {
+                // We want to extract from the DB a message and a delay.
+                // First, we try deserializing the new format, where the DB key is a message ID, and the value is the serialized DelayedMessage
+                let (message, delay) = match serde_json::from_slice::<DelayedMessage>(&value) {
+                    Ok(item) => {
+                        // Everything OK, we were deserializing a logback in the "new" format
+                        (item.message, item.delay)
+                    }
+                    Err(_) => {
+                        // Deserialization failed: try to deserialize in backward-compat mode,
+                        // where the key was the message itself and the value was the time.
+                        let message: Message = match serde_json::from_str(key.as_str()) {
+                            Ok(msg) => msg,
+                            Err(e) => {
+                                // This deserialization failed too: we give up
+                                warn!(
+                                    "Skipping log in storage system which could not be deserialized [{e}]: {:X?}",
+                                    key
+                                );
+                                continue;
+                            }
+                        };
+                        let delay: Result<[u8; 8], _> = value.try_into();
+                        let delay = match delay {
+                            Ok(delay) => u64::from_be_bytes(delay),
+                            Err(_) => {
+                                warn!("Something went wrong while deserializing delay");
+                                continue;
+                            }
+                        };
+                        // We managed to recover a message and a delay
+                        (message, delay)
                     }
                 };
-                let time: Result<[u8; 8], _> = time.try_into();
-                if let Ok(time) = time {
-                    let delay = u64::from_be_bytes(time);
-                    log_heap.push(Reverse(DelayedMessage { delay, message }));
-                }
+                log_heap.push(Reverse(DelayedMessage { delay, message }));
             }
         }
 
@@ -132,14 +148,12 @@ impl Internal {
             log.delay += current_time;
 
             if let Some(storage) = &self.storage {
-                let time: Vec<u8> = log.delay.to_be_bytes().to_vec();
-                // It is my understanding that serde is deterministic given the same structure
-                // meaning that below when it comes time to remove this key serializing the same
-                // struct will result in the same bytes.
-                let message = serde_json::to_string(&log.message);
-
-                if let Ok(message) = message {
-                    if let Err(e) = storage.insert(LOGBACK_NS.to_string(), message, time).await {
+                // Prepare what will be stored in the DB by serializing the DelayedMessage
+                if let Ok(db_item) = serde_json::to_vec(&log) {
+                    if let Err(e) = storage
+                        .insert(LOGBACK_NS.to_string(), log.message.id.clone(), db_item)
+                        .await
+                    {
                         error!("Storage system could not persist a message: {e}");
                     }
                 }
@@ -162,15 +176,25 @@ impl Internal {
 
             let log = self.log_heap.pop().unwrap();
             if let Some(storage) = &self.storage {
-                let message = serde_json::to_string(&log.0.message);
-                if let Ok(message) = message {
-                    match storage.delete(LOGBACK_NS, &message).await {
-                        Ok(None) => {
-                            error!("We tried to deleted a log back message that wasn't persisted")
+                // Delete the logback from the storage because we are about to send it for processing.
+                // According to the new format, the key is the ID inside the DelayedMessage's message field
+                match storage.delete(LOGBACK_NS, &log.0.message.id).await {
+                    Ok(None) => {
+                        // We did not find this logback in the DB. There is a chance we were processing a message serialized in the old format,
+                        // where the key was the message itself. Try to remove that
+                        let message = serde_json::to_string(&log.0.message);
+                        if let Ok(message) = message {
+                            match storage.delete(LOGBACK_NS, &message).await {
+                                Ok(None) => error!(
+                                    "We tried to deleted a log back message that wasn't persisted"
+                                ),
+                                Ok(Some(_)) => (),
+                                Err(e) => error!("Error removing persisted log: {e}"),
+                            }
                         }
-                        Ok(Some(_)) => (),
-                        Err(e) => error!("Error removing persisted log: {e}"),
                     }
+                    Ok(Some(_)) => (),
+                    Err(e) => error!("Error removing persisted log: {e}"),
                 }
             }
             self.sender.send(log.0.message).unwrap();

--- a/runtime/plaid/src/data/internal/mod.rs
+++ b/runtime/plaid/src/data/internal/mod.rs
@@ -162,7 +162,7 @@ impl Internal {
                 // According to the new format, the key is the ID inside the DelayedMessage's message field
                 match storage.delete(LOGBACK_NS, &log.0.message.id).await {
                     Ok(None) => {
-                        error!("We tried to deleted a log back message that wasn't persisted")
+                        error!("We tried to delete a log back message that wasn't persisted")
                     }
                     Ok(Some(_)) => (),
                     Err(e) => error!("Error removing persisted log: {e}"),

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -1,5 +1,5 @@
 pub mod github;
-mod internal;
+pub mod internal;
 mod interval;
 mod okta;
 mod websocket;

--- a/runtime/plaid/src/executor/mod.rs
+++ b/runtime/plaid/src/executor/mod.rs
@@ -42,9 +42,9 @@ pub struct Message {
     /// The data passed to the module
     pub data: Vec<u8>,
     /// Any headers the module will have access to, while processing this message
-    pub headers: Option<HashMap<String, Vec<u8>>>,
+    pub headers: HashMap<String, Vec<u8>>,
     /// Any query parameters the module will have access to, while processing this message
-    pub query_params: Option<HashMap<String, Vec<u8>>>,
+    pub query_params: HashMap<String, Vec<u8>>,
     /// Where the message came from
     pub source: LogSource,
     /// If this message is allowed to trigger additional messages to the same
@@ -72,8 +72,8 @@ impl Message {
             id: uuid::Uuid::new_v4().to_string(),
             type_,
             data,
-            headers: Some(HashMap::new()),
-            query_params: Some(HashMap::new()),
+            headers: HashMap::new(),
+            query_params: HashMap::new(),
             source,
             logbacks_allowed,
             response_sender: None,
@@ -87,8 +87,8 @@ impl Message {
         data: Vec<u8>,
         source: LogSource,
         logbacks_allowed: LogbacksAllowed,
-        headers: Option<HashMap<String, Vec<u8>>>,
-        query_params: Option<HashMap<String, Vec<u8>>>,
+        headers: HashMap<String, Vec<u8>>,
+        query_params: HashMap<String, Vec<u8>>,
         response_sender: Option<OneShotSender<Option<ResponseMessage>>>,
         module: Option<Arc<PlaidModule>>,
     ) -> Self {

--- a/runtime/plaid/src/executor/mod.rs
+++ b/runtime/plaid/src/executor/mod.rs
@@ -35,6 +35,8 @@ pub struct ResponseMessage {
 /// A message to be processed by one or more modules
 #[derive(Serialize, Deserialize)]
 pub struct Message {
+    /// A unique identifier for this message
+    pub id: String,
     /// The message channel that this message is going to run on
     pub type_: String,
     /// The data passed to the module
@@ -67,6 +69,7 @@ impl Message {
         logbacks_allowed: LogbacksAllowed,
     ) -> Self {
         Self {
+            id: uuid::Uuid::new_v4().to_string(),
             type_,
             data,
             headers: Some(HashMap::new()),
@@ -78,10 +81,35 @@ impl Message {
         }
     }
 
+    /// Construct a new message with optional fields
+    pub fn new_detailed(
+        type_: String,
+        data: Vec<u8>,
+        source: LogSource,
+        logbacks_allowed: LogbacksAllowed,
+        headers: Option<HashMap<String, Vec<u8>>>,
+        query_params: Option<HashMap<String, Vec<u8>>>,
+        response_sender: Option<OneShotSender<Option<ResponseMessage>>>,
+        module: Option<Arc<PlaidModule>>,
+    ) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            type_,
+            data,
+            headers,
+            query_params,
+            source,
+            logbacks_allowed,
+            response_sender,
+            module,
+        }
+    }
+
     /// Create a duplicate of the message that does
     /// not have the response sender.
     pub fn create_duplicate(&self) -> Self {
         Self {
+            id: self.id.clone(),
             type_: self.type_.clone(),
             data: self.data.clone(),
             headers: self.headers.clone(),

--- a/runtime/plaid/src/functions/message.rs
+++ b/runtime/plaid/src/functions/message.rs
@@ -156,14 +156,7 @@ macro_rules! generate_string_getter {
                     }
                 };
 
-                let $what = match &env.data().message.$what {
-                    Some(v) => v,
-                    None => {
-                        // This should never happen. If the message doesn't have this data,
-                        // we should always have Some(empty_map).
-                        return crate::functions::FunctionErrors::InternalApiError as i32;
-                    }
-                };
+                let $what = &env.data().message.$what;
 
                 let name = match safely_get_string(&memory_view, name_buf, name_len) {
                     Ok(x) => x,

--- a/runtime/plaid/src/storage/dynamodb/mod.rs
+++ b/runtime/plaid/src/storage/dynamodb/mod.rs
@@ -19,9 +19,9 @@ const VALUE: &str = "value";
 #[derive(Deserialize)]
 pub struct Config {
     /// How to authenticate to AWS
-    authentication: AwsAuthentication,
+    pub authentication: AwsAuthentication,
     /// The name of DynamoDB table used for Plaid's DB
-    table_name: String,
+    pub table_name: String,
 }
 
 /// A wrapper for DynamoDB
@@ -188,6 +188,26 @@ impl StorageProvider for DynamoDb {
             counter += item.0.as_bytes().len() as u64 + item.1.len() as u64;
         }
         Ok(counter)
+    }
+
+    async fn apply_migration(
+        &self,
+        namespace: &str,
+        f: Box<dyn Fn(String, Vec<u8>) -> (String, Vec<u8>) + Send + Sync>,
+    ) -> Result<(), StorageError> {
+        // Get all the data for this namespace
+        let data = self.fetch_all(namespace, None).await?;
+        // For each key/value pair, perform the migration...
+        for (key, value) in data {
+            // Apply the transformation and obtain a new key and new value
+            let (new_key, new_value) = f(key.clone(), value);
+            // Delete the old entry because we are about to insert the new one
+            self.delete(namespace, &key).await?;
+            // And insert the new pair
+            self.insert(namespace.to_string(), new_key, new_value)
+                .await?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Main changes:
* Every `Message` now has an ID. This is immediately useful for logbacks, and can be useful for other messages too in the future.
* When persisting logbacks in the DB, we use the `Message`'s ID as key, while the value is the serialization of the corresponding `DelayedMessage`.
* When deserializing and deleting logbacks from the DB, we only deserialize the new format. If data exists in the DB that was serialized in the old way(s), then it should be migrated with the tool that this PR introduces.

Note - In the previous format, the key was the JSON serialization of the message, while the value was the byte representation of the logback's delay.

Fixes #12 