### PR TITLE
Keep logbacks and DB in sync

### DIFF
--- a/runtime/plaid/src/apis/general/logback.rs
+++ b/runtime/plaid/src/apis/general/logback.rs
@@ -23,15 +23,10 @@ impl General {
             logbacks_allowed,
         );
 
-        // If the delay is zero, we can get the log through much faster without
-        // waiting for the data collector to find it, buffer it, and finally
-        // enqueue it on the Message channel by doing it ourselves.
-        if delay == 0 {
-            self.log_sender.send(msg).is_ok()
-        } else {
-            self.delayed_log_sender
-                .send(DelayedMessage::new(delay, msg))
-                .is_ok()
-        }
+        // Send the message to the dedicated channel, from where it will
+        // be picked up by the dedicated data generator.
+        self.delayed_log_sender
+            .send(DelayedMessage::new(delay, msg))
+            .is_ok()
     }
 }

--- a/runtime/plaid/src/apis/general/mod.rs
+++ b/runtime/plaid/src/apis/general/mod.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 
 use std::{collections::HashMap, time::Duration};
 
-use crate::{data::DelayedMessage, executor::Message};
+use crate::data::DelayedMessage;
 
 use super::default_timeout_seconds;
 
@@ -29,8 +29,6 @@ pub struct General {
     config: GeneralConfig,
     /// Client to make requests with
     clients: Clients,
-    /// Sender object for messages
-    log_sender: Sender<Message>,
     /// Sender object for messages that must be processed with a delay
     delayed_log_sender: Sender<DelayedMessage>,
     /// Secure random generator
@@ -82,18 +80,13 @@ impl Clients {
 }
 
 impl General {
-    pub fn new(
-        config: GeneralConfig,
-        log_sender: Sender<Message>,
-        delayed_log_sender: Sender<DelayedMessage>,
-    ) -> Self {
+    pub fn new(config: GeneralConfig, delayed_log_sender: Sender<DelayedMessage>) -> Self {
         let clients = Clients::new(&config);
         let system_random = SystemRandom::new();
 
         Self {
             config,
             clients,
-            log_sender,
             delayed_log_sender,
             system_random,
         }

--- a/runtime/plaid/src/apis/mod.rs
+++ b/runtime/plaid/src/apis/mod.rs
@@ -31,7 +31,7 @@ use tokio::runtime::Runtime;
 use web::{Web, WebConfig};
 use yubikey::{Yubikey, YubikeyConfig};
 
-use crate::{data::DelayedMessage, executor::Message};
+use crate::data::DelayedMessage;
 
 use self::rustica::{Rustica, RusticaConfig};
 
@@ -93,11 +93,7 @@ pub enum ApiError {
 }
 
 impl Api {
-    pub async fn new(
-        config: ApiConfigs,
-        log_sender: Sender<Message>,
-        delayed_log_sender: Sender<DelayedMessage>,
-    ) -> Self {
+    pub async fn new(config: ApiConfigs, delayed_log_sender: Sender<DelayedMessage>) -> Self {
         #[cfg(feature = "aws")]
         let aws = match config.aws {
             Some(aws) => Some(Aws::new(aws).await),
@@ -105,7 +101,7 @@ impl Api {
         };
 
         let general = match config.general {
-            Some(gc) => Some(General::new(gc, log_sender, delayed_log_sender)),
+            Some(gc) => Some(General::new(gc, delayed_log_sender)),
             _ => None,
         };
 

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -89,7 +89,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Configurating APIs for Modules");
     // Create the API that powers all the wrapped calls that modules can make
-    let api = Api::new(config.apis, log_sender.clone(), delayed_log_sender).await;
+    let api = Api::new(config.apis, delayed_log_sender).await;
 
     // Create an Arc so all the handlers have access to our API object
     let api = Arc::new(api);

--- a/runtime/plaid/src/data/internal/mod.rs
+++ b/runtime/plaid/src/data/internal/mod.rs
@@ -44,11 +44,7 @@ impl std::cmp::PartialOrd for DelayedMessage {
 
 impl std::cmp::Ord for DelayedMessage {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        if self.delay < other.delay {
-            std::cmp::Ordering::Less
-        } else {
-            std::cmp::Ordering::Greater
-        }
+        self.delay.cmp(&other.delay)
     }
 }
 

--- a/runtime/plaid/src/data/internal/mod.rs
+++ b/runtime/plaid/src/data/internal/mod.rs
@@ -77,12 +77,8 @@ impl Internal {
 
             for (key, value) in previous_logs {
                 // We want to extract from the DB a message and a delay.
-                // First, we try deserializing the new format, where the DB key is a message ID, and the value is the serialized DelayedMessage
                 let (message, delay) = match serde_json::from_slice::<DelayedMessage>(&value) {
-                    Ok(item) => {
-                        // Everything OK, we were deserializing a logback in the "new" format
-                        (item.message, item.delay)
-                    }
+                    Ok(item) => (item.message, item.delay),
                     Err(e) => {
                         warn!(
                             "Skipping log in storage system which could not be deserialized [{e}]: {:X?}",

--- a/runtime/plaid/src/data/internal/mod.rs
+++ b/runtime/plaid/src/data/internal/mod.rs
@@ -53,39 +53,45 @@ pub struct Internal {
     sender: Sender<Message>,
     receiver: Receiver<DelayedMessage>,
     internal_sender: Sender<DelayedMessage>,
-    storage: Option<Arc<Storage>>,
+    storage: Arc<Storage>,
+}
+
+/// Fill the log heap with the content read from the DB
+async fn fill_heap_from_db(
+    storage: Arc<Storage>,
+) -> Result<BinaryHeap<Reverse<DelayedMessage>>, DataError> {
+    let mut log_heap = BinaryHeap::new();
+
+    let previous_logs = storage
+        .fetch_all(LOGBACK_NS, None)
+        .await
+        .map_err(|e| DataError::StorageError(e))?;
+
+    for (key, value) in previous_logs {
+        // We want to extract from the DB a message and a delay.
+        let (message, delay) = match serde_json::from_slice::<DelayedMessage>(&value) {
+            Ok(item) => (item.message, item.delay),
+            Err(e) => {
+                warn!(
+                    "Skipping log in storage system which could not be deserialized [{e}]: {:X?}",
+                    key
+                );
+                continue;
+            }
+        };
+        log_heap.push(Reverse(DelayedMessage { delay, message }));
+    }
+
+    Ok(log_heap)
 }
 
 impl Internal {
     pub async fn new(
         log_sender: Sender<Message>,
-        storage: Option<Arc<Storage>>,
+        storage: Arc<Storage>,
     ) -> Result<Self, DataError> {
         let (internal_sender, receiver) = bounded(4096);
-
-        let mut log_heap = BinaryHeap::new();
-
-        if let Some(storage) = &storage {
-            let previous_logs = storage
-                .fetch_all(LOGBACK_NS, None)
-                .await
-                .map_err(|e| DataError::StorageError(e))?;
-
-            for (key, value) in previous_logs {
-                // We want to extract from the DB a message and a delay.
-                let (message, delay) = match serde_json::from_slice::<DelayedMessage>(&value) {
-                    Ok(item) => (item.message, item.delay),
-                    Err(e) => {
-                        warn!(
-                            "Skipping log in storage system which could not be deserialized [{e}]: {:X?}",
-                            key
-                        );
-                        continue;
-                    }
-                };
-                log_heap.push(Reverse(DelayedMessage { delay, message }));
-            }
-        }
+        let log_heap = fill_heap_from_db(storage.clone()).await?;
 
         Ok(Self {
             log_heap,
@@ -107,28 +113,36 @@ impl Internal {
             .expect("Time went backwards")
             .as_secs();
 
-        // Pull all logs off the channel, set their time, and put them on the heap.
+        // Pull all logs off the channel, set their time, and store them in the DB.
+        // Then discard the current content of the heap, pull the content of the DB
+        // and use it to fill the heap.
         //
-        // If persistence is available, we will also set them there in case the system
-        // reboots
+        // This ensures that modifications which are made out-of-band to the DB are
+        // reflected in the heap's content.
+
+        // First, receive everything from the channel and write to DB
         while let Ok(mut log) = self.receiver.try_recv() {
             log.delay += current_time;
 
-            if let Some(storage) = &self.storage {
-                // Prepare what will be stored in the DB by serializing the DelayedMessage
-                if let Ok(db_item) = serde_json::to_vec(&log) {
-                    if let Err(e) = storage
-                        .insert(LOGBACK_NS.to_string(), log.message.id.clone(), db_item)
-                        .await
-                    {
-                        error!("Storage system could not persist a message: {e}");
-                    }
+            // Prepare what will be stored in the DB by serializing the DelayedMessage
+            if let Ok(db_item) = serde_json::to_vec(&log) {
+                if let Err(e) = self
+                    .storage
+                    .insert(LOGBACK_NS.to_string(), log.message.id.clone(), db_item)
+                    .await
+                {
+                    error!("Storage system could not persist a message: {e}");
                 }
             }
-
-            // Put the log into the in-memory heap
-            self.log_heap.push(Reverse(log));
         }
+
+        // Then, overwrite the current heap with the content read from the DB
+        self.log_heap = fill_heap_from_db(self.storage.clone())
+            .await
+            .map_err(|e| format!("{e:?}"))?;
+
+        // Now the heap is reflecting the content of the DB: we can look at it
+        // and see if something should be executed.
 
         while let Some(heap_top) = self.log_heap.peek() {
             let heap_top = &heap_top.0;
@@ -142,16 +156,13 @@ impl Internal {
             }
 
             let log = self.log_heap.pop().unwrap();
-            if let Some(storage) = &self.storage {
-                // Delete the logback from the storage because we are about to send it for processing.
-                // According to the new format, the key is the ID inside the DelayedMessage's message field
-                match storage.delete(LOGBACK_NS, &log.0.message.id).await {
-                    Ok(None) => {
-                        error!("We tried to delete a log back message that wasn't persisted")
-                    }
-                    Ok(Some(_)) => (),
-                    Err(e) => error!("Error removing persisted log: {e}"),
+            // Delete the logback from the storage because we are about to send it for processing.
+            match self.storage.delete(LOGBACK_NS, &log.0.message.id).await {
+                Ok(None) => {
+                    error!("We tried to delete a log back message that wasn't persisted")
                 }
+                Ok(Some(_)) => (),
+                Err(e) => error!("Error removing persisted log: {e}"),
             }
             self.sender.send(log.0.message).unwrap();
         }

--- a/runtime/plaid/src/data/internal/mod.rs
+++ b/runtime/plaid/src/data/internal/mod.rs
@@ -136,6 +136,8 @@ impl Internal {
             }
         }
 
+        // TODO the following part will be executed only by the instance that processes logbacks
+
         // Then, overwrite the current heap with the content read from the DB
         self.log_heap = fill_heap_from_db(self.storage.clone())
             .await

--- a/runtime/plaid/src/data/internal/mod.rs
+++ b/runtime/plaid/src/data/internal/mod.rs
@@ -16,9 +16,6 @@ use super::DataError;
 
 const LOGBACK_NS: &str = "logback_internal";
 
-#[derive(Deserialize, Default)]
-pub struct InternalConfig {}
-
 #[derive(Serialize, Deserialize)]
 pub struct DelayedMessage {
     pub delay: u64,
@@ -56,8 +53,6 @@ impl std::cmp::Ord for DelayedMessage {
 }
 
 pub struct Internal {
-    #[allow(dead_code)]
-    config: InternalConfig,
     log_heap: BinaryHeap<Reverse<DelayedMessage>>,
     sender: Sender<Message>,
     receiver: Receiver<DelayedMessage>,
@@ -67,7 +62,6 @@ pub struct Internal {
 
 impl Internal {
     pub async fn new(
-        config: InternalConfig,
         log_sender: Sender<Message>,
         storage: Option<Arc<Storage>>,
     ) -> Result<Self, DataError> {
@@ -102,7 +96,6 @@ impl Internal {
         }
 
         Ok(Self {
-            config,
             log_heap,
             sender: log_sender,
             receiver,

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -57,7 +57,7 @@ impl DataInternal {
     async fn new(
         config: DataConfig,
         logger: Sender<Message>,
-        storage: Option<Arc<Storage>>,
+        storage: Arc<Storage>,
         els: Logger,
     ) -> Result<Self, DataError> {
         let github = config
@@ -92,7 +92,7 @@ impl Data {
     pub async fn start(
         config: DataConfig,
         sender: Sender<Message>,
-        storage: Option<Arc<Storage>>,
+        storage: Arc<Storage>,
         els: Logger,
     ) -> Result<Option<Sender<DelayedMessage>>, DataError> {
         let di = DataInternal::new(config, sender, storage, els).await?;

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -29,7 +29,6 @@ pub use self::internal::DelayedMessage;
 pub struct DataConfig {
     github: Option<github::GithubConfig>,
     okta: Option<okta::OktaConfig>,
-    internal: Option<internal::InternalConfig>,
     interval: Option<interval::IntervalConfig>,
     websocket: Option<websocket::WebSocketDataGenerator>,
 }
@@ -69,19 +68,7 @@ impl DataInternal {
             .okta
             .map(|okta| okta::Okta::new(okta, logger.clone()));
 
-        let internal = match config.internal {
-            Some(internal) => {
-                internal::Internal::new(internal, logger.clone(), storage.clone()).await
-            }
-            None => {
-                internal::Internal::new(
-                    internal::InternalConfig::default(),
-                    logger.clone(),
-                    storage.clone(),
-                )
-                .await
-            }
-        };
+        let internal = internal::Internal::new(logger.clone(), storage.clone()).await;
 
         let interval = config
             .interval

--- a/runtime/plaid/src/storage/dynamodb/mod.rs
+++ b/runtime/plaid/src/storage/dynamodb/mod.rs
@@ -44,6 +44,10 @@ impl DynamoDb {
 
 #[async_trait]
 impl StorageProvider for DynamoDb {
+    fn is_persistent(&self) -> bool {
+        true
+    }
+
     async fn insert(
         &self,
         namespace: String,

--- a/runtime/plaid/src/storage/in_memory/mod.rs
+++ b/runtime/plaid/src/storage/in_memory/mod.rs
@@ -1,0 +1,114 @@
+//! This module provides a way for Plaid to use an in-memory store as a DB. Note - This storage is not persisted across reboots.
+
+use super::{StorageError, StorageProvider};
+use async_trait::async_trait;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::RwLock;
+
+pub struct InMemoryDb {
+    db: Arc<RwLock<HashMap<String, HashMap<String, Vec<u8>>>>>,
+}
+
+impl InMemoryDb {
+    pub fn new() -> Result<Self, StorageError> {
+        Ok(Self {
+            db: Arc::new(RwLock::new(HashMap::new())),
+        })
+    }
+}
+
+#[async_trait]
+impl StorageProvider for InMemoryDb {
+    async fn insert(
+        &self,
+        namespace: String,
+        key: String,
+        value: Vec<u8>,
+    ) -> Result<Option<Vec<u8>>, StorageError> {
+        let mut db = self.db.write().await;
+        let ns = db.entry(namespace).or_default();
+        Ok(ns.insert(key, value))
+    }
+
+    async fn get(&self, namespace: &str, key: &str) -> Result<Option<Vec<u8>>, StorageError> {
+        let db = self.db.read().await;
+        Ok(db.get(namespace).and_then(|ns| ns.get(key).cloned()))
+    }
+
+    async fn delete(&self, namespace: &str, key: &str) -> Result<Option<Vec<u8>>, StorageError> {
+        let mut db = self.db.write().await;
+        if let Some(ns) = db.get_mut(namespace) {
+            Ok(ns.remove(key))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn list_keys(
+        &self,
+        namespace: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<String>, StorageError> {
+        let keys = self
+            .db
+            .read()
+            .await
+            .get(namespace)
+            .map(|ns| {
+                ns.keys()
+                    .filter(|k| prefix.map_or(true, |p| k.starts_with(p)))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(keys)
+    }
+
+    async fn fetch_all(
+        &self,
+        namespace: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<(String, Vec<u8>)>, StorageError> {
+        let db = self.db.read().await;
+        let values = db
+            .get(namespace)
+            .map(|ns| {
+                ns.iter()
+                    .filter(|(k, _)| prefix.map_or(true, |p| k.starts_with(p)))
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(values)
+    }
+
+    async fn get_namespace_byte_size(&self, namespace: &str) -> Result<u64, StorageError> {
+        let all = self.fetch_all(namespace, None).await?;
+        let mut counter = 0u64;
+        for item in all {
+            // Count bytes for keys and values
+            counter += item.0.as_bytes().len() as u64 + item.1.len() as u64;
+        }
+        Ok(counter)
+    }
+
+    async fn apply_migration(
+        &self,
+        namespace: &str,
+        f: Box<dyn Fn(String, Vec<u8>) -> (String, Vec<u8>) + Send + Sync>,
+    ) -> Result<(), StorageError> {
+        // Get all the data for this namespace
+        let data = self.fetch_all(namespace, None).await?;
+        // For each key/value pair, perform the migration...
+        for (key, value) in data {
+            // Apply the transformation and obtain a new key and new value
+            let (new_key, new_value) = f(key.clone(), value);
+            // Delete the old entry because we are about to insert the new one
+            self.delete(namespace, &key).await?;
+            // And insert the new pair
+            self.insert(namespace.to_string(), new_key, new_value)
+                .await?;
+        }
+        Ok(())
+    }
+}

--- a/runtime/plaid/src/storage/in_memory/mod.rs
+++ b/runtime/plaid/src/storage/in_memory/mod.rs
@@ -19,6 +19,10 @@ impl InMemoryDb {
 
 #[async_trait]
 impl StorageProvider for InMemoryDb {
+    fn is_persistent(&self) -> bool {
+        false
+    }
+
     async fn insert(
         &self,
         namespace: String,

--- a/runtime/plaid/src/storage/mod.rs
+++ b/runtime/plaid/src/storage/mod.rs
@@ -11,7 +11,10 @@ pub mod dynamodb;
 #[cfg(feature = "sled")]
 pub mod sled;
 
+pub mod in_memory;
+
 use futures_util::future::join_all;
+use in_memory::InMemoryDb;
 use serde::Deserialize;
 
 use crate::loader::LimitValue;
@@ -137,6 +140,13 @@ pub trait StorageProvider {
 }
 
 impl Storage {
+    pub fn new_in_memory() -> Self {
+        Self {
+            database: Box::new(InMemoryDb::new().unwrap()),
+            shared_dbs: None,
+        }
+    }
+
     pub async fn new(config: Config) -> Result<Self, StorageError> {
         // Try building a database from the values in the config
         let database: Box<dyn StorageProvider + Send + Sync> = match config.db {

--- a/runtime/plaid/src/storage/mod.rs
+++ b/runtime/plaid/src/storage/mod.rs
@@ -96,6 +96,9 @@ impl std::error::Error for StorageError {}
 /// Defines the basic methods that all storage providers must offer.
 #[async_trait]
 pub trait StorageProvider {
+    /// Return whether this storage provider is backed by persistent storage.
+    /// If not, it means the data only lives in memory and is lost in case of a reboot.
+    fn is_persistent(&self) -> bool;
     /// Insert a new key pair into the storage provider
     async fn insert(
         &self,

--- a/runtime/plaid/src/storage/sled/mod.rs
+++ b/runtime/plaid/src/storage/sled/mod.rs
@@ -29,6 +29,10 @@ impl Sled {
 
 #[async_trait]
 impl StorageProvider for Sled {
+    fn is_persistent(&self) -> bool {
+        true
+    }
+
     async fn insert(
         &self,
         namespace: String,


### PR DESCRIPTION
When it comes to logbacks, what is persisted in the DB and what is loaded in the in-memory heap is not necessarily the same. If someone were to change the content of the DB (e.g., deleting a logback entry to prevent its execution), nothing would happen until Plaid is rebooted. This feels counterintuitive and error-prone.

This PR introduces strong synchronization between DB and heap: at every iteration, the heap's content is discarded and it is refilled with the content read from the DB. This guarantees that out-of-band changes to the DB are reflected in Plaid on the next logback iteration.

However, this means logbacks now conceptually need a DB to read content from. This is at odds with the fact that Plaid can run without persistent storage.
To solve this issue, we introduce a new `StorageProvider` implementation which is fully in-memory (backed by a simple `HashMap`). Then, the internal system always gets a `Storage` (it's not `Option<_>` anymore): if we have a persistent one, we use that, otherwise we create an in-memory DB.

TODO
- [x] Logbacks with delay 0 must be sent to the DB and not immediately to the channel. This is to prepare support for "not all instances run logbacks". ~@obelisk Actually, I am not so convinced about this anymore. Because if we execute the logback immediately, it does not make it to the DB, and we will have no issues or conflicts with other instances.~ Let's maintain the model of a "logback instance" for better clarity.