### PR TITLE
Make `from` address optional in `EstimateGasRequest`

### DIFF
--- a/runtime/plaid-stl/src/blockchain/evm/types.rs
+++ b/runtime/plaid-stl/src/blockchain/evm/types.rs
@@ -249,7 +249,7 @@ pub struct EthCallRequest {
 #[derive(Serialize, Deserialize)]
 pub struct EstimateGasRequest {
     /// The account the transaction is sent from
-    pub from: String,
+    pub from: Option<String>,
     /// The address the transaction is directed to
     /// If `None`, it indicates a contract creation transaction
     pub to: Option<String>,
@@ -265,19 +265,15 @@ pub struct EstimateGasRequest {
 
 impl EstimateGasRequest {
     /// Create a new builder for EstimateGasRequest
-    pub fn builder(
-        chain_id: impl Into<ChainId>,
-        from: impl Display,
-        block_tag: BlockTag,
-    ) -> EstimateGasRequestBuilder {
-        EstimateGasRequestBuilder::new(chain_id, from.to_string(), block_tag)
+    pub fn builder(chain_id: impl Into<ChainId>, block_tag: BlockTag) -> EstimateGasRequestBuilder {
+        EstimateGasRequestBuilder::new(chain_id, block_tag)
     }
 }
 
 /// Builder for `EstimateGasRequest`
 pub struct EstimateGasRequestBuilder {
     chain_id: ChainId,
-    from: String,
+    from: Option<String>,
     to: Option<String>,
     value: Option<String>,
     data: Option<String>,
@@ -285,15 +281,21 @@ pub struct EstimateGasRequestBuilder {
 }
 
 impl EstimateGasRequestBuilder {
-    fn new(chain_id: impl Into<ChainId>, from: impl Display, block_tag: BlockTag) -> Self {
+    fn new(chain_id: impl Into<ChainId>, block_tag: BlockTag) -> Self {
         Self {
             chain_id: chain_id.into(),
-            from: from.to_string(),
+            from: None,
             to: None,
             value: None,
             data: None,
             block_tag,
         }
+    }
+
+    /// Set the source address
+    pub fn from(mut self, from: impl Into<String>) -> Self {
+        self.from = Some(from.into());
+        self
     }
 
     /// Set the destination address

--- a/runtime/plaid/src/apis/blockchain/evm/mod.rs
+++ b/runtime/plaid/src/apis/blockchain/evm/mod.rs
@@ -248,7 +248,9 @@ impl EvmClient {
         let node_selector = self.get_node_selector(request.chain_id)?;
 
         let mut object = serde_json::Map::new();
-        object.insert("from".to_string(), Value::String(request.from.to_string()));
+        if let Some(from) = request.from {
+            object.insert("from".to_string(), Value::String(from.to_string()));
+        }
 
         if let Some(to) = request.to {
             object.insert("to".to_string(), Value::String(to.to_string()));


### PR DESCRIPTION
## Summary

Makes the `from` address field optional in `EstimateGasRequest` for EVM blockchain operations. This change allows gas estimation without requiring a source address, aligning with Ethereum JSON-RPC specification where the `from` parameter is optional for `eth_estimateGas` calls.

## Changes

- Modified `EstimateGasRequest.from` field from `String` to `Option<String>` in the STL types
- Updated `EstimateGasRequestBuilder::new()` to no longer require a `from` parameter
- Added new `EstimateGasRequestBuilder::from()` method to optionally set the source address
- Updated `EvmClient::estimate_gas()` to conditionally include the `from` field in JSON-RPC request only when provided

## Rationale

The `eth_estimateGas` method allows the `from` field to be optional. When omitted, the node uses a default address (typically the zero address). The previous implementation required this field, unnecessarily restricting valid use cases where gas estimation doesn't depend on a specific sender address.

This change improves API ergonomics by matching the underlying protocol specification and allowing more flexible gas estimation scenarios.