### PR TITLE
Bump GraphQL request buffer

### DIFF
--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3205,7 +3205,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "alkali",
  "async-trait",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.23.2"
+version = "0.23.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/github/mod.rs
+++ b/runtime/plaid-stl/src/github/mod.rs
@@ -688,7 +688,7 @@ pub fn make_advanced_graphql_query(
     extern "C" {
         new_host_function_with_error_buffer!(github, make_advanced_graphql_query);
     }
-    const RETURN_BUFFER_SIZE: usize = 32 * 1024; // 32 KiB
+    const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
 
     #[derive(Serialize)]
     struct Request {

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.23.2"
+version = "0.23.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
We are exceeding the buffer size limit when querying repo releases. Bumping this buffer size should solve that.

We are only bumping `make_advanced_graphql_query` and not `make_graphql_query` to avoid exceeding the memory limits of rules that are running fine. `make_advanced_graphql_query` is more suitable for bigger responses with the nested response type.