### PR TITLE
Fix Ord impl for DelayedMessage and ScheduledJob

### DIFF
--- a/runtime/plaid/src/data/internal/mod.rs
+++ b/runtime/plaid/src/data/internal/mod.rs
@@ -47,11 +47,7 @@ impl std::cmp::PartialOrd for DelayedMessage {
 
 impl std::cmp::Ord for DelayedMessage {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        if self.delay < other.delay {
-            std::cmp::Ordering::Less
-        } else {
-            std::cmp::Ordering::Greater
-        }
+        self.delay.cmp(&other.delay)
     }
 }
 

--- a/runtime/plaid/src/data/interval/mod.rs
+++ b/runtime/plaid/src/data/interval/mod.rs
@@ -87,11 +87,7 @@ impl std::cmp::PartialOrd for ScheduledJob {
 
 impl std::cmp::Ord for ScheduledJob {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        if self.execution_time < other.execution_time {
-            std::cmp::Ordering::Less
-        } else {
-            std::cmp::Ordering::Greater
-        }
+        self.execution_time.cmp(&other.execution_time)
     }
 }
 


### PR DESCRIPTION
Correctly handle the equality case by relying on `cmp(...)`.