### PR TITLE
feat: Add GitHub API functions for PRs, refs, and files

### DIFF
--- a/runtime/plaid-stl/src/github/mod.rs
+++ b/runtime/plaid-stl/src/github/mod.rs
@@ -261,6 +261,59 @@ pub struct CodeSearchCriteria {
     pub discard_specific_files: Option<Vec<String>>,
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct GetOrCreateBranchReferenceParams {
+    /// The account owner of the repository. The name is not case sensitive.
+    pub owner: String,
+    /// The name of the repository without the .git extension. The name is not case sensitive.
+    pub repo: String,
+    /// The Git reference. For more information, see [Git References](https://git-scm.com/book/en/v2/Git-Internals-Git-References) in the Git documentation.
+    pub reference: GitRef,
+    /// The SHA1 value for this reference.
+    pub sha: Option<String>,
+}
+
+/// A reference in Git that points to a branch or a tag.
+///
+/// This is a simplified representation that only supports
+/// `refs/heads/*` and `refs/tags/*`.
+#[derive(Serialize, Deserialize)]
+pub enum GitRef {
+    /// A branch reference under `refs/heads/`
+    Branch(String),
+    /// A tag reference under `refs/tags/`
+    Tag(String),
+}
+
+impl Display for GitRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tag(tag) => write!(f, "tags/{tag}"),
+            Self::Branch(branch) => write!(f, "heads/{branch}"),
+        }
+    }
+}
+
+/// A Git reference as returned by the remote API.
+///
+/// Wraps an underlying object type (e.g., commit, tag)
+/// and its associated SHA.
+#[derive(Deserialize)]
+pub struct GitApiRef {
+    pub target: GitRefTarget,
+}
+
+/// The target object that a Git reference points to.
+/// For example, a branch may point to a commit.
+#[derive(Deserialize)]
+pub struct GitRefTarget {
+    /// The type of the object (e.g., "commit", "tag").
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// The SHA-1 hash of the referenced object.
+    pub sha: String,
+}
+
 // TODO: Do not use this function, it is deprecated and will be removed soon
 pub fn add_user_to_team(team: &str, user: &str, org: &str, role: &str) -> Result<(), i32> {
     add_user_to_team_detailed(team, user, org, role).map_err(|_| -4)
@@ -1991,4 +2044,128 @@ pub fn check_codeowners_file(
 
     serde_json::from_str::<CodeownersStatus>(&response_body)
         .map_err(|_| PlaidFunctionError::InternalApiError)
+}
+
+/// Returns a single Git reference (branch or tag) from the repository.
+///
+/// This function only requires the **short name** of the reference:
+/// - For a branch, pass the branch name (e.g., `"main"`, not `"refs/heads/main"`).
+/// - For a tag, pass the tag name (e.g., `"v1.0.0"`, not `"refs/tags/v1.0.0"`).
+///
+/// The API call will automatically expand these into fully qualified
+/// Git reference paths under `refs/heads/` or `refs/tags/`.
+///
+/// See the [GitHub API docs](https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#get-a-reference)
+/// for more details.
+///
+/// # Arguments
+/// * `owner` - The account owner of the repository. Case-insensitive.
+/// * `repo` - The name of the repository without the `.git` extension. Case-insensitive.
+/// * `reference` - A [`GitRef`] representing either a branch or a tag, specified by its short name.
+///
+/// # Returns
+/// - `Ok(Some(GitApiRef))` if the reference exists.
+/// - `Ok(None)` if the reference does not exist.
+/// - `Err(PlaidFunctionError)` if the request fails.
+pub fn get_reference(
+    owner: impl Display,
+    repo: impl Display,
+    reference: GitRef,
+) -> Result<Option<GitApiRef>, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(github, get_reference);
+    }
+
+    let request = GetOrCreateBranchReferenceParams {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        reference,
+        sha: None,
+    };
+
+    let request = serde_json::to_string(&request).unwrap();
+    const RETURN_BUFFER_SIZE: usize = 1024 * 10; // 10 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let res = unsafe {
+        github_get_reference(
+            request.as_bytes().as_ptr(),
+            request.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    let response_body =
+        String::from_utf8(return_buffer).map_err(|_| PlaidFunctionError::InternalApiError)?;
+
+    if response_body.is_empty() {
+        Ok(None)
+    } else {
+        let reference = serde_json::from_str::<GitApiRef>(&response_body)
+            .map_err(|_| PlaidFunctionError::InternalApiError)?;
+
+        Ok(Some(reference))
+    }
+}
+
+/// Creates a new Git reference (branch or tag) in the repository.
+///
+/// This function only requires the **short name** of the reference:
+/// - For a branch, pass the branch name (e.g., `"feature-x"`, not `"refs/heads/feature-x"`).
+/// - For a tag, pass the tag name (e.g., `"v1.0.0"`, not `"refs/tags/v1.0.0"`).
+///
+/// The API call will automatically expand these into fully qualified
+/// Git reference paths under `refs/heads/` or `refs/tags/`.
+///
+/// See the [GitHub API docs](https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#create-a-reference)
+/// for more details.
+///
+/// # Arguments
+/// * `owner` - The account owner of the repository. Case-insensitive.
+/// * `repo` - The name of the repository without the `.git` extension. Case-insensitive.
+/// * `reference` - A [`GitRef`] representing either a branch or a tag, specified by its short name.
+/// * `sha` - The SHA-1 identifier of the commit or object the new reference should point to.
+///
+/// # Returns
+/// - `Ok(())` if the reference was created successfully.
+/// - `Err(PlaidFunctionError)` if the request fails.
+pub fn create_reference(
+    owner: impl Display,
+    repo: impl Display,
+    reference: GitRef,
+    sha: impl Display,
+) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(github, create_reference);
+    }
+
+    let request = GetOrCreateBranchReferenceParams {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        reference,
+        sha: Some(sha.to_string()),
+    };
+
+    let params = serde_json::to_string(&request).unwrap();
+    let res =
+        unsafe { github_create_reference(params.as_bytes().as_ptr(), params.as_bytes().len()) };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    Ok(())
 }

