### PR TITLE
Align data types between host and guest when fetching random bytes

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -180,7 +180,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/src/plaid/random.rs
+++ b/runtime/plaid-stl/src/plaid/random.rs
@@ -2,12 +2,12 @@ use crate::PlaidFunctionError;
 
 pub fn fetch_random_bytes(num_bytes: u16) -> Result<Vec<u8>, PlaidFunctionError> {
     extern "C" {
-        /// Send a log to a Slack Webhook
-        fn fetch_random_bytes(data: *mut u8, num_bytes: usize) -> i32;
+        /// Fetch randomness from the host
+        fn fetch_random_bytes(data: *mut u8, num_bytes: u16) -> i32;
     }
 
     let mut random_bytes = vec![0; num_bytes as usize];
-    let ret = unsafe { fetch_random_bytes(random_bytes.as_mut_ptr(), num_bytes as usize) };
+    let ret = unsafe { fetch_random_bytes(random_bytes.as_mut_ptr(), num_bytes) };
 
     // This should always be the case but we check just in case
     if ret != num_bytes as i32 {


### PR DESCRIPTION
The function parameter `data_buffer_len` of the API function `fetch_random_bytes()` is `u16` . However, the STL implementation had a `usize` in the definition.