### PR TITLE
Gracefully handle errors when sending DG logs for processing

### DIFF
--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -322,7 +322,7 @@ impl DataGenerator for &mut Github {
         self.seen_logs_uuid.put(id.to_string(), 0u32);
     }
 
-    fn send_for_processing(&self, payload: Vec<u8>) {
+    fn send_for_processing(&self, payload: Vec<u8>) -> Result<(), ()> {
         self.logger
             .send(Message::new(
                 format!("github"),
@@ -330,6 +330,6 @@ impl DataGenerator for &mut Github {
                 LogSource::Generator(Generator::Github),
                 self.config.logbacks_allowed.clone(),
             ))
-            .unwrap();
+            .map_err(|_| ())
     }
 }

--- a/runtime/plaid/src/data/okta/mod.rs
+++ b/runtime/plaid/src/data/okta/mod.rs
@@ -289,7 +289,7 @@ impl DataGenerator for &mut Okta {
         self.seen_logs_uuid.put(id.to_string(), 0u32);
     }
 
-    fn send_for_processing(&self, payload: Vec<u8>) {
+    fn send_for_processing(&self, payload: Vec<u8>) -> Result<(), ()> {
         self.logger
             .send(Message::new(
                 "okta".to_string(),
@@ -297,6 +297,6 @@ impl DataGenerator for &mut Okta {
                 LogSource::Generator(Generator::Okta),
                 self.config.logbacks_allowed.clone(),
             ))
-            .unwrap();
+            .map_err(|_| ())
     }
 }


### PR DESCRIPTION
Avoid unwrapping and instead bubble up the error.

Note - Now the log is marked as seen only _after_ being successfully sent. This ensures that, in case of an error, a future run of the data generator will process that log and not discard it as already-seen.
