### PR TITLE
Slack API Refactor

### DIFF
--- a/.github/workflows/Integration.yml
+++ b/.github/workflows/Integration.yml
@@ -12,6 +12,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   SLACK_TEST_WEBHOOK: ${{ secrets.SLACK_TEST_WEBHOOK }}
+  SLACK_TEST_BOT_TOKEN: ${{ secrets.SLACK_TEST_BOT_TOKEN }}
 
 jobs:
   ubuntu-cranelift:

--- a/.github/workflows/Integration.yml
+++ b/.github/workflows/Integration.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  SLACK_TEST_WEBHOOK: ${{ secrets.SLACK_TEST_WEBHOOK }}
 
 jobs:
   ubuntu-cranelift:

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -425,6 +425,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_slack"
+version = "0.1.0"
+dependencies = [
+ "plaid_stl",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "test_sshcerts_usage"
 version = "0.1.0"
 dependencies = [

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "tests/test_time",
     "tests/test_shared_db_rule_1",
     "tests/test_shared_db_rule_2",
+    "tests/test_slack",
 ]
 
 [profile.release]

--- a/modules/tests/test_slack/Cargo.toml
+++ b/modules/tests/test_slack/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "test_slack"
+description = "Test rule to check the Slack API works"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+plaid_stl = { path = "../../../runtime/plaid-stl" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+
+[lib]
+crate-type = ["cdylib"]

--- a/modules/tests/test_slack/harness/harness.sh
+++ b/modules/tests/test_slack/harness/harness.sh
@@ -21,17 +21,13 @@ fi
 RH_PID=$!
 
 
-# Define what webhook within Plaid we're going to call
-
-# Check if we're running in GitHub Actions
-
 
 # Call the webhook
 OUTPUT=$(curl -XPOST -d 'slack_input' http://$PLAID_LOCATION/webhook/$URL)
 sleep 2
 kill $RH_PID 2>&1 > /dev/null
 
-echo -e "OK" > expected.txt
+echo -e "OK\nOK\nOK" > expected.txt
 diff expected.txt $FILE
 RESULT=$?
 

--- a/modules/tests/test_slack/harness/harness.sh
+++ b/modules/tests/test_slack/harness/harness.sh
@@ -27,7 +27,7 @@ OUTPUT=$(curl -XPOST -d 'slack_input' http://$PLAID_LOCATION/webhook/$URL)
 sleep 2
 kill $RH_PID 2>&1 > /dev/null
 
-echo -e "OK\nOK\nOK" > expected.txt
+echo -e "OK\nOK\nOK\nOK\nOK" > expected.txt
 diff expected.txt $FILE
 RESULT=$?
 

--- a/modules/tests/test_slack/harness/harness.sh
+++ b/modules/tests/test_slack/harness/harness.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+# If GITHUB_ACTIONS is not set, skip because Plaid won't be running
+# with the Slack API properly configured
+if [ -z "$GITHUB_ACTIONS" ]; then
+  echo "Not running in GitHub Actions, skipping Slack tests"
+  exit 0
+fi
+
+URL="testslack"
+FILE="received_data.$URL.txt"
+
+# Start the webhook
+$REQUEST_HANDLER > $FILE &
+if [ $? -ne 0 ]; then
+  echo "SlackTest: Failed to start request handler"
+  rm $FILE
+  exit 1
+fi
+
+RH_PID=$!
+
+
+# Define what webhook within Plaid we're going to call
+
+# Check if we're running in GitHub Actions
+
+
+# Call the webhook
+OUTPUT=$(curl -XPOST -d 'slack_input' http://$PLAID_LOCATION/webhook/$URL)
+sleep 2
+kill $RH_PID 2>&1 > /dev/null
+
+echo -e "OK" > expected.txt
+diff expected.txt $FILE
+RESULT=$?
+
+rm -f $FILE expected.txt
+
+exit $RESULT

--- a/modules/tests/test_slack/src/lib.rs
+++ b/modules/tests/test_slack/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use plaid_stl::network::make_named_request;
-use plaid_stl::slack::{self, post_message, post_text_to_webhook};
+use plaid_stl::slack::{self, get_presence, post_message, post_text_to_webhook, user_info};
 use plaid_stl::{entrypoint_with_source, messages::LogSource, plaid};
 
 entrypoint_with_source!();
@@ -31,6 +31,31 @@ fn main(log: String, _: LogSource) -> Result<(), i32> {
     ) {
         plaid::print_debug_string("Failed to send Slack message");
         panic!("Couldn't send Slack message")
+    }
+
+    make_named_request("test-response", "OK", HashMap::new()).unwrap();
+
+    match get_presence("plaid-testing", &user_id) {
+        Ok(presence) => {
+            plaid::print_debug_string(&format!("Got user presence as: {}", presence.presence))
+        }
+        Err(_) => {
+            plaid::print_debug_string("Failed to get user presence");
+            panic!("Couldn't get user presence")
+        }
+    }
+
+    make_named_request("test-response", "OK", HashMap::new()).unwrap();
+
+    match user_info("plaid-testing", &user_id) {
+        Ok(info) => plaid::print_debug_string(&format!(
+            "Got user info. Status is: [{}]. TZ is: [{}]",
+            info.user.profile.status_text, info.user.tz_label
+        )),
+        Err(_) => {
+            plaid::print_debug_string("Failed to get user presence");
+            panic!("Couldn't get user presence")
+        }
     }
 
     make_named_request("test-response", "OK", HashMap::new()).unwrap();

--- a/modules/tests/test_slack/src/lib.rs
+++ b/modules/tests/test_slack/src/lib.rs
@@ -1,0 +1,20 @@
+use std::collections::HashMap;
+
+use plaid_stl::network::make_named_request;
+use plaid_stl::slack::post_text_to_webhook;
+use plaid_stl::{entrypoint_with_source, messages::LogSource, plaid};
+
+entrypoint_with_source!();
+
+fn main(log: String, _: LogSource) -> Result<(), i32> {
+    plaid::print_debug_string(&format!("Testing slack APIs with log: {log}"));
+
+    if let Err(_) = post_text_to_webhook("test_webhook", "Testing this makes it to slack") {
+        plaid::print_debug_string("Failed to post to slack");
+        panic!("Couldn't post to slack")
+    }
+
+    make_named_request("test-response", "OK", HashMap::new()).unwrap();
+
+    Ok(())
+}

--- a/modules/tests/test_slack/src/lib.rs
+++ b/modules/tests/test_slack/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use plaid_stl::network::make_named_request;
-use plaid_stl::slack::post_text_to_webhook;
+use plaid_stl::slack::{self, post_message, post_text_to_webhook};
 use plaid_stl::{entrypoint_with_source, messages::LogSource, plaid};
 
 entrypoint_with_source!();
@@ -12,6 +12,25 @@ fn main(log: String, _: LogSource) -> Result<(), i32> {
     if let Err(_) = post_text_to_webhook("test_webhook", "Testing this makes it to slack") {
         plaid::print_debug_string("Failed to post to slack");
         panic!("Couldn't post to slack")
+    }
+
+    make_named_request("test-response", "OK", HashMap::new()).unwrap();
+
+    let user_id = slack::get_id_from_email("plaid-testing", "mitchell@confurious.io")
+        .unwrap_or_else(|_| {
+            plaid::print_debug_string("Failed to get user ID from email");
+            panic!("Couldn't get user ID from email")
+        });
+
+    make_named_request("test-response", "OK", HashMap::new()).unwrap();
+
+    if let Err(_) = post_message(
+        "plaid-testing",
+        &user_id,
+        "Testing that this goes directly to obelisk",
+    ) {
+        plaid::print_debug_string("Failed to send Slack message");
+        panic!("Couldn't send Slack message")
     }
 
     make_named_request("test-response", "OK", HashMap::new()).unwrap();

--- a/runtime/plaid-stl/src/slack/mod.rs
+++ b/runtime/plaid-stl/src/slack/mod.rs
@@ -87,8 +87,7 @@ pub fn post_raw_text_to_webhook(name: &str, log: &str) -> Result<(), i32> {
     Ok(())
 }
 
-/// Definition of the structured data to be sent to the Plaid runtime for opening
-/// a Slack view
+/// Data to be sent to the Plaid runtime for posting a message
 #[derive(Serialize, Deserialize)]
 pub struct PostMessage {
     pub bot: String,
@@ -149,8 +148,7 @@ pub fn post_message_with_blocks(
     Ok(())
 }
 
-/// Definition of the structured data to be sent to the Plaid runtime for opening
-/// a Slack view
+/// Data to be sent to the runtime to open a view
 #[derive(Serialize, Deserialize)]
 pub struct ViewOpen {
     pub bot: String,
@@ -177,8 +175,7 @@ pub fn views_open(bot: &str, view: &str) -> Result<(), PlaidFunctionError> {
     Ok(())
 }
 
-/// Definition of the structured data to be sent to the Plaid runtime for getting
-/// a Slack user's ID from their email address
+/// Data to be sent to the runtime for getting a user's ID from their email address
 #[derive(Serialize, Deserialize)]
 pub struct GetIdFromEmail {
     pub bot: String,

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -53,14 +53,13 @@ test_mode_exemptions = [
     "test_time.wasm",
     "test_shared_db_rule_1.wasm",
     "test_shared_db_rule_2.wasm",
+    "test_slack.wasm",
 ]
 
 
 # Uncomment this to require that all rules be signed by an authorized signer
 [loading.module_signing]
-authorized_signers = [
-    "{plaid-secret{public-key}}",
-]
+authorized_signers = ["{plaid-secret{public-key}}"]
 signatures_required = 1
 
 [loading.persistent_response_size]
@@ -105,6 +104,7 @@ signatures_required = 1
 "test_time.wasm" = "time"
 "test_shared_db_rule_1.wasm" = "test_shareddb_1"
 "test_shared_db_rule_2.wasm" = "test_shareddb_2"
+"test_slack.wasm" = "test_slack"
 
 # Configure the computation amount. See the loader module for more
 # information on how computation cost is calculated.
@@ -131,7 +131,6 @@ default = "Unlimited"
 [loading.storage_size.module_overrides]
 "test_db.wasm" = { Limited = 50 }
 
-
 # [apis."okta"]
 # token = ""
 # domain = ""
@@ -153,6 +152,7 @@ allowed_rules = [
     "test_get_everything.wasm",
     "test_shared_db_rule_1.wasm",
     "test_shared_db_rule_2.wasm",
+    "test_slack.wasm",
 ]
 [apis."general"."network"."web_requests"."test-response"."headers"]
 testheader = "Some data here"
@@ -238,6 +238,7 @@ available_in_test_mode = false
 
 [apis."slack"]
 [apis."slack"."webhooks"]
+test_webhook = "{plaid-secret{test-webhook-secret}}"
 [apis."slack"."bot_tokens"]
 
 [apis."web"]
@@ -373,6 +374,10 @@ headers = []
 
 [webhooks."internal".webhooks."testregex"]
 log_type = "test_regex"
+headers = []
+
+[webhooks."internal".webhooks."testslack"]
+log_type = "test_slack"
 headers = []
 
 

--- a/runtime/plaid/resources/plaid.toml
+++ b/runtime/plaid/resources/plaid.toml
@@ -240,6 +240,7 @@ available_in_test_mode = false
 [apis."slack"."webhooks"]
 test_webhook = "{plaid-secret{test-webhook-secret}}"
 [apis."slack"."bot_tokens"]
+"plaid-testing" = "{plaid-secret{test-slack-bot-token}}"
 
 [apis."web"]
 [apis."web".keys]

--- a/runtime/plaid/resources/secrets.example.toml
+++ b/runtime/plaid/resources/secrets.example.toml
@@ -1,3 +1,4 @@
 "test-secret" = "This is a test secret"
 "public-key" = "{CI_PUBLIC_KEY_PLACEHOLDER}"
 "test-webhook-secret" = "{CI_SLACK_TEST_WEBHOOK}"
+"test-slack-bot-token" = "{CI_SLACK_TEST_BOT_TOKEN}"

--- a/runtime/plaid/resources/secrets.example.toml
+++ b/runtime/plaid/resources/secrets.example.toml
@@ -1,2 +1,3 @@
 "test-secret" = "This is a test secret"
 "public-key" = "{CI_PUBLIC_KEY_PLACEHOLDER}"
+"test-webhook-secret" = "{CI_SLACK_TEST_WEBHOOK}"

--- a/runtime/plaid/src/apis/slack/api.rs
+++ b/runtime/plaid/src/apis/slack/api.rs
@@ -63,16 +63,6 @@ impl Apis {
     }
 }
 
-impl std::fmt::Display for Apis {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::PostMessage => write!(f, "Chat Post Message"),
-            Self::ViewsOpen => write!(f, "Views Open"),
-            Self::LookupByEmail => write!(f, "Users Lookup By Email"),
-        }
-    }
-}
-
 /// Slack user profile as returned by https://api.slack.com/methods/users.lookupByEmail
 #[derive(Serialize, Deserialize)]
 struct SlackUserProfile {
@@ -110,7 +100,7 @@ impl Slack {
             request = request.body(body);
         }
 
-        info!("Calling {api} for bot: {bot_name}");
+        info!("Calling [{}] for bot: {bot_name}", api.get_uri());
         match request.send().await {
             Ok(r) => {
                 let status = r.status();

--- a/runtime/plaid/src/apis/slack/api.rs
+++ b/runtime/plaid/src/apis/slack/api.rs
@@ -1,5 +1,6 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
+use reqwest::{Client, RequestBuilder};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -15,12 +16,59 @@ enum Apis {
     LookupByEmail,
 }
 
+impl Apis {
+    fn get_uri(&self) -> &str {
+        match self {
+            Self::PostMessage => "chat.postMessage",
+            Self::ViewsOpen => "views.open",
+            Self::LookupByEmail => "users.lookupByEmail",
+        }
+    }
+
+    fn build_post_request(client: &Client, api: &Apis, uri_params: String) -> RequestBuilder {
+        client
+            .post(format!(
+                "https://slack.com/api/{}{uri_params}",
+                api.get_uri()
+            ))
+            .header("Content-Type", "application/json; charset=utf-8")
+    }
+
+    fn build_get_request(client: &Client, api: &Apis, uri_params: String) -> RequestBuilder {
+        client.get(format!(
+            "https://slack.com/api/{}{uri_params}",
+            api.get_uri()
+        ))
+    }
+
+    /// Create a request builder and properly configure the API, headers, and authorization token
+    fn request_builder<T: AsRef<str>>(
+        client: &Client,
+        api: &Apis,
+        token: String,
+        uri_params: Option<T>,
+    ) -> RequestBuilder {
+        let uri_params = match uri_params {
+            Some(p) => format!("?{}", p.as_ref()),
+            None => String::new(),
+        };
+
+        let builder = match api {
+            Apis::PostMessage => Self::build_post_request(client, api, uri_params),
+            Apis::ViewsOpen => Self::build_post_request(client, api, uri_params),
+            Apis::LookupByEmail => Self::build_get_request(client, api, uri_params),
+        };
+
+        builder.header("Authorization", token)
+    }
+}
+
 impl std::fmt::Display for Apis {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self {
-            Self::PostMessage => write!(f, "chat.postMessage"),
-            Self::ViewsOpen => write!(f, "views.open"),
-            Self::LookupByEmail => write!(f, "users.lookupByEmail"),
+        match self {
+            Self::PostMessage => write!(f, "Chat Post Message"),
+            Self::ViewsOpen => write!(f, "Views Open"),
+            Self::LookupByEmail => write!(f, "Users Lookup By Email"),
         }
     }
 }
@@ -38,102 +86,81 @@ struct SlackUser {
 
 impl Slack {
     /// Get token for a bot, if present
-    fn get_token(&self, bot: &str) -> Result<String, ()> {
-        let token = self.config.bot_tokens.get(bot).ok_or(())?;
-        Ok(format!("Bearer {token}"))
+    fn get_token(&self, bot: &str) -> Result<String, ApiError> {
+        match self.config.bot_tokens.get(bot) {
+            Some(token) => Ok(format!("Bearer {token}")),
+            None => Err(ApiError::SlackError(SlackError::UnknownBot(
+                bot.to_string(),
+            ))),
+        }
     }
 
-    /// Make a call to the Slack API. Depending on which API we are calling, a GET or a POST are executed.
-    async fn call_slack(&self, params: &str, api: Apis) -> Result<String, ApiError> {
-        let request: HashMap<String, String> =
-            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+    /// Make a call to the Slack API
+    async fn call_slack(
+        &self,
+        bot_name: String,
+        api: Apis,
+        body: Option<String>,
+        uri_params: Option<String>,
+    ) -> Result<(u16, String), ApiError> {
+        let mut request =
+            Apis::request_builder(&self.client, &api, self.get_token(&bot_name)?, uri_params);
 
-        let bot = request
-            .get("bot")
-            .ok_or(ApiError::MissingParameter("bot".to_string()))?
-            .to_string();
+        if let Some(body) = body {
+            request = request.body(body);
+        }
 
-        let token = self.get_token(&bot).map_err(|_| {
-            error!("A module tried to call api {api} for a bot that didn't exist: {bot}");
-            ApiError::SlackError(SlackError::UnknownBot(bot.to_string()))
-        })?;
-
-        info!("Calling {api} for bot: {bot}");
-        match api {
-            Apis::PostMessage | Apis::ViewsOpen => {
-                // It's a POST call
-                let body = request
-                    .get("body")
-                    .ok_or(ApiError::MissingParameter("body".to_string()))?
-                    .to_string();
-                match self
-                    .client
-                    .post(format!("https://slack.com/api/{api}"))
-                    .header("Authorization", token)
-                    .header("Content-Type", "application/json; charset=utf-8")
-                    .body(body)
-                    .send()
-                    .await
-                {
-                    Ok(r) => {
-                        let status = r.status();
-                        if status == 200 {
-                            return Ok("".to_string());
-                        }
-                        let response = r.text().await;
-                        error!("Slack data returned: {}", response.unwrap_or_default());
-
-                        return Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(
-                            status.as_u16(),
-                        )));
-                    }
-                    Err(e) => return Err(ApiError::NetworkError(e)),
-                }
+        info!("Calling {api} for bot: {bot_name}");
+        match request.send().await {
+            Ok(r) => {
+                let status = r.status();
+                let response = r.text().await.unwrap_or_default();
+                trace!("Slack returned: {status}: {response}");
+                Ok((status.as_u16(), response))
             }
-            Apis::LookupByEmail => {
-                // It's a GET call
-                let email = request
-                    .get("email")
-                    .ok_or(ApiError::MissingParameter("email".to_string()))?
-                    .to_string();
-                match self
-                    .client
-                    .get(format!("https://slack.com/api/{api}?email={email}"))
-                    .header("Authorization", token)
-                    .send()
-                    .await
-                {
-                    Ok(r) => {
-                        let status = r.status();
-                        if status == 200 {
-                            let response = r.json::<SlackUserProfile>().await.map_err(|_| {
-                                ApiError::SlackError(SlackError::UnexpectedPayload(
-                                    "could not deserialize to Slack user profile".to_string(),
-                                ))
-                            })?;
-                            return Ok(response.user.id);
-                        }
-                        error!("Failed to retrieve user's Slack ID");
-                        return Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(
-                            status.as_u16(),
-                        )));
-                    }
-                    Err(e) => return Err(ApiError::NetworkError(e)),
-                }
-            }
+            Err(e) => return Err(ApiError::NetworkError(e)),
         }
     }
 
     /// Open an arbitrary view for a configured bot. The view contents is defined by the caller but the bot
     /// must be configured in Plaid.
     pub async fn views_open(&self, params: &str, _: Arc<PlaidModule>) -> Result<u32, ApiError> {
-        self.call_slack(params, Apis::ViewsOpen).await.map(|_| 0)
+        let params: plaid_stl::slack::ViewOpen =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        match self
+            .call_slack(params.bot, Apis::ViewsOpen, Some(params.body), None)
+            .await
+        {
+            Ok((200, _)) => Ok(0),
+            Ok((status, _)) => {
+                error!("Slack returned unexpected status code: {status}");
+                Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(
+                    status,
+                )))
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Call the Slack postMessage API. The message and location are defined by the module but the bot
     /// must be configured in Plaid.
     pub async fn post_message(&self, params: &str, _: Arc<PlaidModule>) -> Result<u32, ApiError> {
-        self.call_slack(params, Apis::PostMessage).await.map(|_| 0)
+        let params: plaid_stl::slack::PostMessage =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        match self
+            .call_slack(params.bot, Apis::PostMessage, Some(params.body), None)
+            .await
+        {
+            Ok((200, _)) => Ok(0),
+            Ok((status, _)) => {
+                error!("Slack returned unexpected status code: {status}");
+                Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(
+                    status,
+                )))
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Calls the Slack API to retrieve a user's Slack ID from their email address
@@ -142,6 +169,28 @@ impl Slack {
         params: &str,
         _: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        self.call_slack(params, Apis::LookupByEmail).await
+        let params: plaid_stl::slack::GetIdFromEmail =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        match self
+            .call_slack(params.bot, Apis::LookupByEmail, None, Some(params.email))
+            .await
+        {
+            Ok((200, response)) => {
+                let response: SlackUserProfile = serde_json::from_str(&response).map_err(|_| {
+                    ApiError::SlackError(SlackError::UnexpectedPayload(
+                        "could not deserialize to Slack user profile".to_string(),
+                    ))
+                })?;
+                Ok(response.user.id)
+            }
+            Ok((status, _)) => {
+                error!("Slack returned unexpected status code: {status}");
+                Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(
+                    status,
+                )))
+            }
+            Err(e) => Err(e),
+        }
     }
 }

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -375,6 +375,8 @@ impl_new_function!(slack, post_message, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(slack, get_id_from_email, ALLOW_IN_TEST_MODE);
 impl_new_function!(slack, post_to_arbitrary_webhook, ALLOW_IN_TEST_MODE);
 impl_new_function!(slack, post_to_named_webhook, ALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(slack, get_presence, ALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(slack, user_info, ALLOW_IN_TEST_MODE);
 
 // Splunk Functions
 impl_new_function!(splunk, post_hec, ALLOW_IN_TEST_MODE);
@@ -611,6 +613,8 @@ pub fn to_api_function(
         "slack_get_id_from_email" => {
             Function::new_typed_with_env(&mut store, &env, slack_get_id_from_email)
         }
+        "slack_get_presence" => Function::new_typed_with_env(&mut store, &env, slack_get_presence),
+        "slack_user_info" => Function::new_typed_with_env(&mut store, &env, slack_user_info),
 
         // General Calls
         "general_simple_json_post_request" => {

--- a/testing/integration.sh
+++ b/testing/integration.sh
@@ -51,10 +51,12 @@ if uname | grep -q Darwin; then
     # macOS (BSD sed)
     sed -i '' "s|{CI_PUBLIC_KEY_PLACEHOLDER}|$public_key|g" $SECRET_WORKING_PATH
     sed -i '' "s|{CI_SLACK_TEST_WEBHOOK}|$SLACK_TEST_WEBHOOK|g" $SECRET_WORKING_PATH
+    sed -i '' "s|{CI_SLACK_TEST_BOT_TOKEN}|$SLACK_TEST_BOT_TOKEN|g" $SECRET_WORKING_PATH
 else
     # Linux (GNU sed)
     sed -i "s|{CI_PUBLIC_KEY_PLACEHOLDER}|$public_key|g" $SECRET_WORKING_PATH
     sed -i "s|{CI_SLACK_TEST_WEBHOOK}|$SLACK_TEST_WEBHOOK|g" $SECRET_WORKING_PATH
+    sed -i "s|{CI_SLACK_TEST_BOT_TOKEN}|$SLACK_TEST_BOT_TOKEN|g" $SECRET_WORKING_PATH
 fi
 
 # Clear out the module_signatures directory

--- a/testing/integration.sh
+++ b/testing/integration.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
-# Build all of the Plaid workspace
+# Set up all the variables we need to run the integration tests
 PLATFORM=$(uname -a)
-CONFIG_PATH="plaid/resources/plaid.toml"
+
+CONFIG_PATH="runtime/plaid/resources/plaid.toml"
+CONFIG_WORKING_PATH=/tmp/plaid_config.toml
+
+SECRET_PATH="runtime/plaid/resources/secrets.example.toml"
+SECRET_WORKING_PATH=/tmp/secrets.example.toml
+
+export REQUEST_HANDLER=$(pwd)/runtime/target/release/request_handler
+
 
 # Compiler should be passed in as the first argument
 if [ -z "$1" ]; then
@@ -12,6 +20,10 @@ fi
 echo "Testing runtime with compiler: $1"
 
 
+# Copy the configuration and secrets to the tmp directory
+cp $CONFIG_PATH $CONFIG_WORKING_PATH
+cp $SECRET_PATH $SECRET_WORKING_PATH
+
 # On macOS, we need to install a brew provided version of LLVM
 # so that we can compile WASM binaries.
 if uname | grep -q Darwin; then
@@ -19,7 +31,7 @@ if uname | grep -q Darwin; then
   PATH="/opt/homebrew/opt/llvm/bin:$PATH"
 fi
 
-export REQUEST_HANDLER=$(pwd)/runtime/target/release/request_handler
+
 
 echo "Building All Plaid Modules"
 cd modules
@@ -34,13 +46,21 @@ cp -r modules/target/wasm32-unknown-unknown/release/test_*.wasm compiled_modules
 ssh-keygen -t ed25519 -f plaidrules_key_ed25519 -N ""
 public_key=$(cat plaidrules_key_ed25519.pub | awk '{printf "%s %s %s", $1, $2, $3}')
 
+# Do any needed replacements within the secrets file
 if uname | grep -q Darwin; then
     # macOS (BSD sed)
-    sed -i '' "s|{CI_PUBLIC_KEY_PLACEHOLDER}|$public_key|g" ./runtime/plaid/resources/secrets.example.toml
+    sed -i '' "s|{CI_PUBLIC_KEY_PLACEHOLDER}|$public_key|g" $SECRET_WORKING_PATH
+    sed -i '' "s|{CI_SLACK_TEST_WEBHOOK}|$SLACK_TEST_WEBHOOK|g" $SECRET_WORKING_PATH
 else
     # Linux (GNU sed)
-    sed -i "s|{CI_PUBLIC_KEY_PLACEHOLDER}|$public_key|g" ./runtime/plaid/resources/secrets.example.toml
+    sed -i "s|{CI_PUBLIC_KEY_PLACEHOLDER}|$public_key|g" $SECRET_WORKING_PATH
+    sed -i "s|{CI_SLACK_TEST_WEBHOOK}|$SLACK_TEST_WEBHOOK|g" $SECRET_WORKING_PATH
 fi
+
+# Clear out the module_signatures directory
+rm -rf module_signatures/*
+# Remove the old sled database if there is one (happens on repeated test runs)
+rm -rf /tmp/sled
 
 # Create module signatures directory
 mkdir module_signatures
@@ -71,9 +91,7 @@ cd runtime
 if [ "$1" == "llvm" ]; then
   # If the compiler is llvm, modify the plaid.toml file to use the llvm backend
   # and save to a new file
-  cp plaid/resources/plaid.toml plaid/resources/plaid.llvm.toml
-  sed -i.bak 's/compiler_backend = "cranelift"/compiler_backend = "llvm"/g' plaid/resources/plaid.llvm.toml && rm plaid/resources/plaid.llvm.toml.bak
-  CONFIG_PATH="plaid/resources/plaid.llvm.toml"
+  sed -i.bak 's/compiler_backend = "cranelift"/compiler_backend = "llvm"/g' $CONFIG_WORKING_PATH && rm $CONFIG_WORKING_PATH.bak
   # If macOS
   if  uname | grep -q Darwin; then
     export RUSTFLAGS="-L /opt/homebrew/lib/"
@@ -87,7 +105,7 @@ if [ $? -ne 0 ]; then
   # Exit with an error
   exit 1
 fi
-RUST_LOG=plaid=debug cargo run --bin=plaid --release --no-default-features --features sled,$1 -- --config ${CONFIG_PATH} --secrets plaid/resources/secrets.example.toml &
+RUST_LOG=plaid=debug cargo run --bin=plaid --release --no-default-features --features sled,$1 -- --config ${CONFIG_WORKING_PATH} --secrets $SECRET_WORKING_PATH &
 PLAID_PID=$!
 cd ..
 sleep 60
@@ -101,6 +119,7 @@ for module in modules/tests/*; do
   if [ -d "$module" ]; then
     # If the module has a harness.sh file
     if [ -f "$module/harness/harness.sh" ]; then
+      echo "Running integration test for module $module"
       # Run the harness.sh file
       bash $module/harness/harness.sh
       # If the harness.sh file returns an error


### PR DESCRIPTION
I revisited the Slack API because I wanted to add the ability to fetch user info (specifically timezone data) and I was unhappy with how I previously structured the code. There was no clear separation of responsibilities and it was hard to see how APIs were implemented and especially difficult to add new ones. 

This changes all of that and couples the STL and the Plaid library together to throw compile time errors for inconsistencies rather than runtime `ApiError::MissingParameter` errors.