### PR TITLE
Enforce size limit on the body of a GET request

### DIFF
--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -32,7 +32,7 @@ use std::{
 };
 
 use crossbeam_channel::TrySendError;
-use warp::{http::HeaderMap, hyper::body::Bytes, path, Filter};
+use warp::{http::HeaderMap, path, Filter};
 
 #[derive(Debug)]
 enum Errors {
@@ -52,7 +52,7 @@ const MAX_WEBHOOK_BODY_SIZE: usize = 1024 * 256; // 256KiB
 
 async fn post_handler(
     webhook: String,
-    mut body: impl Stream<Item = Result<impl Buf, warp::Error>> + Unpin + Send + Sync,
+    body: impl Stream<Item = Result<impl Buf, warp::Error>> + Unpin + Send + Sync,
     headers: HeaderMap,
     webhooks: HashMap<String, WebhookConfig>,
     exec: Arc<Executor>,
@@ -67,60 +67,15 @@ async fn post_handler(
 
         let logbacks_allowed = webhook_configuration.logbacks_allowed.clone();
 
-        // Keep a vector of references to avoid doing too many allocations
-        // before doing a final copy into a single buffer
-        let mut buffers = Vec::new();
-        // We reserve space for 32 chunk pointers to also avoid reallocating this pointer
-        // buffer
-        buffers.reserve(32);
-        let mut total_bytes_count = 0usize;
-
-        // Read a maximum of 256KB from the request
-        // I'm trying to find a source to get proof that this
-        // next() call is not going to read possibly gigabytes into memory but for now
-        // I'm going to trust it.
-        while let Some(buf) = body.next().await {
-            match buf {
-                Ok(buf) => {
-                    // Immiedately exit if this chunk is going to exceed our maximum allowed size
-                    if buf.remaining() + total_bytes_count > MAX_WEBHOOK_BODY_SIZE {
-                        error!(
-                            "Webhook body for webhook: {webhook} exceeded maximum allowed size of {} bytes",
-                            MAX_WEBHOOK_BODY_SIZE
-                        );
-                        // We still return a 200 to avoid leaking information
-                        return Box::new(warp::reply());
-                    }
-                    // Consider these bytes read
-                    total_bytes_count += buf.remaining();
-
-                    // Get all the pieces of this buffer into our vec of vecs
-                    buffers.push(buf);
-                }
-                Err(e) => {
-                    error!("Error reading webhook body for webhook: {webhook}: {e}");
-                    // We still return a 200 to avoid leaking information
-                    return Box::new(warp::reply());
-                }
+        // Read the body with size limit
+        let full_body = match read_body_with_limit(body, MAX_WEBHOOK_BODY_SIZE).await {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                error!("Error reading body for webhook: {webhook}: {e}");
+                // We still return a 200 to avoid leaking information
+                return Box::new(warp::reply());
             }
-        }
-
-        let mut full_body = Vec::with_capacity(total_bytes_count);
-
-        let total_buffers = buffers.len();
-        let mut total_chunks = 0;
-        for mut buffer in buffers {
-            while buffer.remaining() > 0 {
-                let chunk = buffer.chunk();
-                let chunk_len = chunk.len();
-                full_body.extend_from_slice(chunk);
-                buffer.advance(chunk_len);
-                total_chunks += 1;
-            }
-        }
-        trace!(
-            "Read {total_bytes_count} bytes from webhook body across {total_buffers} buffers and {total_chunks} chunks"
-        );
+        };
 
         // Create the message we're going to send into the execution system.
         let mut message = Message::new(
@@ -157,6 +112,64 @@ async fn post_handler(
     }
     // Always Empty Response
     Box::new(warp::reply())
+}
+
+/// Read the body of a request with a maximum size limit
+async fn read_body_with_limit(
+    mut body: impl Stream<Item = Result<impl Buf, warp::Error>> + Unpin,
+    max_size: usize,
+) -> Result<Vec<u8>, String> {
+    // Keep a vector of references to avoid doing too many allocations
+    // before doing a final copy into a single buffer
+    let mut buffers = Vec::new();
+    // We reserve space for 32 chunk pointers to also avoid reallocating this pointer
+    // buffer
+    buffers.reserve(32);
+    let mut total_bytes_count = 0usize;
+
+    // Read a maximum of max_size from the request
+    // I'm trying to find a source to get proof that this
+    // next() call is not going to read possibly gigabytes into memory but for now
+    // I'm going to trust it.
+    while let Some(buf) = body.next().await {
+        match buf {
+            Ok(buf) => {
+                // Immediately exit if this chunk is going to exceed our maximum allowed size
+                if buf.remaining() + total_bytes_count > max_size {
+                    return Err(format!(
+                        "Body exceeded maximum allowed size of {max_size} bytes"
+                    ));
+                }
+                // Consider these bytes read
+                total_bytes_count += buf.remaining();
+
+                // Get all the pieces of this buffer into our vec of vecs
+                buffers.push(buf);
+            }
+            Err(e) => {
+                return Err(format!("Error reading body: {e}"));
+            }
+        }
+    }
+
+    let mut full_body = Vec::with_capacity(total_bytes_count);
+
+    let total_buffers = buffers.len();
+    let mut total_chunks = 0;
+    for mut buffer in buffers {
+        while buffer.remaining() > 0 {
+            let chunk = buffer.chunk();
+            let chunk_len = chunk.len();
+            full_body.extend_from_slice(chunk);
+            buffer.advance(chunk_len);
+            total_chunks += 1;
+        }
+    }
+    trace!(
+        "Read {total_bytes_count} bytes from webhook body across {total_buffers} buffers and {total_chunks} chunks"
+    );
+
+    Ok(full_body)
 }
 
 #[tokio::main]
@@ -350,13 +363,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let get_route = warp::get()
                 .and(path!("webhook" / String))
                 .and(warp::query::<HashMap<String, String>>())
-                .and(warp::body::bytes())
+                .and(warp::body::stream())
                 .and(warp::header::headers_cloned())
                 .and(with(webhook_config.clone()))
                 .and(with(modules_by_name.clone()))
                 .and(with(get_cache.clone()))
                 .and(with(webhook_server_get_log_sender.clone()))
-                .and_then(|webhook: String, query: HashMap<String, String>, body: Bytes, headers: HeaderMap, webhook_config: Arc<WebhookServerConfiguration>, modules: Arc<HashMap<String, Arc<PlaidModule>>>, get_cache: Arc<RwLock<HashMap<String, (u64, String)>>>, log_sender: crossbeam_channel::Sender<Message>| async move {
+                .and_then(|webhook: String, query: HashMap<String, String>, body, headers: HeaderMap, webhook_config: Arc<WebhookServerConfiguration>, modules: Arc<HashMap<String, Arc<PlaidModule>>>, get_cache: Arc<RwLock<HashMap<String, (u64, String)>>>, log_sender: crossbeam_channel::Sender<Message>| async move {
                     if let Some(webhook_configuration) = webhook_config.webhooks.get(&webhook) {
                         match &webhook_configuration.get_mode {
                             // Note that CacheMode is elided here as there is no caching for static data
@@ -438,10 +451,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                                 let (response_send, response_recv) = tokio::sync::oneshot::channel();
 
+                                // Read the body with size limit
+                                let body_bytes = match read_body_with_limit(body, MAX_WEBHOOK_BODY_SIZE).await {
+                                    Ok(bytes) => bytes,
+                                    Err(e) => {
+                                        error!("Error reading body for get request to {webhook}: {e}");
+                                        return Ok(warp::reply::html(String::new()));
+                                    }
+                                };
+
                                 // Construct a message to send to the rule
                                 let mut message = Message::new_detailed(
                                     name.to_string(),
-                                    body.to_vec(),
+                                    body_bytes,
                                     source,
                                     logbacks_allowed,
                                     query.into_iter().map(|(k, v)| (k, v.into_bytes())).collect(),


### PR DESCRIPTION
Extract recently-added logic into a reusable `read_body_with_limit` function, which is then used for both POST and GET requests.