### PR TITLE
Support restricting MNR redirects

### DIFF
--- a/runtime/plaid/src/apis/general/network.rs
+++ b/runtime/plaid/src/apis/general/network.rs
@@ -59,7 +59,8 @@ pub struct Request {
     #[serde(default)]
     available_in_test_mode: bool,
     /// Whether to follow redirects
-    pub enable_redirects: Option<bool>,
+    #[serde(default)] // default to false
+    pub enable_redirects: bool,
 }
 
 /// Deserialize a non‐zero timeout (1–255 seconds) into a `Duration`, erroring on 0.


### PR DESCRIPTION
MNRs used to follow redirects by default, which could introduce security issues.

With this PR we
* Default to **not** following redirects
* Support a per-request setting to enable redirects

The result is that we default to a safe configuration, but allow for fine-tuning at the request level.

## Backward compatibility
This change is backward compatible, but it introduces a more restrictive behavior by default.
Existing MNRs that rely on the ability to follow redirects would therefore break at runtime. To fix this, one must enable redirects for each request that needs them.