### PR TITLE
Add schema validation for Dynamo DB table

### DIFF
--- a/runtime/plaid/src/bin/db_migrator.rs
+++ b/runtime/plaid/src/bin/db_migrator.rs
@@ -197,7 +197,9 @@ async fn apply_dynamodb_migration(
         authentication: plaid::AwsAuthentication::Iam {},
         table_name: table_name.to_string(),
     };
-    let dynamodb = plaid::storage::dynamodb::DynamoDb::new(config).await;
+    let dynamodb = plaid::storage::dynamodb::DynamoDb::new(config)
+        .await
+        .unwrap();
     dynamodb
         .apply_migration(
             namespace,

--- a/runtime/plaid/src/bin/ddb_logback_explorer.rs
+++ b/runtime/plaid/src/bin/ddb_logback_explorer.rs
@@ -59,7 +59,9 @@ async fn fetch_all(table_name: &str, namespace: &str) -> Result<Vec<(String, Vec
         authentication: plaid::AwsAuthentication::Iam {},
         table_name: table_name.to_string(),
     };
-    let dynamodb = plaid::storage::dynamodb::DynamoDb::new(config).await;
+    let dynamodb = plaid::storage::dynamodb::DynamoDb::new(config)
+        .await
+        .unwrap();
     dynamodb
         .fetch_all(namespace, None)
         .await


### PR DESCRIPTION
When using AWS Dynamo DB as the storage layer for Plaid, the table's schema was not validated.

With this PR we make `DynamoDb::new(...)` fallible and return an error if any of the following conditions is not satisfied:
* The table has a partition / hash key called `namespace`
* The table has a sort / range key called `key`

Instead, we do not check the `value` attribute because Dynamo DB supports free attributes, which do not need to be set in advance.