### PR TITLE
Add APIs to require signed commits and get weekly commits to a repo

### DIFF
--- a/runtime/plaid-stl/src/github/mod.rs
+++ b/runtime/plaid-stl/src/github/mod.rs
@@ -151,6 +151,13 @@ pub struct RepositoryCustomProperty {
     pub value: String,
 }
 
+#[derive(Deserialize)]
+/// Number of commits made to a repo in a week
+pub struct WeeklyCommits {
+    pub all: Vec<u16>,
+    pub owner: Vec<u16>,
+}
+
 impl FileSearchResultItem {
     /// Retrieve the content of the search result
     pub fn retrieve_raw_content(&self) -> Result<String, PlaidFunctionError> {
@@ -1749,4 +1756,79 @@ pub fn pull_request_request_reviewers(
     }
 
     Ok(())
+}
+
+/// Enforce signed commits on a given branch of a given repo
+/// For more details, see https://docs.github.com/en/enterprise-cloud@latest/rest/branches/branch-protection?apiVersion=2022-11-28#create-commit-signature-protection
+pub fn require_signed_commits(
+    owner: impl Display,
+    repo: impl Display,
+    branch: impl Display,
+) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(github, require_signed_commits);
+    }
+
+    let mut params: HashMap<&'static str, String> = HashMap::new();
+    params.insert("owner", owner.to_string());
+    params.insert("repo", repo.to_string());
+    params.insert("branch", branch.to_string());
+
+    let params = serde_json::to_string(&params).unwrap();
+    let res = unsafe {
+        github_require_signed_commits(params.as_bytes().as_ptr(), params.as_bytes().len())
+    };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    Ok(())
+}
+
+/// Get the weekly commit count on a given repo.
+/// For more details, see https://docs.github.com/en/rest/metrics/statistics?apiVersion=2022-11-28#get-the-weekly-commit-count
+pub fn get_weekly_commit_count(
+    owner: impl Display,
+    repo: impl Display,
+) -> Result<WeeklyCommits, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(github, get_weekly_commit_count);
+    }
+
+    const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let mut params: HashMap<&'static str, String> = HashMap::new();
+    params.insert("owner", owner.to_string());
+    params.insert("repo", repo.to_string());
+    let params = serde_json::to_string(&params).unwrap();
+
+    let res = unsafe {
+        github_get_weekly_commit_count(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    let response_body =
+        String::from_utf8(return_buffer).map_err(|_| PlaidFunctionError::InternalApiError)?;
+    let response_body = serde_json::from_str::<WeeklyCommits>(&response_body)
+        .map_err(|_| PlaidFunctionError::InternalApiError)?;
+
+    Ok(response_body)
 }

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -307,6 +307,7 @@ impl_new_function!(
 impl_new_function!(github, trigger_repo_dispatch, DISALLOW_IN_TEST_MODE);
 impl_new_function!(github, check_org_membership_of_user, ALLOW_IN_TEST_MODE);
 impl_new_function!(github, delete_deploy_key, DISALLOW_IN_TEST_MODE);
+impl_new_function!(github, require_signed_commits, DISALLOW_IN_TEST_MODE);
 
 impl_new_function_with_error_buffer!(github, make_graphql_query, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, make_advanced_graphql_query, ALLOW_IN_TEST_MODE);
@@ -327,6 +328,7 @@ impl_new_function!(
     pull_request_request_reviewers,
     DISALLOW_IN_TEST_MODE
 );
+impl_new_function_with_error_buffer!(github, get_weekly_commit_count, ALLOW_IN_TEST_MODE);
 
 // GitHub Functions only available with GitHub App authentication
 impl_new_function!(github, review_fpat_requests_for_org, DISALLOW_IN_TEST_MODE);
@@ -608,6 +610,12 @@ pub fn to_api_function(
         }
         "github_pull_request_request_reviewers" => {
             Function::new_typed_with_env(&mut store, &env, github_pull_request_request_reviewers)
+        }
+        "github_require_signed_commits" => {
+            Function::new_typed_with_env(&mut store, &env, github_require_signed_commits)
+        }
+        "github_get_weekly_commit_count" => {
+            Function::new_typed_with_env(&mut store, &env, github_get_weekly_commit_count)
         }
 
         // Slack Calls


### PR DESCRIPTION
This PR adds two new runtime APIs for interacting with GitHub:
* A POST request to require that commits be signed
* A GET request to retrieve the number of weekly commits to a given repo