### PR TITLE
Increase sleep duration when fetching Okta logs

### DIFF
--- a/runtime/plaid/src/data/okta/mod.rs
+++ b/runtime/plaid/src/data/okta/mod.rs
@@ -26,7 +26,6 @@ pub struct OktaConfig {
     limit: u16,
     /// Number of milliseconds to wait in between calls to the Okta API.
     /// Okta enforces a rate limit of 50 calls/sec for the `/logs` endpoint.
-    /// If no value is provided here, we will default to 1 milliseconds between calls
     #[serde(default = "default_sleep_milliseconds")]
     sleep_duration: u64,
     /// How we ask the Okta API to sort logs. This can be "ASCENDING" (from oldest to newest)
@@ -68,7 +67,7 @@ where
 /// It is used as the default value for deserialization of the `sleep_duration` field,
 /// of `OktaConfig` in the event that no value is provided.
 fn default_sleep_milliseconds() -> u64 {
-    1
+    1000
 }
 
 fn default_canon_time() -> u64 {


### PR DESCRIPTION
On a successful call to Okta's `/logs` endpoint, i.e., a call that yields new logs, we now sleep for 1 second before making a new request.

The previous value (1 ms) was not "wrong" but it made it likely for this to happen:
* call `/logs` and get some new logs
* sleep for 1 ms
* call `/logs` and get the same logs (very likely because so little time has passed)
* exit the loop, which will cause the thread to sleep for 10 seconds

With this change, we increase the probability that new logs come in during the sleep time, thus pulling in logs at a more consistent pace.

@wbssbw Unless I am missing something and there was a reason to set that value so low.