### PR TITLE
Slack get DND

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.25.1"
+version = "0.25.3"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3159,7 +3159,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.25.1"
+version = "0.25.3"
 dependencies = [
  "alkali",
  "async-trait",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.25.1"
+version = "0.25.3"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.25.1"
+version = "0.25.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.25.1"
+version = "0.25.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -381,6 +381,7 @@ impl_new_function_with_error_buffer!(slack, get_id_from_email, ALLOW_IN_TEST_MOD
 impl_new_function!(slack, post_to_arbitrary_webhook, ALLOW_IN_TEST_MODE);
 impl_new_function!(slack, post_to_named_webhook, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(slack, get_presence, ALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(slack, get_dnd, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(slack, user_info, ALLOW_IN_TEST_MODE);
 
 // Splunk Functions
@@ -622,6 +623,7 @@ pub fn to_api_function(
             Function::new_typed_with_env(&mut store, &env, slack_get_id_from_email)
         }
         "slack_get_presence" => Function::new_typed_with_env(&mut store, &env, slack_get_presence),
+        "slack_get_dnd" => Function::new_typed_with_env(&mut store, &env, slack_get_dnd),
         "slack_user_info" => Function::new_typed_with_env(&mut store, &env, slack_user_info),
 
         // General Calls


### PR DESCRIPTION
Add a new API to retrieve a user's DND info from Slack's API.