### PR TITLE
fix(websocket): Prevent client panic on logger error

### DIFF
--- a/runtime/plaid/src/data/websocket/mod.rs
+++ b/runtime/plaid/src/data/websocket/mod.rs
@@ -220,7 +220,11 @@ impl WebsocketGenerator {
                         return;
                     };
 
-                    logger.log_websocket_dropped(socket_name).unwrap();
+                    if let Err(e) = logger.log_websocket_dropped(socket_name.clone()) {
+                        error!(
+                            "Failed to log WebSocket drop for socket [{socket_name}]. Error: {e}",
+                        );
+                    };
 
                     client.uri_selector.mark_failed();
                 }


### PR DESCRIPTION
If the logger used for recording system errors is not disconnected, then when a WebSocket connection error occurs,
the logger will fail to record this and return an error, which causes the WebSocket client thread to panic. This will mean
the related URI is never marked as having failed and will continue to repeat connection attempts without increasing
the back oﬀ time.