### PR TITLE
Add GitHub request reviewers

### DIFF
--- a/runtime/plaid/src/apis/github/mod.rs
+++ b/runtime/plaid/src/apis/github/mod.rs
@@ -6,6 +6,7 @@ mod environments;
 mod graphql;
 mod members;
 mod pats;
+mod pull_requests;
 mod repos;
 mod secrets;
 mod teams;

--- a/runtime/plaid/src/apis/github/pull_requests.rs
+++ b/runtime/plaid/src/apis/github/pull_requests.rs
@@ -1,0 +1,67 @@
+use plaid_stl::github::PullRequestRequestReviewers;
+use serde::Serialize;
+
+use super::Github;
+use crate::{
+    apis::{github::GitHubError, ApiError},
+    loader::PlaidModule,
+};
+use std::sync::Arc;
+
+impl Github {
+    /// Add reviewers to a pull request
+    pub async fn pull_request_request_reviewers(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<bool, ApiError> {
+        #[derive(Serialize)]
+        struct RequestReviewers {
+            reviewers: Vec<String>,
+            team_reviewers: Vec<String>,
+        }
+        let request: PullRequestRequestReviewers =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        // Parse out all the parameters from our parameter string
+        let owner = self.validate_org(&request.owner)?;
+        let repo = self.validate_repository_name(&request.repo)?;
+        let pull_number = request.pull_number;
+
+        for reviewer in &request.reviewers {
+            self.validate_username(&reviewer)?;
+        }
+
+        for team in &request.team_reviewers {
+            self.validate_team_slug(&team)?;
+        }
+
+        info!("Requesting reviews from users: [{}] and teams: [{}] on [{owner}/{repo}/{pull_number}] org on behalf of {module}", request.reviewers.join(", "), request.team_reviewers.join(", "));
+
+        let address = format!("/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers");
+
+        let body = RequestReviewers {
+            reviewers: request.reviewers.clone(),
+            team_reviewers: request.team_reviewers.clone(),
+        };
+
+        match self.make_generic_post_request(address, body, module).await {
+            Ok((status, Ok(_))) => {
+                if status == 201 {
+                    Ok(true)
+                } else if status == 404 {
+                    Ok(false)
+                } else if status == 422 {
+                    warn!("Some of the reviewers or teams are not collaborators on this repository. Context: [{owner}/{repo}/{pull_number}]. Users: [{}] and teams: [{}]", request.reviewers.join(", "), request.team_reviewers.join(", "));
+                    Ok(false)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -322,6 +322,11 @@ impl_new_function_with_error_buffer!(github, add_users_to_org_copilot, DISALLOW_
 impl_new_function_with_error_buffer!(github, remove_users_from_org_copilot, DISALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, get_custom_properties_values, ALLOW_IN_TEST_MODE);
 impl_new_function!(github, comment_on_pull_request, DISALLOW_IN_TEST_MODE);
+impl_new_function!(
+    github,
+    pull_request_request_reviewers,
+    DISALLOW_IN_TEST_MODE
+);
 
 // GitHub Functions only available with GitHub App authentication
 impl_new_function!(github, review_fpat_requests_for_org, DISALLOW_IN_TEST_MODE);
@@ -599,6 +604,9 @@ pub fn to_api_function(
         }
         "github_delete_deploy_key" => {
             Function::new_typed_with_env(&mut store, &env, github_delete_deploy_key)
+        }
+        "github_pull_request_request_reviewers" => {
+            Function::new_typed_with_env(&mut store, &env, github_pull_request_request_reviewers)
         }
 
         // Slack Calls


### PR DESCRIPTION
## This needs to be landed after the Slack API refactor.

This ads a new GitHub API for requesting reviewers on PRs. Otherwise it's pretty simple but uses the new strict variable passing mechanism of PlaidSTL structs serialized on both ends.