### PR TITLE
Fix WebSocket URI selector to prevent unsafe heap assumptions

### DIFF
--- a/runtime/plaid/src/data/websocket/mod.rs
+++ b/runtime/plaid/src/data/websocket/mod.rs
@@ -276,6 +276,7 @@ impl WebSocketClient {
             configuration.uris.clone(),
             configuration.min_retry_duration,
             configuration.max_retry_duration,
+            configuration.log_type.clone(),
         );
 
         Self {


### PR DESCRIPTION
## Summary

Refactors the `UriSelector` to use a handle-based approach. Previously, the selector implicitly assumed the URI at the top of the heap remained unchanged between `next_uri()` and subsequent `mark_failed()` or `reset_failure()` calls, creating fragility under future modifications. The new design requires callers to pass back the exact `UriEntry` they received, eliminating this unsafe assumption while also enabling proper failure tracking for connections that drop after being established.

## Changes

**Code (`runtime/plaid/src/data/websocket/selector.rs`)**
- Changed `next_uri()` to pop and return `UriEntry` instead of `(String, Uri)` tuple
- Updated `mark_failed()` to accept `UriEntry` by value for reinsertion
- Updated `reset_failure()` to accept and return `UriEntry` without reinserting (caller holds it until failure)
- Removed implicit heap operations; entries now explicitly passed between selector and caller

**Code (`runtime/plaid/src/data/websocket/mod.rs`)**
- Updated `start()` to return `Option<UriEntry>` instead of `Option<String>`
- Refactored connection flow to pass `UriEntry` through success and failure paths

## Rationale

The original design relied on implicit ordering guarantees that could be violated by future code changes. The handle-based approach makes the contract explicit: the caller receives an entry, uses it, and returns it for state updates. This eliminates silent bugs where the wrong URI could be penalized if heap state changed between operations.