### PR TITLE
Enforce JWT expiration

### DIFF
--- a/runtime/plaid/src/apis/web/mod.rs
+++ b/runtime/plaid/src/apis/web/mod.rs
@@ -61,6 +61,12 @@ impl Web {
         let mut request: HashMap<&str, serde_json::Value> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
+        if !request.contains_key("exp") {
+            return Err(ApiError::WebError(WebError::BadRequest(
+                "Missing exp in JWT claims".to_string(),
+            )));
+        }
+
         // Get the kid from the request params
         let kid = request
             .get("kid")


### PR DESCRIPTION
When making JSON Web Token requests, the system did not enforce that an `exp` (expiry) field is included in the
claims.

As a consequence, tokens may be issued without expiration, making them valid indefinitely if a consuming system does not enforce its own checks.

This PR enforces that an `exp` field is present in the request, otherwise an error is returned.