### PR TITLE
Multi-byte write to the guest's memory

### DIFF
--- a/runtime/plaid/src/functions/memory.rs
+++ b/runtime/plaid/src/functions/memory.rs
@@ -95,11 +95,9 @@ pub fn safely_write_data_back(
         .slice(&memory_view, data.len() as u32)
         .map_err(|_| FunctionErrors::CouldNotGetAdequateMemory)?;
 
-    for i in 0..data.len() {
-        if let Err(_) = values.index(i as u64).write(data[i]) {
-            return Err(FunctionErrors::FailedToWriteGuestMemory);
-        }
-    }
+    values
+        .write_slice(data)
+        .map_err(|_| FunctionErrors::FailedToWriteGuestMemory)?;
 
     Ok(data.len() as i32)
 }


### PR DESCRIPTION
Instead of writing byte-by-byte, use `write_slice` when writing data back to the guest's memory.