--- a/runtime/plaid-stl/src/github/pull_requests.rs
+++ b/runtime/plaid-stl/src/github/pull_requests.rs
@@ -1,0 +1,370 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+use crate::PlaidFunctionError;
+
+/// Request to fetch pull requests from a repository.
+///
+/// Represents the top-level parameters needed to query pull requests
+/// for a given repository, including the repository owner, name, and
+/// optional filter options.
+#[derive(Serialize, Deserialize)]
+pub struct GetPullRequestRequest {
+    /// Owner of the repository (e.g., GitHub username or org).
+    pub owner: String,
+    /// Name of the repository.
+    pub repo: String,
+    /// Optional filter options to narrow down the pull request query.
+    pub options: Option<GetPullRequestOptions>,
+    /// Page number for pagination.
+    pub page: u16,
+    /// Number of results per page (max 100).
+    pub per_page: usize,
+}
+
+/// Optional filters to apply when fetching pull requests.
+///
+/// Each field is optional; if none are provided, the request will
+/// return all pull requests for the repository.
+#[derive(Serialize, Deserialize, Default)]
+pub struct GetPullRequestOptions {
+    /// Filter pull requests by state (`open`, `closed`, or `all`).
+    ///
+    /// If not provided, GitHub defaults to `"open"`.
+    pub state: Option<PullRequestState>,
+    /// Filter pull requests by the source branch (the "head").
+    ///
+    /// Must be in the form `owner:branch`, where `owner` is the GitHub account
+    /// that owns the repository containing the branch:
+    ///   - If the PR branch lives in the same repository, `owner` is the same as
+    ///     the repository owner you pass in the API path.
+    ///   - If the PR branch comes from a fork, `owner` is the user or organization
+    ///     that owns the fork.
+    ///
+    /// Examples:
+    ///   - `octocat:feature-branch` (user-owned repo)
+    ///   - `github:security-fix` (org-owned fork)
+    ///
+    /// Supplying only the branch name (without the `owner:` prefix) is not valid
+    /// and will cause the filter to be ignored.
+    pub head: Option<String>,
+    /// Filter pull requests by the target branch (the "base") of the repository
+    /// you are querying.
+    pub base: Option<String>,
+}
+
+impl GetPullRequestOptions {
+    /// Creates a new builder for constructing `GetPullRequestOptions`.
+    pub fn builder() -> GetPullRequestOptionsBuilder {
+        GetPullRequestOptionsBuilder::default()
+    }
+}
+
+/// Builder for `GetPullRequestOptions`.
+///
+/// Provides a fluent interface for constructing `GetPullRequestOptions`
+/// without having to manually set optional fields.
+#[derive(Default)]
+pub struct GetPullRequestOptionsBuilder {
+    /// Filter pull requests by state (`open`, `closed`, or `all`).
+    ///
+    /// If not provided, GitHub defaults to `"open"`.
+    pub state: Option<PullRequestState>,
+    /// Filter pull requests by the source branch (the "head").
+    ///
+    /// Must be in the form `owner:branch`, where `owner` is the GitHub account
+    /// that owns the repository containing the branch:
+    ///   - If the PR branch lives in the same repository, `owner` is the same as
+    ///     the repository owner you pass in the API path.
+    ///   - If the PR branch comes from a fork, `owner` is the user or organization
+    ///     that owns the fork.
+    ///
+    /// Examples:
+    ///   - `octocat:feature-branch` (user-owned repo)
+    ///   - `github:security-fix` (org-owned fork)
+    ///
+    /// Supplying only the branch name (without the `owner:` prefix) is not valid
+    /// and will cause the filter to be ignored.
+    pub head: Option<String>,
+    /// Filter pull requests by the target branch (the "base") of the repository
+    /// you are querying.
+    pub base: Option<String>,
+}
+
+impl GetPullRequestOptionsBuilder {
+    /// Sets the pull request state filter.
+    pub fn state(mut self, state: PullRequestState) -> Self {
+        self.state = Some(state);
+        self
+    }
+
+    /// Sets the head branch filter.
+    pub fn head<T: Into<String>>(mut self, head: T) -> Self {
+        self.head = Some(head.into());
+        self
+    }
+
+    /// Sets the base branch filter.
+    pub fn base<T: Into<String>>(mut self, base: T) -> Self {
+        self.base = Some(base.into());
+        self
+    }
+
+    /// Consumes the builder and returns the constructed `GetPullRequestOptions`.
+    pub fn build(self) -> GetPullRequestOptions {
+        GetPullRequestOptions {
+            state: self.state,
+            head: self.head,
+            base: self.base,
+        }
+    }
+}
+
+/// Possible states of a pull request.
+#[derive(Serialize, Deserialize)]
+pub enum PullRequestState {
+    /// Only open pull requests.
+    Open,
+    /// Only closed pull requests.
+    Closed,
+    /// All pull requests, regardless of state.
+    All,
+}
+
+impl Display for PullRequestState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "closed"),
+            Self::All => write!(f, "all"),
+        }
+    }
+}
+
+/// Minimal representation of a GitHub Pull Request.
+/// Captures identifiers, state, timestamps, author, and branch context.
+#[derive(Debug, Deserialize, Clone)]
+pub struct PullRequest {
+    /// Unique internal GitHub ID for the pull request.
+    pub id: i64,
+    /// Pull request number within the repository.
+    pub number: i64,
+    /// API URL for this pull request.
+    pub url: String,
+    /// Web URL for viewing the pull request in the browser.
+    pub html_url: String,
+    /// Title of the pull request.
+    pub title: String,
+    /// Current state (e.g., "open", "closed").
+    pub state: String,
+    /// Whether the pull request is marked as a draft.
+    pub draft: Option<bool>,
+    /// ISO8601 timestamp if the PR was merged.
+    pub merged_at: Option<String>,
+    /// ISO8601 timestamp if the PR was closed.
+    pub closed_at: Option<String>,
+    /// ISO8601 timestamp when the PR was created.
+    pub created_at: String,
+    /// ISO8601 timestamp when the PR was last updated.
+    pub updated_at: String,
+    /// Author of the pull request, if present.
+    pub user: Option<User>,
+    /// The branch the changes are proposed from.
+    pub head: BranchSummary,
+    /// The branch the changes are proposed into.
+    pub base: BranchSummary,
+}
+
+/// Minimal representation of a GitHub user.
+/// Includes login name and numeric identifier.
+#[derive(Debug, Deserialize, Clone)]
+pub struct User {
+    /// GitHub username (login).
+    pub login: String,
+    /// Unique internal GitHub user ID.
+    pub id: i64,
+}
+
+/// Summary of a branch reference in a pull request.
+/// Includes the branch name and repository context.
+#[derive(Debug, Deserialize, Clone)]
+pub struct BranchSummary {
+    /// Branch name (ref).
+    #[serde(rename = "ref")]
+    pub r#ref: String,
+    /// Repository the branch belongs to.
+    pub repo: RepoSummary,
+}
+
+/// Summary of a repository.
+/// Minimal set of fields useful for identifying and linking.
+#[derive(Debug, Deserialize, Clone)]
+pub struct RepoSummary {
+    /// Full "owner/repo" name.
+    pub full_name: String,
+    /// Web URL for viewing the repository in the browser.
+    pub html_url: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CreatePullRequestRequest {
+    /// The account owner of the repository. The name is not case sensitive.
+    pub owner: String,
+    /// The name of the repository without the `.git` extension. The name is not case sensitive.
+    pub repo: String,
+    /// The title of the new pull request
+    pub title: String,
+    /// The name of the branch where your changes are implemented.
+    /// For cross-repository pull requests in the same network, namespace head
+    /// with a user like this: username:branch.
+    pub head: String,
+    /// The name of the branch you want the changes pulled into. This should be an existing branch
+    /// on the current repository. You cannot submit a pull request to one repository that
+    /// requests a merge to a base of another repository.
+    pub base: String,
+    /// The contents of the pull request.
+    pub body: Option<String>,
+    /// Indicates whether the pull request is a draft
+    pub draft: bool,
+}
+
+/// Fetches pull requests from a repository.
+///
+/// Queries the pull requests for the given `owner` and `repo`.  
+/// Optional filters can be applied via `GetPullRequestOptions`, such as:
+/// - limiting results to a particular state (`open`, `closed`, or `all`)
+/// - filtering by source branch (`head`)
+/// - filtering by target branch (`base`)
+///
+/// See the [GitHub API docs](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests)
+/// for more details.
+///
+/// # Arguments
+/// - `owner`: The account or organization that owns the repository.
+/// - `repo`: The name of the repository.
+/// - `options`: Optional filters to narrow the set of returned pull requests.
+///
+/// # Returns
+/// - `Ok(Vec<PullRequest>)` with all matching pull requests, or
+/// - `Err(PlaidFunctionError)` if the request fails.
+pub fn get_pull_requests(
+    owner: impl Display,
+    repo: impl Display,
+    options: Option<GetPullRequestOptions>,
+) -> Result<Vec<PullRequest>, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(github, get_pull_requests);
+    }
+
+    let per_page = 100;
+    let mut request_base = GetPullRequestRequest {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        options,
+        page: 1,
+        per_page,
+    };
+    const RETURN_BUFFER_SIZE: usize = 1024 * 1024 * 5; // 5 MiB
+
+    let mut prs = Vec::<PullRequest>::new();
+
+    loop {
+        let request = serde_json::to_string(&request_base).unwrap();
+
+        let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+        let res = unsafe {
+            github_get_pull_requests(
+                request.as_bytes().as_ptr(),
+                request.as_bytes().len(),
+                return_buffer.as_mut_ptr(),
+                RETURN_BUFFER_SIZE,
+            )
+        };
+
+        if res < 0 {
+            return Err(res.into());
+        }
+
+        return_buffer.truncate(res as usize);
+
+        // This should be safe because unless the Plaid runtime is expressly trying
+        // to mess with us, this came from a String in the API module.
+        let this_page = String::from_utf8(return_buffer).unwrap();
+        let this_page = serde_json::from_str::<Vec<PullRequest>>(&this_page)
+            .map_err(|_| PlaidFunctionError::InternalApiError)?;
+        let prs_returned = this_page.len();
+
+        prs.extend(this_page);
+
+        // If we did not fill this page, we know there won't be a next one.
+        if prs_returned < per_page {
+            break;
+        }
+
+        request_base.page += 1;
+    }
+
+    Ok(prs)
+}
+
+/// Creates a pull request in a repository.
+///
+/// Opens a new pull request in the given `owner` and `repo`. The `title`
+/// and `head`/`base` branches are required, with an optional `body` for
+/// a description. Set `draft` to `true` to open the pull request as a draft.  
+/// This function only supports creation; updating or merging pull requests
+/// must be done via separate APIs.
+///
+/// See the [GitHub API docs](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#create-a-pull-request)
+/// for more details.
+///
+/// # Arguments
+/// - `owner`: The account or organization that owns the repository.
+/// - `repo`: The name of the repository.
+/// - `title`: The title of the pull request.
+/// - `head`: The name of the branch where changes are implemented (the source branch).
+/// - `base`: The name of the branch you want the changes pulled into (the target branch).
+/// - `body`: Optional text providing a description of the pull request.
+/// - `draft`: Whether to create the pull request as a draft (`true`) or a normal PR (`false`).
+///
+/// # Returns
+/// - `Ok(())` if the pull request was successfully created, or
+/// - `Err(PlaidFunctionError)` if the request fails (e.g., invalid branches,
+///   missing permissions, or Plaid system misconfiguration).
+pub fn create_pull_request(
+    owner: impl Display,
+    repo: impl Display,
+    title: impl Display,
+    head: impl Display,
+    base: impl Display,
+    body: Option<impl Display>,
+    draft: bool,
+) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(github, create_pull_rquest);
+    }
+
+    let request = CreatePullRequestRequest {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        title: title.to_string(),
+        head: head.to_string(),
+        base: base.to_string(),
+        body: body.map(|b| b.to_string()),
+        draft,
+    };
+
+    let request = serde_json::to_string(&request).unwrap();
+
+    let res =
+        unsafe { github_create_pull_rquest(request.as_bytes().as_ptr(), request.as_bytes().len()) };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    Ok(())
+}

