### PR TITLE
Fix SBOM API and bump to 28.0

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.27.4"
+version = "0.28.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3224,7 +3224,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.27.4"
+version = "0.28.0"
 dependencies = [
  "aes",
  "alkali",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.27.4"
+version = "0.28.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.27.4"
+version = "0.28.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/github/types.rs
+++ b/runtime/plaid-stl/src/github/types.rs
@@ -40,7 +40,7 @@ pub struct ExternalRef {
 pub struct SbomPackage {
     pub name: String,
     #[serde(rename = "SPXID")]
-    pub spxid: String,
+    pub spxid: Option<String>,
     pub version_info: String,
     pub files_analyzed: bool,
     pub download_location: String,

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.27.4"
+version = "0.28.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
* Mark the `SPXID` field as optional
* Bump to v0.28.0