### PR TITLE
Fix ambiguity in wasm return code

### DIFF
--- a/runtime/plaid-stl/src/lib.rs
+++ b/runtime/plaid-stl/src/lib.rs
@@ -173,7 +173,7 @@ macro_rules! entrypoint_with_source {
 
             let buffer_size = fetch_data_and_source(vec![].as_mut_ptr(), 0);
             let buffer_size = if buffer_size < 4 {
-                return buffer_size;
+                return -3;
             } else {
                 buffer_size as u32
             };
@@ -182,7 +182,7 @@ macro_rules! entrypoint_with_source {
 
             let copied_size = fetch_data_and_source(data_buffer.as_mut_ptr(), buffer_size);
             let copied_size = if copied_size < 4 {
-                return copied_size;
+                return -4;
             } else {
                 copied_size as u32
             };
@@ -232,7 +232,7 @@ macro_rules! entrypoint_with_source_and_response {
 
             let buffer_size = fetch_data_and_source(vec![].as_mut_ptr(), 0);
             let buffer_size = if buffer_size < 4 {
-                return buffer_size;
+                return -3;
             } else {
                 buffer_size as u32
             };
@@ -241,7 +241,7 @@ macro_rules! entrypoint_with_source_and_response {
 
             let copied_size = fetch_data_and_source(data_buffer.as_mut_ptr(), buffer_size);
             let copied_size = if copied_size < 4 {
-                return copied_size;
+                return -4;
             } else {
                 copied_size as u32
             };


### PR DESCRIPTION
A `0` returned by the WASM entrypoint function means "success". However, there are currently some possible edge cases where the entrypoint could return `0` when the module has not even been executed.
In particular,
* If the size of the data-and-source buffer is 0
* If the number of bytes that were copied that were copied into that buffer is 0

To fix this ambiguity, we return two new error codes (`-3` and `-4`, respectively) in these cases and, more in general, when there are problems with this buffer. This ensures that a WASM module returns `0` if and only if it has been executed successfully.