### PR TITLE
[ON HOLD] Parse Content-Length header if present, otherwise stop processing

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3435,7 +3435,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "aes",
  "alkali",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.33.1"
+version = "0.34.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.33.1"
+version = "0.34.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/github/secrets.rs
+++ b/runtime/plaid/src/apis/github/secrets.rs
@@ -42,9 +42,10 @@ impl Github {
 
         // Validate secret length against GitHub's 48KiB limit
         if secret.len() > GITHUB_SECRET_MAX_BYTES {
-            return Err(ApiError::GitHubError(GitHubError::InvalidInput(
-                format!("Secret exceeds GitHub's 48KiB limit: {} bytes", secret.len()),
-            )));
+            return Err(ApiError::GitHubError(GitHubError::InvalidInput(format!(
+                "Secret exceeds GitHub's 48KiB limit: {} bytes",
+                secret.len()
+            ))));
         }
 
         match env_name {

--- a/runtime/plaid/src/functions/internal.rs
+++ b/runtime/plaid/src/functions/internal.rs
@@ -8,7 +8,7 @@ use crate::{
     functions::{get_memory, safely_get_string},
 };
 
-use super::{safely_get_memory, safely_write_data_back, calculate_max_buffer_size, FunctionErrors};
+use super::{calculate_max_buffer_size, safely_get_memory, safely_write_data_back, FunctionErrors};
 
 /// Implement a way for a module to print to env_logger
 pub fn print_debug_string(env: FunctionEnvMut<Env>, log_buffer: WasmPtr<u8>, log_buffer_size: u32) {


### PR DESCRIPTION
Because some requests might reach warp without a `Content-Length` header and that would be breaking the filter we had in place, causing warp to respond with a HTTP 411. See [here](https://docs.rs/warp/latest/warp/filters/body/fn.content_length_limit.html) for more info.

Instead, now we parse the `Content-Length` header if present and manually check it's below a threshold, but we reply HTTP 200 in all cases.