### PR TITLE
Require at least one interval job in `IntervalConfig` to prevent busy loop

### DIFF
--- a/runtime/plaid/src/data/interval/mod.rs
+++ b/runtime/plaid/src/data/interval/mod.rs
@@ -14,26 +14,23 @@ use crate::executor::Message;
 /// Defines the list of interval jobs to be processed
 pub struct IntervalConfig {
     /// A HashMap of job name to job config.
+    #[serde(deserialize_with = "parse_jobs")]
     jobs: HashMap<String, IntervalJob>,
     /// Maximum percentage of internal time to shift all jobs for better work distribution    
     #[serde(deserialize_with = "parse_splay")]
     splay: u32,
 }
 
-/// Custom parser for splay. Returns an error if a splay > 100 is given
-fn parse_jobs<'de, D>(deserializer: D) -> Result<u32, D::Error>
+/// Custom parser for `jobs`. Returns an error if an empty jobs map is provided
+fn parse_jobs<'de, D>(deserializer: D) -> Result<HashMap<String, IntervalJob>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let splay = u32::deserialize(deserializer)?;
-
-    if splay > 100 {
-        Err(serde::de::Error::custom(
-            "Invalid splay value provided. Max splay is 100",
-        ))
-    } else {
-        Ok(splay)
+    let map = HashMap::<String, IntervalJob>::deserialize(deserializer)?;
+    if map.is_empty() {
+        return Err(serde::de::Error::custom("`jobs` map must not be empty"));
     }
+    Ok(map)
 }
 
 /// Custom parser for splay. Returns an error if a splay > 100 is given


### PR DESCRIPTION
If `fetch_interval_jobs()` returns zero, the interval job processor loop will immediately run again without any delay.
This can result in a tight, busy loop that consumes unnecessary CPU resources. To mitigate this, we add an additional check in the deserialization of `IntervalConfig` that requires that at least 1 interval job be configured.