### PR TITLE
Relax GH path validation

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3224,7 +3224,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "aes",
  "alkali",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.28.2"
+version = "0.28.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.28.2"
+version = "0.28.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/github/validators.rs
+++ b/runtime/plaid/src/apis/github/validators.rs
@@ -73,7 +73,7 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
     define_regex_validator!(validators, "secret_name", r"^[A-Z][A-Z0-9_]*$");
     define_regex_validator!(validators, "filename", r"^[a-zA-Z0-9\.]{1,32}$");
     define_regex_validator!(validators, "extension", r"^[a-zA-Z0-9]{1,5}$");
-    define_regex_validator!(validators, "path", r"^[a-zA-Z0-9\./]{1,64}$");
+    define_regex_validator!(validators, "path", r"^[a-zA-Z0-9\./_-]{1,128}$");
 
     define_regex_validator!(validators, "event_type", r"^[\w\-_]+$");
 


### PR DESCRIPTION
* Relax GH path validation to accept `_` and `-`, and to allow for paths up to 128 characters
* Bump version to 28.3
