### PR TITLE
Check that a module's computation limit is not 0

### DIFF
--- a/runtime/plaid/src/loader/errors.rs
+++ b/runtime/plaid/src/loader/errors.rs
@@ -7,7 +7,6 @@ pub enum Errors {
     SigningError(sshcerts::error::Error),
     NotEnoughValidSignatures(usize, usize),
     FileError(std::io::Error),
-    InvalidComputationLimit(u64),
 }
 
 impl Display for Errors {
@@ -24,9 +23,6 @@ impl Display for Errors {
                 "Expected {expected} valid signatures but only received {received}"
             ),
             Self::FileError(error) => write!(f, "IO error: {error}"),
-            Self::InvalidComputationLimit(v) => {
-                write!(f, "The value [{v}] is not a valid computation limit")
-            }
         }
     }
 }

--- a/runtime/plaid/src/loader/mod.rs
+++ b/runtime/plaid/src/loader/mod.rs
@@ -106,8 +106,10 @@ pub struct Configuration {
     /// What the log type of a module should be if it's not the first part of the filename
     pub log_type_overrides: HashMap<String, String>,
     /// How much computation a module is allowed to do
+    #[serde(deserialize_with = "deserialize_limited_amount")]
     pub computation_amount: LimitedAmount,
     /// How much memory a module is allowed to use
+    #[serde(deserialize_with = "deserialize_limited_amount")]
     pub memory_page_count: LimitedAmount,
     /// How many bytes a module is allowed to store in persistent storage
     pub storage_size: LimitableAmount,
@@ -151,6 +153,35 @@ pub struct Configuration {
     /// If this value is set, Plaid will treat it as an absolute path, create a text file and write "READY"
     /// when the system is fully up and ready to receive traffic.
     pub readiness_check_file: Option<String>,
+}
+
+/// Deserializer for a LimitedAmount where none of the provided values can be 0.
+fn deserialize_limited_amount<'de, D>(deserializer: D) -> Result<LimitedAmount, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    let raw = LimitedAmount::deserialize(deserializer)?;
+
+    // Validate: no zeros allowed anywhere
+    if raw.default == 0 {
+        return Err(de::Error::custom("`default` cannot be zero"));
+    }
+
+    if let Some((k, _)) = raw.log_type.iter().find(|(_, &v)| v == 0) {
+        return Err(de::Error::custom(format!("`log_type.{k}` cannot be zero")));
+    }
+
+    if let Some((k, _)) = raw.module_overrides.iter().find(|(_, &v)| v == 0) {
+        return Err(de::Error::custom(format!(
+            "`module_overrides.{k}` cannot be zero"
+        )));
+    }
+
+    Ok(LimitedAmount {
+        default: raw.default,
+        log_type: raw.log_type,
+        module_overrides: raw.module_overrides,
+    })
 }
 
 /// This structure defines the parameters required to validate signatures for modules.
@@ -305,9 +336,6 @@ impl PlaidModule {
         // Get the computation limit for the module
         let computation_limit =
             get_module_computation_limit(computation_amount, &filename, log_type);
-        if computation_limit == 0 {
-            return Err(Errors::InvalidComputationLimit(computation_limit));
-        }
 
         // Get the memory limit for the module
         let page_limit = get_module_page_count(memory_page_count, &filename, log_type);


### PR DESCRIPTION
If for some reason `computation_limit` is 0, that will cause a crash [here](https://github.com/obelisk/plaid/blob/main/runtime/plaid/src/executor/mod.rs#L525). With this PR we return an error at module loading time if that happens.