### PR TITLE
Support pagination in data generators

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -180,7 +180,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -201,16 +201,17 @@ impl DataGenerator for &mut Github {
                 ._get(&next.clone().unwrap())
                 .await
                 .map_err(|e| {
-                    let err_str = format!("Could not get logs from GitHub: {}", e);
-                    error!("{}", err_str);
+                    error!("{}", format!("Could not get logs from GitHub: {}", e));
                 })?;
 
             if !response.status().is_success() {
-                let err_str = format!(
-                    "Call to get GitHub logs failed with code: {}",
-                    response.status()
+                error!(
+                    "{}",
+                    format!(
+                        "Call to get GitHub logs failed with code: {}",
+                        response.status()
+                    )
                 );
-                error!("{}", err_str);
                 return Err(());
             }
 
@@ -223,13 +224,14 @@ impl DataGenerator for &mut Github {
 
             // Parse the response's body
             let body = self.client.body_to_string(response).await.map_err(|e| {
-                let err_str = format!("Failed to read body of GitHub response. Error: {e}");
-                error!("{}", err_str);
+                error!(
+                    "{}",
+                    format!("Failed to read body of GitHub response. Error: {e}")
+                );
             })?;
 
             let logs: Vec<Value> = serde_json::from_str(body.as_str()).map_err(|e| {
-                let err_str = format!("Could not parse data from Github: {}\n\n{}", e, body);
-                error!("{}", err_str);
+                error!("{}", format!("Could not parse data from Github: {}", e));
             })?;
 
             if logs.is_empty() {

--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -190,8 +190,8 @@ impl DataGenerator for &mut Github {
             self.config.org, self.config.log_type
         );
 
-        let mut output_logs: Vec<DataGeneratorLog> = Vec::new();
-        let mut next: Option<String> = Some(address);
+        let mut output_logs = vec![];
+        let mut next = Some(address);
 
         loop {
             // At this point we know `next` is Some. Either because this is the first request, or

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -335,17 +335,6 @@ pub async fn get_and_process_dg_logs(mut dg: impl DataGenerator) -> Result<(), (
                 dg.get_name(),
                 dg.get_last_seen()
             );
-
-            // Important: we have to move the window forward. Otherwise, on the next call nothing will
-            // change: with the same `since`, we will get the same logs and we will discard them all because
-            // they will all be in the cache. I.e., the system will enter a deadlock.
-            // To prevent this, we move `since` forward by a portion of the lookback window.
-            // This ensures that, eventually, we will get some new logs.
-            dg.set_last_seen(
-                dg.get_last_seen()
-                    .saturating_add(time::Duration::milliseconds(500)),
-            );
-
             return Ok(());
         }
         info!(

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -205,7 +205,7 @@ pub trait DataGenerator {
     fn get_name(&self) -> String;
 
     /// Get the duration (in milliseconds) the thread will sleep for, after fetching a page of logs
-    fn get_sleep_duration(&self) -> u64; // TODO remove?
+    fn get_sleep_duration(&self) -> u64;
 
     /// Get the number of seconds after which we assume the external API we are querying for logs
     /// reaches stability. This means that we assume all events that have happened at least these many

--- a/runtime/plaid/src/data/okta/mod.rs
+++ b/runtime/plaid/src/data/okta/mod.rs
@@ -156,8 +156,6 @@ impl DataGenerator for &mut Okta {
             }
         };
 
-        // TODO Maybe remove configurability for sortOrder. With this new system, only ASCENDING
-        // really makes sense. Otherwise we are most likely going to miss older logs.
         let address = format!(
             "https://{}/api/v1/logs?sortOrder={}&since={since}&until={until}&limit={}",
             self.config.domain, self.config.log_sorting, self.config.limit
@@ -208,7 +206,7 @@ impl DataGenerator for &mut Okta {
 
             // Attempt to deserialize the response from Okta
             let logs: Vec<Value> = serde_json::from_str(body.as_str())
-                .map_err(|e| error!("Could not parse data from Okta: {e}\n\n{body}"))?;
+                .map_err(|e| error!("Could not parse data from Okta: {e}"))?;
 
             if logs.is_empty() {
                 return Ok(output_logs);
@@ -223,7 +221,7 @@ impl DataGenerator for &mut Okta {
                 {
                     Some(published) => published,
                     None => {
-                        error!("Missing or invalid 'published' field in Okta log: {log:?}",);
+                        error!("Missing or invalid 'published' field in Okta log",);
                         continue;
                     }
                 };
@@ -243,7 +241,7 @@ impl DataGenerator for &mut Okta {
                 {
                     Some(uuid) => uuid,
                     None => {
-                        error!("Missing or invalid 'uuid' field in Okta log: {log:?}",);
+                        error!("Missing or invalid 'uuid' field in Okta log",);
                         continue;
                     }
                 };

--- a/runtime/plaid/src/data/okta/mod.rs
+++ b/runtime/plaid/src/data/okta/mod.rs
@@ -161,8 +161,8 @@ impl DataGenerator for &mut Okta {
             self.config.domain, self.config.log_sorting, self.config.limit
         );
 
-        let mut output_logs: Vec<DataGeneratorLog> = Vec::new();
-        let mut next: Option<String> = Some(address);
+        let mut output_logs = vec![];
+        let mut next = Some(address);
 
         loop {
             // At this point we know `next` is Some. Either because this is the first request, or

--- a/runtime/plaid/src/data/okta/mod.rs
+++ b/runtime/plaid/src/data/okta/mod.rs
@@ -154,97 +154,112 @@ impl DataGenerator for &mut Okta {
             self.config.domain, self.config.log_sorting, self.config.limit
         );
 
-        let response = self
-            .client
-            .get(address)
-            .header("Accept", "application/json")
-            .header("Authorization", format!("SSWS {}", self.config.token))
-            .send()
-            .await
-            .map_err(|e| {
-                error!("Could not get logs from Okta: {e}");
-            })?;
+        let mut output_logs: Vec<DataGeneratorLog> = Vec::new();
+        let mut next: Option<String> = Some(address);
 
-        // Check the response status code
-        // If it's outside of the 2XX range, we log the error and exit the loop, allowing the
-        // data generator to handle a restart
-        if !response.status().is_success() {
-            let status = response.status();
-            let error_body = response.text().await.ok();
-            error!(
-                "Call to Okta API failed with code: {status}. Error: {}",
-                error_body.unwrap_or_default()
-            );
-            return Err(());
-        }
+        loop {
+            // At this point we know `next` is Some. Either because this is the first request, or
+            // because we are here after checking it's not None (which would have stopped the loop).
+            let response = self
+                .client
+                .get(next.unwrap())
+                .header("Accept", "application/json")
+                .header("Authorization", format!("SSWS {}", self.config.token))
+                .send()
+                .await
+                .map_err(|e| {
+                    error!("Could not get logs from Okta: {e}");
+                })?;
 
-        // Get the body from the response from Okta
-        let body = response
-            .text()
-            .await
-            .map_err(|e| error!("Could not get logs from Okta: {e}"))?;
+            // Check the response status code
+            // If it's outside of the 2XX range, we log the error and exit the loop, allowing the
+            // data generator to handle a restart
+            if !response.status().is_success() {
+                let status = response.status();
+                let error_body = response.text().await.ok();
+                error!(
+                    "Call to Okta API failed with code: {status}. Error: {}",
+                    error_body.unwrap_or_default()
+                );
+                return Err(());
+            }
 
-        // Attempt to deserialize the response from Okta
-        let logs: Vec<Value> = serde_json::from_str(body.as_str())
-            .map_err(|e| error!("Could not parse data from Okta: {e}"))?;
+            // See if there is another page of logs after this by looking at the `link` header
+            // https://developer.okta.com/docs/api/#link-header
+            next = response
+                .headers()
+                .get("link")
+                .and_then(|v| super::get_next_from_link_header(v));
 
-        // If there have been no new logs since we last polled, we can exit the loop early
-        // Exiting here will result in a 10 second wait between restarts
-        if logs.is_empty() {
-            debug!("No new Okta logs since: {}", self.last_seen);
-            return Ok(vec![]);
-        }
+            // Get the body from the response from Okta
+            let body = response
+                .text()
+                .await
+                .map_err(|e| error!("Could not get logs from Okta: {e}"))?;
 
-        // Loop over the logs we did get from Okta, attempt to parse their timestamps, and return a vector of such logs
-        let mut output_logs: Vec<DataGeneratorLog> = Vec::with_capacity(logs.len());
+            // Attempt to deserialize the response from Okta
+            let logs: Vec<Value> = serde_json::from_str(body.as_str())
+                .map_err(|e| error!("Could not parse data from Okta: {e}\n\n{body}"))?;
 
-        for log in &logs {
-            let published = match log
-                .as_object()
-                .and_then(|obj| obj.get(OKTA_LOG_PUBLISHED_FIELD_KEY))
-                .and_then(|val| val.as_str())
-            {
-                Some(published) => published,
-                None => {
-                    error!("Missing or invalid 'published' field in Okta log",);
-                    continue;
-                }
-            };
+            if logs.is_empty() {
+                return Ok(output_logs);
+            }
 
-            let log_timestamp = match OffsetDateTime::parse(published, &Rfc3339) {
-                Ok(dt) => dt,
-                Err(_) => {
-                    error!("Got an invalid date from Okta: {}", published);
-                    continue;
-                }
-            };
+            // Loop over the logs we got from Okta, parse them and add them to the growing vector
+            for log in &logs {
+                let published = match log
+                    .as_object()
+                    .and_then(|obj| obj.get(OKTA_LOG_PUBLISHED_FIELD_KEY))
+                    .and_then(|val| val.as_str())
+                {
+                    Some(published) => published,
+                    None => {
+                        error!("Missing or invalid 'published' field in Okta log: {log:?}",);
+                        continue;
+                    }
+                };
 
-            let uuid = match log
-                .as_object()
-                .and_then(|obj| obj.get(OKTA_LOG_UUID_FIELD_KEY))
-                .and_then(|val| val.as_str())
-            {
-                Some(uuid) => uuid,
-                None => {
-                    error!("Missing or invalid 'uuid' field in Okta log",);
-                    continue;
-                }
-            };
+                let log_timestamp = match OffsetDateTime::parse(published, &Rfc3339) {
+                    Ok(dt) => dt,
+                    Err(_) => {
+                        error!("Got an invalid date from Okta: {}", published);
+                        continue;
+                    }
+                };
 
-            // Attempt to parse the log received from Okta to bytes.
-            let log_bytes = match serde_json::to_vec(&log) {
-                Ok(bytes) => bytes,
-                Err(e) => {
-                    error!("Failed to serialize Okta logs to bytes. Error: {e}");
-                    continue;
-                }
-            };
+                let uuid = match log
+                    .as_object()
+                    .and_then(|obj| obj.get(OKTA_LOG_UUID_FIELD_KEY))
+                    .and_then(|val| val.as_str())
+                {
+                    Some(uuid) => uuid,
+                    None => {
+                        error!("Missing or invalid 'uuid' field in Okta log: {log:?}",);
+                        continue;
+                    }
+                };
 
-            output_logs.push(DataGeneratorLog {
-                id: uuid.to_string(),
-                timestamp: log_timestamp,
-                payload: log_bytes,
-            });
+                // Attempt to parse the log received from Okta to bytes.
+                let log_bytes = match serde_json::to_vec(&log) {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        error!("Failed to serialize Okta logs to bytes. Error: {e}");
+                        continue;
+                    }
+                };
+
+                output_logs.push(DataGeneratorLog {
+                    id: uuid.to_string(),
+                    timestamp: log_timestamp,
+                    payload: log_bytes,
+                });
+            }
+
+            // Exit the loop if there is no next page
+            if next.is_none() {
+                break;
+            }
+            // Otherwise we are ready for the next request
         }
 
         Ok(output_logs)


### PR DESCRIPTION
Add support for pagination to `GitHub` and `Okta` data generators. This is done by leveraging the `link` header, which is included by both APIs in a multi-page response.

With this change, we mandate that `fetch_logs` return all logs that happened in the `since..until` time span. If this requires handling pagination, this must be done inside this function.

Note: we also remove the mechanism known as "kicking the window", where we were manually changing `last_seen` to ensure the data generator did not get stuck. The reason is that now we don't limit ourselves to the first page of logs: instead we fetch all the logs in the `since..until` time span. Therefore, as `until` naturally moves forward (since it's calculated as `now - canon_time`) we will automatically get newer logs together with older ones, which will be discarded thanks to the cache.

TODO
- [x] Make cache size configurable