### PR TITLE
Use readiness check to start tests when Plaid is ready

### DIFF
--- a/runtime/plaid/resources/config/loading.toml
+++ b/runtime/plaid/resources/config/loading.toml
@@ -6,6 +6,7 @@
 module_dir = "../compiled_modules/"
 lru_cache_size = 200
 compiler_backend = "cranelift"
+readiness_check_file = "./plaid_ready"
 
 test_mode = true
 test_mode_exemptions = [


### PR DESCRIPTION
Using a `sleep` before starting the tests has two downsides:
* It wastes time if Plaid is ready before the `sleep` returns
* It fails if Plaid is slightly late, resulting in flaky tests

With this PR we leverage the recently-added readiness check to start testing when Plaid is ready.
If Plaid is not ready within 2 minutes, we give up and return an error.