### PR TITLE
Do not use unwrap when pulling randomness for splay

### DIFF
--- a/runtime/plaid/src/data/interval/mod.rs
+++ b/runtime/plaid/src/data/interval/mod.rs
@@ -153,8 +153,13 @@ impl Interval {
 
             // Generate a random number between 0 and splay
             let mut bytes = [0u8; 8];
-            // We assume we will always be able to generate randomness
-            srand.fill(&mut bytes).unwrap();
+            // In the very rare case that we cannot pull randomness, default to 42.
+            // This is just for calculating a timing offset and not a security critical
+            // operation, so using a hard coded number is not an issue.
+            if let Err(_) = srand.fill(&mut bytes) {
+                bytes = 42u64.to_ne_bytes(); // Encode 42 using native endian format
+            }
+
             // Yes there is a slight randomness bias here but we're just calculating a splay
             // so this is not a security critical operation.
             let job_splay = u64::from_be_bytes(bytes) % splay;


### PR DESCRIPTION
When generating the timing oﬀset for tasks ran on a schedule it is possible that the source of the random oﬀset will
cause the program to panic. This is due to the use of `unwrap()` in generating this random oﬀset.

While cases in which `srand.fill()` returns an error are unlikely to occur in practice, this can happen with edge cases
such as a lack of system entropy or when the code is run on a custom system.

This PR removes the `unwrap()` and, in case `srand.fill()` fails, defaults to a safe value.