### PR TITLE
Bring back shortcut for 0-delay logbacks

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3159,7 +3159,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "alkali",
  "async-trait",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/general/logback.rs
+++ b/runtime/plaid/src/apis/general/logback.rs
@@ -23,10 +23,17 @@ impl General {
             logbacks_allowed,
         );
 
-        // Send the message to the dedicated channel, from where it will
-        // be picked up by the dedicated data generator.
-        self.delayed_log_sender
-            .send(DelayedMessage::new(delay, msg))
-            .is_ok()
+        if delay == 0 {
+            // If the delay is zero, we can get the log through much faster without
+            // waiting for the data collector to find it, buffer it, and finally
+            // enqueue it on the Message channel by doing it ourselves.
+            self.log_sender.send(msg).is_ok()
+        } else {
+            // Send the message to the dedicated channel, from where it will
+            // be picked up by the dedicated data generator.
+            self.delayed_log_sender
+                .send(DelayedMessage::new(delay, msg))
+                .is_ok()
+        }
     }
 }

--- a/runtime/plaid/src/apis/general/mod.rs
+++ b/runtime/plaid/src/apis/general/mod.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 
 use std::{collections::HashMap, time::Duration};
 
-use crate::data::DelayedMessage;
+use crate::{data::DelayedMessage, executor::Message};
 
 use super::default_timeout_seconds;
 
@@ -29,6 +29,8 @@ pub struct General {
     config: GeneralConfig,
     /// Client to make requests with
     clients: Clients,
+    /// Sender object for messages
+    log_sender: Sender<Message>,
     /// Sender object for messages that must be processed with a delay
     delayed_log_sender: Sender<DelayedMessage>,
     /// Secure random generator
@@ -80,13 +82,18 @@ impl Clients {
 }
 
 impl General {
-    pub fn new(config: GeneralConfig, delayed_log_sender: Sender<DelayedMessage>) -> Self {
+    pub fn new(
+        config: GeneralConfig,
+        log_sender: Sender<Message>,
+        delayed_log_sender: Sender<DelayedMessage>,
+    ) -> Self {
         let clients = Clients::new(&config);
         let system_random = SystemRandom::new();
 
         Self {
             config,
             clients,
+            log_sender,
             delayed_log_sender,
             system_random,
         }

--- a/runtime/plaid/src/apis/mod.rs
+++ b/runtime/plaid/src/apis/mod.rs
@@ -32,6 +32,7 @@ use web::{Web, WebConfig};
 use yubikey::{Yubikey, YubikeyConfig};
 
 use crate::data::DelayedMessage;
+use crate::executor::Message;
 
 use self::rustica::{Rustica, RusticaConfig};
 
@@ -93,7 +94,11 @@ pub enum ApiError {
 }
 
 impl Api {
-    pub async fn new(config: ApiConfigs, delayed_log_sender: Sender<DelayedMessage>) -> Self {
+    pub async fn new(
+        config: ApiConfigs,
+        log_sender: Sender<Message>,
+        delayed_log_sender: Sender<DelayedMessage>,
+    ) -> Self {
         #[cfg(feature = "aws")]
         let aws = match config.aws {
             Some(aws) => Some(Aws::new(aws).await),
@@ -101,7 +106,7 @@ impl Api {
         };
 
         let general = match config.general {
-            Some(gc) => Some(General::new(gc, delayed_log_sender)),
+            Some(gc) => Some(General::new(gc, log_sender, delayed_log_sender)),
             _ => None,
         };
 

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -93,7 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Configuring APIs for Modules");
     // Create the API that powers all the wrapped calls that modules can make
-    let api = Api::new(config.apis, delayed_log_sender).await;
+    let api = Api::new(config.apis, log_sender.clone(), delayed_log_sender).await;
 
     // Create an Arc so all the handlers have access to our API object
     let api = Arc::new(api);


### PR DESCRIPTION
Bring back the shortcut for 0-delay logbacks, so that they can be executed immediately, without passing through the storage layer.