### PR TITLE
Support enforcing a max response size for MNRs

### DIFF
--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3939,6 +3939,7 @@ dependencies = [
  "cookie",
  "cookie_store",
  "futures-core",
+ "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -3958,12 +3959,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.2",
+ "tokio-util",
  "tower 0.5.2",
  "tower-http 0.6.6",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.1",
 ]
@@ -5502,6 +5505,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -64,6 +64,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
     "json",
     "cookies",
+    "stream",
 ] }
 reqwest_cookie_store = "0.8.0"
 rustls = { version = "0.23.17", features = ["ring"] }

--- a/runtime/plaid/src/apis/mod.rs
+++ b/runtime/plaid/src/apis/mod.rs
@@ -128,6 +128,7 @@ pub enum ApiError {
     BlockchainError(blockchain::BlockchainError),
     TestMode,
     JiraError(jira::JiraError),
+    NetworkResponseTooLarge,
 }
 
 impl From<evm::EvmCallError> for ApiError {


### PR DESCRIPTION
This change is backward compatible because the new field is optional. If none is provided, default to no limit.