### PR TITLE
Clean up error logs in data generators

### DIFF
--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -181,27 +181,29 @@ impl DataGenerator for &mut Github {
         );
 
         let response = self.client._get(&address).await.map_err(|e| {
-            let err_str = format!("Could not get logs from GitHub: {}", e);
-            error!("{}", err_str);
+            error!("{}", format!("Could not get logs from GitHub: {}", e));
         })?;
 
         if !response.status().is_success() {
-            let err_str = format!(
-                "Call to get GitHub logs failed with code: {}",
-                response.status()
+            error!(
+                "{}",
+                format!(
+                    "Call to get GitHub logs failed with code: {}",
+                    response.status()
+                )
             );
-            error!("{}", err_str);
             return Err(());
         }
 
         let body = self.client.body_to_string(response).await.map_err(|e| {
-            let err_str = format!("Failed to read body of GitHub response. Error: {e}");
-            error!("{}", err_str);
+            error!(
+                "{}",
+                format!("Failed to read body of GitHub response. Error: {e}")
+            );
         })?;
 
         let logs: Vec<Value> = serde_json::from_str(body.as_str()).map_err(|e| {
-            let err_str = format!("Could not parse data from Github: {}\n\n{}", e, body);
-            error!("{}", err_str);
+            error!("{}", format!("Could not parse data from Github: {e}"));
         })?;
 
         // If there have been no new logs since we last polled, we can exit the loop early

--- a/runtime/plaid/src/data/okta/mod.rs
+++ b/runtime/plaid/src/data/okta/mod.rs
@@ -187,7 +187,7 @@ impl DataGenerator for &mut Okta {
 
         // Attempt to deserialize the response from Okta
         let logs: Vec<Value> = serde_json::from_str(body.as_str())
-            .map_err(|e| error!("Could not parse data from Okta: {e}\n\n{body}"))?;
+            .map_err(|e| error!("Could not parse data from Okta: {e}"))?;
 
         // If there have been no new logs since we last polled, we can exit the loop early
         // Exiting here will result in a 10 second wait between restarts
@@ -207,7 +207,7 @@ impl DataGenerator for &mut Okta {
             {
                 Some(published) => published,
                 None => {
-                    error!("Missing or invalid 'published' field in Okta log: {log:?}",);
+                    error!("Missing or invalid 'published' field in Okta log",);
                     continue;
                 }
             };
@@ -227,7 +227,7 @@ impl DataGenerator for &mut Okta {
             {
                 Some(uuid) => uuid,
                 None => {
-                    error!("Missing or invalid 'uuid' field in Okta log: {log:?}",);
+                    error!("Missing or invalid 'uuid' field in Okta log",);
                     continue;
                 }
             };


### PR DESCRIPTION
Do not log too much information (e.g., the full response body or the full log) when an error occurs in the GitHub or Okta data generators.