### PR TITLE
Parse additional fields from the Slack dnd.info response

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3157,7 +3157,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "alkali",
  "async-trait",
@@ -3206,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.25.3"
+version = "0.25.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/slack/mod.rs
+++ b/runtime/plaid-stl/src/slack/mod.rs
@@ -241,7 +241,8 @@ pub struct GetDndInfo {
 pub struct GetDndInfoResponse {
     pub ok: bool,
     pub dnd_enabled: bool,
-    // There are other fields but we don't need to parse them.
+    pub next_dnd_start_ts: u64,
+    pub next_dnd_end_ts: u64,
     // Note: there is a `snooze_enabled` property but the docs say
     //   "All of the snooze_* properties will only be visible if the user being queried is also the current user."
     // Therefore we leave it out because the typical use case is retrieving info about another user.

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.25.3"
+version = "0.25.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
It turns out that looking at `dnd_enabled` is not a perfect way to understand if a user has snoozed their notifications. Apparently, this value can be influenced by other factors, like workspace-level settings.

Instead, we include the start and end timestamp for DND, and the idea is that we can check if `now` falls between these values.
