### PR TITLE
Add new entrypoint to support raw bytes as logs

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -500,6 +500,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_vec_entrypoint"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "plaid_stl",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -22,7 +22,8 @@ members = [
     "tests/test_slack",
     "load_tests/load_test",
     "tests/test_cron",
-    "tests/test_aes_enc_dec"
+    "tests/test_aes_enc_dec",
+    "tests/test_vec_entrypoint"
 ]
 
 [profile.release]

--- a/modules/tests/test_vec_entrypoint/Cargo.toml
+++ b/modules/tests/test_vec_entrypoint/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "test_vec_entrypoint"
+description = "Test rule that receives a log in the form of a vector of raw bytes"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+base64 = "0.22"
+plaid_stl = { path = "../../../runtime/plaid-stl" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+
+[lib]
+crate-type = ["cdylib"]

--- a/modules/tests/test_vec_entrypoint/harness/harness.sh
+++ b/modules/tests/test_vec_entrypoint/harness/harness.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Define what webhook within Plaid we're going to call
+URL="test_vec_entrypoint"
+FILE="received_data.$URL.txt"
+
+# Start the webhook
+$REQUEST_HANDLER > $FILE &
+if [ $? -ne 0 ]; then
+  echo "Failed to start request handler"
+  rm $FILE
+  exit 1
+fi
+
+RH_PID=$!
+
+# Call the webhook
+head -c 16 /dev/urandom | curl -X POST "http://$PLAID_LOCATION/webhook/$URL" \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary @-
+sleep 2
+
+kill $RH_PID 2>&1 > /dev/null
+
+RESULT=$(head -n 1 $FILE)
+rm -f $FILE
+
+if [[ $RESULT == "16" ]]; then
+    exit 0
+else
+    exit 1
+fi

--- a/modules/tests/test_vec_entrypoint/src/lib.rs
+++ b/modules/tests/test_vec_entrypoint/src/lib.rs
@@ -1,0 +1,19 @@
+use base64::prelude::*;
+use std::collections::HashMap;
+
+use plaid_stl::{
+    entrypoint_vec_with_source, messages::LogSource, network::make_named_request, plaid,
+};
+
+entrypoint_vec_with_source!();
+
+fn main(log: Vec<u8>, _: LogSource) -> Result<(), i32> {
+    let log_len = log.len();
+    let log_b64 = BASE64_STANDARD.encode(log);
+    plaid::print_debug_string(&format!(
+        "The rule received {log_len} raw bytes and this is their base64 encoding: {log_b64}"
+    ));
+
+    make_named_request("test-response", &log_len.to_string(), HashMap::new()).unwrap();
+    Ok(())
+}

--- a/runtime/plaid/resources/config/apis.toml
+++ b/runtime/plaid/resources/config/apis.toml
@@ -17,6 +17,7 @@ allowed_rules = [
     "test_shared_db_rule_2.wasm",
     "test_slack.wasm",
     "test_aes_enc_dec.wasm",
+    "test_vec_entrypoint.wasm",
 ]
 root_certificate = """
 {plaid-secret{integration-test-root-ca}}

--- a/runtime/plaid/resources/config/loading.toml
+++ b/runtime/plaid/resources/config/loading.toml
@@ -25,6 +25,7 @@ test_mode_exemptions = [
     "test_slack.wasm",
     "test_cron.wasm",
     "test_aes_enc_dec.wasm",
+    "test_vec_entrypoint.wasm",
 ]
 
 
@@ -78,6 +79,7 @@ test_mode_exemptions = [
 "example_github_graphql.wasm" = "example_github_graphql"
 "test_cron.wasm" = "test_cron"
 "test_aes_enc_dec.wasm" = "test_aes_enc_dec"
+"test_vec_entrypoint.wasm" = "test_vec_entrypoint"
 
 # Configure the computation amount. See the loader module for more
 # information on how computation cost is calculated.

--- a/runtime/plaid/resources/config/webhooks.toml
+++ b/runtime/plaid/resources/config/webhooks.toml
@@ -97,6 +97,10 @@ headers = []
 log_type = "test_aes_enc_dec"
 headers = []
 
+[webhooks."internal".webhooks."test_vec_entrypoint"]
+log_type = "test_vec_entrypoint"
+headers = []
+
 # End webhooks for tests
 
 # Additional webhook examples

--- a/runtime/plaid/resources/docker/musl/Dockerfile.amd64
+++ b/runtime/plaid/resources/docker/musl/Dockerfile.amd64
@@ -5,6 +5,11 @@ RUN mkdir /build
 WORKDIR /build
 COPY . .
 
+# Pin this version for now until the __rust_probestack issue is resolved 
+RUN rustup toolchain install nightly-2024-12-14
+RUN rustup default nightly-2024-12-14
+RUN rustup target add x86_64-unknown-linux-musl
+
 RUN cargo build --release --bin=plaid
 
 FROM alpine:3.6 AS alpine


### PR DESCRIPTION
The new entrypoint preserves the `Vec<u8>` it gets from the `Message` and passes it to the `main` function, which is then responsible for handling it.