### PR TITLE
Per-MNR timeout & certificate support

### DIFF
--- a/runtime/plaid/resources/config/apis.toml
+++ b/runtime/plaid/resources/config/apis.toml
@@ -2,7 +2,7 @@
 [apis."general".network.web_requests]
 [apis."general"."network"."web_requests"."test-response"]
 verb = "post"
-uri = "http://localhost:8998/response"
+uri = "https://localhost:8998/response"
 return_body = true
 return_code = true
 allowed_rules = [
@@ -17,32 +17,44 @@ allowed_rules = [
     "test_shared_db_rule_2.wasm",
     "test_slack.wasm",
 ]
+root_certificate = """
+{plaid-secret{integration-test-root-ca}}
+"""
 [apis."general"."network"."web_requests"."test-response"."headers"]
 testheader = "Some data here"
 
 [apis."general"."network"."web_requests"."test-response-mnr"]
 verb = "post"
-uri = "http://localhost:8998/testmnr"
+uri = "https://localhost:8998/testmnr"
 return_body = true
 return_code = true
 allowed_rules = ["test_mnr.wasm"]
+root_certificate = """
+{plaid-secret{integration-test-root-ca}}
+"""
 [apis."general"."network"."web_requests"."test-response-mnr"."headers"]
 
 [apis."general"."network"."web_requests"."test-response-mnr-headers"]
 verb = "post"
-uri = "http://localhost:8998/testmnr/headers"
+uri = "https://localhost:8998/testmnr/headers"
 return_body = true
 return_code = true
 allowed_rules = ["test_mnr.wasm"]
+root_certificate = """
+{plaid-secret{integration-test-root-ca}}
+"""
 [apis."general"."network"."web_requests"."test-response-mnr-headers"."headers"]
 first_header = "first_value"
 
 [apis."general"."network"."web_requests"."test-response-mnr-vars"]
 verb = "post"
-uri = "http://localhost:8998/testmnr/{variable}"
+uri = "https://localhost:8998/testmnr/{variable}"
 return_body = true
 return_code = true
 allowed_rules = ["test_mnr.wasm"]
+root_certificate = """
+{plaid-secret{integration-test-root-ca}}
+"""
 [apis."general"."network"."web_requests"."test-response-mnr-vars"."headers"]
 
 [apis."general"."network"."web_requests"."google_test"]

--- a/runtime/plaid/resources/secrets.example.toml
+++ b/runtime/plaid/resources/secrets.example.toml
@@ -2,3 +2,4 @@
 "public-key" = "{CI_PUBLIC_KEY_PLACEHOLDER}"
 "test-webhook-secret" = "{CI_SLACK_TEST_WEBHOOK}"
 "test-slack-bot-token" = "{CI_SLACK_TEST_BOT_TOKEN}"
+"integration-test-root-ca" = """{CI_CERTIFICATE_PLACEHOLDER}"""

--- a/runtime/plaid/src/apis/general/mod.rs
+++ b/runtime/plaid/src/apis/general/mod.rs
@@ -8,7 +8,7 @@ use reqwest::Client;
 use ring::rand::SystemRandom;
 use serde::Deserialize;
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use crate::{data::DelayedMessage, executor::Message};
 
@@ -17,7 +17,7 @@ use super::default_timeout_seconds;
 #[derive(Deserialize)]
 pub struct GeneralConfig {
     /// Configuration for network requests
-    network: network::Config,
+    pub network: network::Config,
     /// The number of seconds until an external API request times out.
     /// If no value is provided, the result of `default_timeout_seconds()` will be used.
     #[serde(default = "default_timeout_seconds")]
@@ -28,7 +28,7 @@ pub struct General {
     /// General Plaid configuration
     config: GeneralConfig,
     /// Client to make requests with
-    client: Client,
+    clients: Clients,
     /// Sender object for messages
     log_sender: Sender<Message>,
     /// Sender object for messages that must be processed with a delay
@@ -37,22 +37,62 @@ pub struct General {
     system_random: SystemRandom,
 }
 
+/// Holds the default HTTP client plus any named clients with per-request customizations.
+pub struct Clients {
+    /// The default `Client` used for requests without custom timeouts or certificates.
+    default: Client,
+    /// Named `Client` instances configured with custom timeouts or root certificates.
+    specialized: HashMap<String, Client>,
+}
+
+impl Clients {
+    fn new(config: &GeneralConfig) -> Self {
+        let default_timeout_duration = Duration::from_secs(config.api_timeout_seconds);
+        let default = reqwest::Client::builder()
+            .timeout(default_timeout_duration)
+            .build()
+            .unwrap();
+
+        let specialized = config
+            .network
+            .web_requests
+            .iter()
+            .filter_map(|(name, req)| {
+                if req.timeout.is_some() || req.root_certificate.is_some() {
+                    let mut builder = reqwest::Client::builder()
+                        .timeout(req.timeout.unwrap_or(default_timeout_duration));
+
+                    if let Some(ca) = req.root_certificate.clone() {
+                        builder = builder.add_root_certificate(ca);
+                    }
+
+                    let client = builder.build().unwrap();
+                    Some((name.clone(), client))
+                } else {
+                    None
+                }
+            })
+            .collect::<HashMap<String, Client>>();
+
+        Self {
+            default,
+            specialized,
+        }
+    }
+}
+
 impl General {
     pub fn new(
         config: GeneralConfig,
         log_sender: Sender<Message>,
         delayed_log_sender: Sender<DelayedMessage>,
     ) -> Self {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(config.api_timeout_seconds))
-            .build()
-            .unwrap();
-
+        let clients = Clients::new(&config);
         let system_random = SystemRandom::new();
 
         Self {
             config,
-            client,
+            clients,
             log_sender,
             delayed_log_sender,
             system_random,

--- a/runtime/plaid/src/apis/general/network.rs
+++ b/runtime/plaid/src/apis/general/network.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use crate::loader::PlaidModule;
-use reqwest::header::HeaderMap;
-use serde::{Deserialize, Serialize};
+use reqwest::{header::HeaderMap, Certificate, Client};
+use serde::{de, Deserialize, Serialize};
 
 use crate::apis::ApiError;
 
@@ -10,7 +10,7 @@ use super::General;
 
 #[derive(Deserialize)]
 pub struct Config {
-    web_requests: HashMap<String, Request>,
+    pub web_requests: HashMap<String, Request>,
 }
 
 /// Request to make a web request
@@ -41,6 +41,15 @@ pub struct Request {
     return_body: bool,
     /// Flag to return the code from the request
     return_code: bool,
+    /// Optional root TLS certificate to use for this request.  
+    /// When set, the request will be sent via a special HTTP client configured with this certificate.
+    #[serde(deserialize_with = "certificate_deserializer")]
+    pub root_certificate: Option<Certificate>,
+    /// Optional per‐request timeout.  
+    /// When set, the request will be sent via a special HTTP client configured with this timeout;  
+    /// if unset, the default timeout from the API config is used.
+    #[serde(deserialize_with = "duration_deserializer")]
+    pub timeout: Option<Duration>,
     /// Rules allowed to use this request
     allowed_rules: Vec<String>,
     /// Headers to include in the request
@@ -49,6 +58,34 @@ pub struct Request {
     /// if the call has side effects. If it is not set, this will default to false.
     #[serde(default)]
     available_in_test_mode: bool,
+}
+
+/// Deserialize a non‐zero timeout (1–255 seconds) into a `Duration`, erroring on 0.
+fn duration_deserializer<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    let duration = u8::deserialize(deserializer)?;
+    if duration == 0 {
+        return Err(serde::de::Error::custom(format!(
+            "Invalid timeout duration provided. Acceptable values are between 1 and 255 seconds"
+        )));
+    }
+
+    Ok(Some(Duration::from_secs(duration as u64)))
+}
+
+/// Deserialize a PEM‐encoded string into a `Certificate`, erroring on parse failure.
+fn certificate_deserializer<'de, D>(deserializer: D) -> Result<Option<Certificate>, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    let pem = String::deserialize(deserializer)?;
+    let cert = Certificate::from_pem(pem.as_bytes()).map_err(|e| {
+        serde::de::Error::custom(format!("Invalid certificate provided. Error: {e}"))
+    })?;
+
+    Ok(Some(cert))
 }
 
 /// Data returned by a request.
@@ -82,7 +119,8 @@ impl General {
         let auth = request.get("auth");
 
         let request_builder = self
-            .client
+            .clients
+            .default
             .post(url)
             .header("Content-Type", "application/json; charset=utf-8");
 
@@ -159,12 +197,13 @@ impl General {
             uri = uri.replace(format!("{{{}}}", replacement.0).as_str(), replacement.1);
         }
 
+        let client = self.get_client(&request_name);
         let request_builder = match request_specification.verb.as_str() {
-            "delete" => self.client.delete(&uri),
-            "get" => self.client.get(&uri),
-            "patch" => self.client.patch(&uri),
-            "post" => self.client.post(&uri),
-            "put" => self.client.put(&uri),
+            "delete" => client.delete(&uri),
+            "get" => client.get(&uri),
+            "patch" => client.patch(&uri),
+            "post" => client.post(&uri),
+            "put" => client.put(&uri),
             // Not sure we want to support head
             //"head" => self.client.head(&request_specification.uri),
             _ => return Err(ApiError::BadRequest),
@@ -202,6 +241,14 @@ impl General {
                 }
             }
             Err(e) => Err(ApiError::NetworkError(e)),
+        }
+    }
+
+    fn get_client(&self, mnr: &str) -> &Client {
+        if let Some(client) = self.clients.specialized.get(mnr) {
+            client
+        } else {
+            &self.clients.default
         }
     }
 }

--- a/runtime/plaid/src/bin/request_handler.rs
+++ b/runtime/plaid/src/bin/request_handler.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use warp::Filter;
 
 #[tokio::main]
@@ -52,10 +54,18 @@ async fn main() {
             },
         );
 
+    let cert = fs::read("/tmp/plaid_config/server.pem").expect("failed to read server.pem");
+    let key = fs::read("/tmp/plaid_config/server.key").expect("failed to read server.key");
+
     // Start the server on 127.0.0.1:8998
     let routes = post_route
         .or(mnr_vars_route)
         .or(mnr_headers_route)
         .or(mnr_route);
-    warp::serve(routes).run(([127, 0, 0, 1], 8998)).await;
+    warp::serve(routes)
+        .tls()
+        .cert(cert)
+        .key(key)
+        .run(([127, 0, 0, 1], 8998))
+        .await;
 }