--- a/runtime/plaid/src/apis/github/mod.rs
+++ b/runtime/plaid/src/apis/github/mod.rs
@@ -7,6 +7,7 @@ mod graphql;
 mod members;
 mod pats;
 mod pull_requests;
+mod refs;
 mod repos;
 mod secrets;
 mod teams;

--- a/runtime/plaid/src/apis/github/refs.rs
+++ b/runtime/plaid/src/apis/github/refs.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use super::Github;
+use crate::{
+    apis::{github::GitHubError, ApiError},
+    loader::PlaidModule,
+};
+use plaid_stl::github::GetOrCreateBranchReferenceParams;
+
+impl Github {
+    /// Returns a single reference from the Git database.
+    pub async fn get_reference(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
+        let request: GetOrCreateBranchReferenceParams =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let owner = self.validate_username(&request.owner)?;
+        let repo = self.validate_repository_name(&request.repo)?;
+
+        info!(
+            "Fetching reference [{}] for repository [{owner}/{repo}] on behalf of [{module}]",
+            request.reference
+        );
+        let address = format!("/repos/{owner}/{repo}/git/ref/{}", request.reference);
+
+        match self.make_generic_get_request(address, module).await {
+            Ok((status, Ok(body))) => {
+                if status == 200 {
+                    Ok(body)
+                } else if status == 404 {
+                    Ok(Default::default())
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Creates a reference for a repository.
+    pub async fn create_reference(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<u32, ApiError> {
+        let request: GetOrCreateBranchReferenceParams =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let Some(sha) = request.sha else {
+            return Err(ApiError::BadRequest);
+        };
+
+        let owner = self.validate_username(&request.owner)?;
+        let repo = self.validate_repository_name(&request.repo)?;
+        let sha = self.validate_commit_hash(&sha)?;
+
+        let reference = format!("refs/{}", request.reference);
+
+        info!(
+            "Creating reference [{reference}] for repository [{owner}/{repo}] on behalf of [{module}]",
+        );
+
+        let address = format!("/repos/{owner}/{repo}/git/refs");
+
+        let body = serde_json::json!({
+            "ref": reference,
+            "sha": sha,
+        });
+
+        match self.make_generic_post_request(address, body, module).await {
+            Ok((status, Ok(_))) => {
+                if status == 201 {
+                    Ok(0)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -332,6 +332,8 @@ impl_new_function!(
     DISALLOW_IN_TEST_MODE
 );
 impl_new_function_with_error_buffer!(github, get_weekly_commit_count, ALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(github, get_reference, ALLOW_IN_TEST_MODE);
+impl_new_function!(github, create_reference, DISALLOW_IN_TEST_MODE);
 
 // GitHub Functions only available with GitHub App authentication
 impl_new_function!(github, review_fpat_requests_for_org, DISALLOW_IN_TEST_MODE);
@@ -629,6 +631,7 @@ pub fn to_api_function(
         "github_pull_request_request_reviewers" => {
             Function::new_typed_with_env(&mut store, &env, github_pull_request_request_reviewers)
         }
+<<<<<<< HEAD
         "github_require_signed_commits" => {
             Function::new_typed_with_env(&mut store, &env, github_require_signed_commits)
         }
@@ -640,6 +643,13 @@ pub fn to_api_function(
         }
         "github_remove_repo_from_team" => {
             Function::new_typed_with_env(&mut store, &env, github_remove_repo_from_team)
+=======
+        "github_get_reference" => {
+            Function::new_typed_with_env(&mut store, &env, github_get_reference)
+        }
+        "github_create_reference" => {
+            Function::new_typed_with_env(&mut store, &env, github_create_reference)
+>>>>>>> 2460f13 (Implement get_reference and create_reference APIs)
         }
 
         // Slack Calls

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -334,6 +334,9 @@ impl_new_function!(
 impl_new_function_with_error_buffer!(github, get_weekly_commit_count, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, get_reference, ALLOW_IN_TEST_MODE);
 impl_new_function!(github, create_reference, DISALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(github, list_pull_requests, ALLOW_IN_TEST_MODE);
+impl_new_function!(github, create_pull_request, DISALLOW_IN_TEST_MODE);
+impl_new_function!(github, create_file, DISALLOW_IN_TEST_MODE);
 
 // GitHub Functions only available with GitHub App authentication
 impl_new_function!(github, review_fpat_requests_for_org, DISALLOW_IN_TEST_MODE);
@@ -631,7 +634,6 @@ pub fn to_api_function(
         "github_pull_request_request_reviewers" => {
             Function::new_typed_with_env(&mut store, &env, github_pull_request_request_reviewers)
         }
-<<<<<<< HEAD
         "github_require_signed_commits" => {
             Function::new_typed_with_env(&mut store, &env, github_require_signed_commits)
         }
@@ -643,14 +645,20 @@ pub fn to_api_function(
         }
         "github_remove_repo_from_team" => {
             Function::new_typed_with_env(&mut store, &env, github_remove_repo_from_team)
-=======
+        }
         "github_get_reference" => {
             Function::new_typed_with_env(&mut store, &env, github_get_reference)
         }
         "github_create_reference" => {
             Function::new_typed_with_env(&mut store, &env, github_create_reference)
->>>>>>> 2460f13 (Implement get_reference and create_reference APIs)
         }
+        "github_list_pull_requests" => {
+            Function::new_typed_with_env(&mut store, &env, github_list_pull_requests)
+        }
+        "github_create_pull_request" => {
+            Function::new_typed_with_env(&mut store, &env, github_create_pull_request)
+        }
+        "github_create_file" => Function::new_typed_with_env(&mut store, &env, github_create_file),
 
         // Slack Calls
         "slack_post_to_named_webhook" => {


### PR DESCRIPTION
This PR introduces new functionality to interact with the GitHub API, enabling the creation and retrieval of pull requests, the management of Git references (branches and tags), and the creation of files within a repository.

### New Features

-   **Pull Requests:**
    -   `list_pull_requests`: Allows fetching a list of pull requests from a repository with support for filtering by state, head, and base branch.
    -   `create_pull_request`: Enables creating new pull requests, including draft PRs.

-   **Git References:**
    -   `get_reference`: Fetches a specific Git reference (branch or tag) by name.
    -   `create_reference`: Creates a new Git reference (branch or tag) pointing to a specific SHA.

-   **File Management:**
    -   `create_file`: Adds the capability to create a new file in a repository.

### Implementation Details

-   The new functions are added to the `plaid-stl` crate with corresponding request and response structs.
-   The `plaid` runtime implements the logic to handle these new API calls in `runtime/plaid/src/apis/github/`.
-   The new functions are exposed to Plaid modules by registering them in `runtime/plaid/src/functions/api.rs`.

This enhances Plaid's capabilities for automating repository management and CI/CD workflows.