### PR TITLE
Multi-logtype support

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -407,6 +407,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_multi_logtype"
+version = "0.1.0"
+dependencies = [
+ "plaid_stl",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "test_persistent_response"
 version = "0.1.0"
 dependencies = [

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "tests/test_slack",
     "load_tests/load_test",
     "tests/test_cron",
+    "tests/test_multi_logtype",
 ]
 
 [profile.release]

--- a/modules/tests/test_multi_logtype/Cargo.toml
+++ b/modules/tests/test_multi_logtype/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "test_multi_logtype"
+description = "Test rule processes multiple log types."
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+plaid_stl = { path = "../../../runtime/plaid-stl" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+
+[lib]
+crate-type = ["cdylib"]

--- a/modules/tests/test_multi_logtype/harness/harness.sh
+++ b/modules/tests/test_multi_logtype/harness/harness.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Define what webhook within Plaid we're going to call
+URL1="multilogtype1"
+URL2="multilogtype2"
+URL3="multilogtype3"
+FILE="received_data.multilogtype.txt"
+
+# Start the webhook
+$REQUEST_HANDLER > $FILE &
+if [ $? -ne 0 ]; then
+  echo "Failed to start request handler"
+  rm $FILE
+  exit 1
+fi
+
+RH_PID=$!
+
+# Call the webhook
+curl -d '{"type": "multilogtype1"}' http://$PLAID_LOCATION/webhook/$URL1
+sleep 2
+curl -d '{"type": "multilogtype2"}' http://$PLAID_LOCATION/webhook/$URL2
+sleep 2
+curl -d '{"type": "multilogtype3"}' http://$PLAID_LOCATION/webhook/$URL3
+
+kill $RH_PID 2>&1 > /dev/null
+sleep 2
+
+# The rule we are testing handles types 1 and 2, but not 3
+echo -e "multilogtype1\nmultilogtype2" > expected.txt
+diff expected.txt $FILE
+RESULT=$?
+
+rm -f $FILE expected.txt
+
+exit $RESULT

--- a/modules/tests/test_multi_logtype/src/lib.rs
+++ b/modules/tests/test_multi_logtype/src/lib.rs
@@ -1,0 +1,22 @@
+use std::collections::HashMap;
+
+use plaid_stl::{entrypoint_with_source, messages::LogSource, network::make_named_request, plaid};
+use serde::Deserialize;
+
+entrypoint_with_source!();
+
+#[derive(Deserialize)]
+struct Log {
+    #[serde(rename = "type")]
+    type_: String,
+}
+
+fn main(log: String, _: LogSource) -> Result<(), i32> {
+    plaid::print_debug_string(&format!("Received log {log}"));
+
+    let log = serde_json::from_str::<Log>(&log).unwrap();
+
+    make_named_request("test-response", &log.type_, HashMap::new()).unwrap();
+
+    Ok(())
+}

--- a/runtime/plaid/resources/config/apis.toml
+++ b/runtime/plaid/resources/config/apis.toml
@@ -16,6 +16,7 @@ allowed_rules = [
     "test_shared_db_rule_1.wasm",
     "test_shared_db_rule_2.wasm",
     "test_slack.wasm",
+    "test_multi_logtype.wasm",
 ]
 root_certificate = """
 {plaid-secret{integration-test-root-ca}}

--- a/runtime/plaid/resources/config/loading.toml
+++ b/runtime/plaid/resources/config/loading.toml
@@ -24,6 +24,7 @@ test_mode_exemptions = [
     "test_shared_db_rule_2.wasm",
     "test_slack.wasm",
     "test_cron.wasm",
+    "test_multi_logtype.wasm",
 ]
 
 
@@ -59,23 +60,24 @@ test_mode_exemptions = [
 "organization_fetch_auth_token" = "{plaid-secret{example-auth-token}}"
 
 [loading.log_type_overrides]
-"test_crashtest.wasm" = "crashtest"
-"test_db.wasm" = "test_db"
-"test_fileopen.wasm" = "test_fileopen"
-"test_get_everything.wasm" = "test_geteverything"
-"test_logback.wasm" = "test_logback"
-"test_mnr.wasm" = "test_mnr"
-"test_persistent_response.wasm" = "prtest"
-"test_random.wasm" = "test_random"
-"test_regex.wasm" = "test_regex"
-"test_sshcerts_usage.wasm" = "test_sshcerts"
-"test_testmode.wasm" = "testmode"
-"test_time.wasm" = "time"
-"test_shared_db_rule_1.wasm" = "test_shareddb_1"
-"test_shared_db_rule_2.wasm" = "test_shareddb_2"
-"test_slack.wasm" = "test_slack"
-"example_github_graphql.wasm" = "example_github_graphql"
-"test_cron.wasm" = "test_cron"
+"test_crashtest.wasm" = ["crashtest"]
+"test_db.wasm" = ["test_db"]
+"test_fileopen.wasm" = ["test_fileopen"]
+"test_get_everything.wasm" = ["test_geteverything"]
+"test_logback.wasm" = ["test_logback"]
+"test_mnr.wasm" = ["test_mnr"]
+"test_persistent_response.wasm" = ["prtest"]
+"test_random.wasm" = ["test_random"]
+"test_regex.wasm" = ["test_regex"]
+"test_sshcerts_usage.wasm" = ["test_sshcerts"]
+"test_testmode.wasm" = ["testmode"]
+"test_time.wasm" = ["time"]
+"test_shared_db_rule_1.wasm" = ["test_shareddb_1"]
+"test_shared_db_rule_2.wasm" = ["test_shareddb_2"]
+"test_slack.wasm" = ["test_slack"]
+"example_github_graphql.wasm" = ["example_github_graphql"]
+"test_cron.wasm" = ["test_cron"]
+"test_multi_logtype.wasm" = ["multilogtype1", "multilogtype2"]
 
 # Configure the computation amount. See the loader module for more
 # information on how computation cost is calculated.

--- a/runtime/plaid/resources/config/webhooks.toml
+++ b/runtime/plaid/resources/config/webhooks.toml
@@ -93,6 +93,18 @@ headers = []
 log_type = "test_slack"
 headers = []
 
+[webhooks."internal".webhooks."multilogtype1"]
+log_type = "multilogtype1"
+headers = []
+
+[webhooks."internal".webhooks."multilogtype2"]
+log_type = "multilogtype2"
+headers = []
+
+[webhooks."internal".webhooks."multilogtype3"]
+log_type = "multilogtype3"
+headers = []
+
 # End webhooks for tests
 
 # Additional webhook examples


### PR DESCRIPTION
### Breaking config change
The config now needs to look like this

```
[loading.log_type_overrides]
"test_cron.wasm" = ["test_cron"]
"test_multi_logtype.wasm" = ["multilogtype1", "multilogtype2"]
...
```

I.e., on the right of the `=` sign, we now have an array and not a single string.