### PR DESCRIPTION
Previously all MNRs calls shared a single `reqwest::Client`, which made it impossible to tweak timeouts or trust bundles on a per-request basis. This PR introduces a new `Clients` type that holds:  
- A default client for the vast majority of calls.  
- A specialized pool of named clients, each built with its own timeout and/or root TLS certificate when requested.

**What’s Changed**  
- Refactored client-construction logic to scan every request config and spin up a dedicated `Client` if either `timeout` or `root_certificate` is set.
- Consolidated the two modes into a single `Clients` struct, with a `default: Client` and `specialized: HashMap<String, Client>`.
- Ensures that any request requiring extra control (custom timeouts, custom trust chains, etc.) can now use its own tailored HTTP client without impacting other requests.

**Why**  
- **Granular control:** Some endpoints demand longer timeouts or bespoke CA roots, and the old one-size-fits-all client couldn’t accommodate that.  
- **Performance:** Reuses `reqwest::Client` instances where possible, while still isolating the handful of calls that need special configuration.  

**Testing**
To test the root certificate functionality, we generate a self‐signed CA in `integration.sh` and used it to issue a localhost server certificate, then configured our Warp server to terminate TLS using that `server.pem`/`server.key`. In Plaid's configuration, we instruct the MNRs using the request handler to use `ca.pem` as the root certificate, so that it would trust the request handler's cert. This mini‐end‐to‐end setup verifies that this code can construct custom `Reqwest` clients which honor arbitrary CAs
