### PR TITLE
Implement PartialEq for STL types

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3224,7 +3224,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "aes",
  "alkali",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.27.2"
+version = "0.27.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/github/mod.rs
+++ b/runtime/plaid-stl/src/github/mod.rs
@@ -160,7 +160,7 @@ pub struct CheckCodeownersParams {
 
 /// An error detected in a CODEOWNERS file.
 /// See https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-codeowners-errors for more details.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct CodeownersError {
     pub kind: String,
     pub message: String,
@@ -169,7 +169,7 @@ pub struct CodeownersError {
 }
 
 /// Status for a repo's CODEOWNERS file
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq)]
 pub enum CodeownersStatus {
     /// The file is present and has no errors
     Ok,

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.27.2"
+version = "0.27.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Derive `PartialEq` for `CodeownersStatus` and `CodeownersError`, so that they can be compared in modules' code.