### PR TITLE
Allow dot character in npm usernames

### DIFF
--- a/runtime/plaid/src/apis/npm/validators.rs
+++ b/runtime/plaid/src/apis/npm/validators.rs
@@ -53,7 +53,7 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
     define_regex_validator!(validators, "npm_team_name", r"^[a-zA-Z0-9-_]+$");
 
     // Validate an npm username. This is probably stricter than necessary
-    define_regex_validator!(validators, "npm_username", r"^[a-zA-Z0-9-_]+$");
+    define_regex_validator!(validators, "npm_username", r"^[a-zA-Z0-9._-]+$");
 
     define_regex_validator!(
         validators,
@@ -78,7 +78,7 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
     );
 
     define_regex_validator!(validators, "repository_name", r"^[\w\-\./]+$");
-    
+
     // The token ID is actually a UUID
     define_regex_validator!(validators, "token_id", r"^[a-f0-9-]{36}$");
 


### PR DESCRIPTION
Something like `aaa.bbb` is a valid NPM username, but the previous validator would consider it invalid because it would not allow the `.` character.