### PR TITLE
Add runtime API to check a repo's CODEOWNERS file

### DIFF
--- a/.github/workflows/FeatureCheck.yml
+++ b/.github/workflows/FeatureCheck.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Setup Rust
         run: |
+          rustup toolchain install nightly-2024-12-14  # pinning the nightly version should help with caching dependencies
+          rustup default nightly-2024-12-14
           rustup target add wasm32-unknown-unknown
 
       - uses: actions/checkout@v4

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.27.1"
+version = "0.28.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.28.0"
+version = "0.27.2"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3224,7 +3224,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.27.1"
+version = "0.28.0"
 dependencies = [
  "aes",
  "alkali",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.27.1"
+version = "0.28.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3224,7 +3224,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.28.0"
+version = "0.27.2"
 dependencies = [
  "aes",
  "alkali",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.28.0"
+version = "0.27.2"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.28.0"
+version = "0.27.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.27.1"
+version = "0.28.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.28.0"
+version = "0.27.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.27.1"
+version = "0.28.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/github/repos.rs
+++ b/runtime/plaid/src/apis/github/repos.rs
@@ -586,14 +586,18 @@ impl Github {
                         Err(_) => Err(ApiError::GitHubError(GitHubError::BadResponse)),
                         Ok(response) => {
                             if response.errors.is_empty() {
-                                Ok(CodeownersStatus::Ok.to_string())
+                                serde_json::to_string(&CodeownersStatus::Ok)
+                                    .map_err(|_| ApiError::GitHubError(GitHubError::BadResponse))
                             } else {
-                                Ok(CodeownersStatus::Invalid.to_string())
+                                // Errors have been detected
+                                serde_json::to_string(&CodeownersStatus::Invalid(response.errors))
+                                    .map_err(|_| ApiError::GitHubError(GitHubError::BadResponse))
                             }
                         }
                     }
                 } else if status == 404 {
-                    Ok(CodeownersStatus::Missing.to_string())
+                    serde_json::to_string(&CodeownersStatus::Missing)
+                        .map_err(|_| ApiError::GitHubError(GitHubError::BadResponse))
                 } else {
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
                         status,

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -324,6 +324,7 @@ impl_new_function_with_error_buffer!(github, list_seats_in_org_copilot, ALLOW_IN
 impl_new_function_with_error_buffer!(github, add_users_to_org_copilot, DISALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, remove_users_from_org_copilot, DISALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, get_custom_properties_values, ALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(github, check_codeowners_file, ALLOW_IN_TEST_MODE);
 impl_new_function!(github, comment_on_pull_request, DISALLOW_IN_TEST_MODE);
 impl_new_function!(
     github,
@@ -585,6 +586,9 @@ pub fn to_api_function(
         }
         "github_get_custom_properties_values" => {
             Function::new_typed_with_env(&mut store, &env, github_get_custom_properties_values)
+        }
+        "github_check_codeowners_file" => {
+            Function::new_typed_with_env(&mut store, &env, github_check_codeowners_file)
         }
         "github_update_branch_protection_rule" => {
             Function::new_typed_with_env(&mut store, &env, github_update_branch_protection_rule)


### PR DESCRIPTION
The API for modules will return whether a CODEOWNERS file is:
* OK - It is present and has no errors
* Missing
* Invalid - It is present but there is at least one error