### PR TITLE
Add BigQuery API support with query execution and permission model

### DIFF
--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -2259,21 +2259,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2959,22 +2944,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -3712,23 +3681,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe 0.2.1",
- "openssl-sys",
- "schannel",
- "security-framework 3.7.0",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3927,32 +3879,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3963,18 +3889,6 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "outref"
@@ -4795,13 +4709,11 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-rustls 0.27.7",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4812,7 +4724,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
@@ -5846,16 +5757,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -92,6 +92,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +133,12 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -167,6 +187,179 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "arrow"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a3ec4fe573f9d1f59d99c085197ef669b00b088ba1d7bb75224732d9357a74"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dcf19f07792d8c7f91086c67b574a79301e367029b17fcf63fb854332246a10"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7845c32b41f7053e37a075b3c2f29c6f5ea1b3ca6e5df7a2d325ee6e1b4a63cf"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.15.5",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5c681a99606f3316f2a99d9c8b6fa3aad0b1d34d8f6d7a1b471893940219d8"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6365f8527d4f87b133eeb862f9b8093c009d41a210b8f101f91aa2392f61daac"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd962fc3bf7f60705b25bcaa8eb3318b2545aa1d528656525ebdd6a17a6cd6fb"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3527365b24372f9c948f16e53738eb098720eea2093ae73c7af04ac5e30a39b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79af2db0e62a508d34ddf4f76bfd6109b6ecc845257c9cba6f939653668f89ac"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-row"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da30e9d10e9c52f09ea0cf15086d6d785c11ae8dcc3ea5f16d402221b6ac7735"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b0f9c0c3582dd55db0f136d3b44bfa0189df07adcf7dc7f2f2e74db0f52eb8"
+
+[[package]]
+name = "arrow-select"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92fc337f01635218493c23da81a364daf38c694b05fc20569c3193c11c561984"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num",
+]
+
+[[package]]
+name = "arrow-string"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d596a9fc25dae556672d5069b090331aca8acb93cae426d8b7dcdf1c558fa0ce"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -247,6 +440,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +470,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -820,6 +1044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand",
+ "tokio",
 ]
 
 [[package]]
@@ -882,6 +1107,20 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "bindgen"
@@ -1055,16 +1294,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1190,6 +1430,26 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -1530,6 +1790,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1954,6 +2220,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flatbuffers"
+version = "24.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustc_version",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,6 +2257,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2192,6 +2483,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "google-cloud-auth"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57a13fbacc5e9c41ded3ad8d0373175a6b7a6ad430d99e89d314ac121b7ab06"
+dependencies = [
+ "async-trait",
+ "base64 0.21.7",
+ "google-cloud-metadata",
+ "google-cloud-token",
+ "home",
+ "jsonwebtoken",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tracing",
+ "urlencoding",
+]
+
+[[package]]
+name = "google-cloud-bigquery"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09bf057f5a44f4975252492feea3a7b26ca0693cbe12511317504c3c02fca5e"
+dependencies = [
+ "anyhow",
+ "arrow",
+ "async-stream",
+ "async-trait",
+ "backon",
+ "base64 0.21.7",
+ "bigdecimal",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-googleapis",
+ "google-cloud-token",
+ "num-bigint",
+ "prost-types",
+ "reqwest",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de13e62d7e0ffc3eb40a0113ddf753cf6ec741be739164442b08893db4f9bfca"
+dependencies = [
+ "google-cloud-token",
+ "http 1.4.0",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-retry2",
+ "tonic",
+ "tower 0.4.13",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-googleapis"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886aa8ec755382a1fdf4651f6e6ec01f2f3bf49f2cb0f068b9a74cafd574a715"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
+name = "google-cloud-metadata"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d901aeb453fd80e51d64df4ee005014f6cf39f2d736dd64f7239c132d9d39a6a"
+dependencies = [
+ "reqwest",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-token"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c12ba8b21d128a2ce8585955246977fbce4415f680ebf9199b6f9d6d725f"
+dependencies = [
+ "async-trait",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,6 +2627,18 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2357,6 +2758,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "019ece39bbefc17f13f677a690328cb978dbf6790e141a3c24e66372cb38588b"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2536,7 +2946,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2549,6 +2959,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2924,6 +3350,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3229,6 +3712,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe 0.2.1",
+ "openssl-sys",
+ "schannel",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3236,6 +3736,20 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -3265,6 +3779,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3286,6 +3809,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3393,6 +3927,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3403,6 +3963,18 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "outref"
@@ -3647,6 +4219,7 @@ dependencies = [
  "fastbloom",
  "flate2",
  "futures-util",
+ "google-cloud-bigquery",
  "hex",
  "http 1.4.0",
  "jsonwebtoken",
@@ -3790,6 +4363,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -4182,6 +4787,7 @@ dependencies = [
  "bytes",
  "cookie",
  "cookie_store 0.22.1",
+ "encoding_rs",
  "futures-core",
  "futures-util",
  "http 1.4.0",
@@ -4189,10 +4795,13 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-rustls 0.27.7",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4203,6 +4812,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
@@ -4213,7 +4823,22 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.4.0",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
 ]
 
 [[package]]
@@ -5162,6 +5787,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5215,6 +5849,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0a122635e32bd827df297f311ca5e0292636bbd82f67ff84a4bedeab06dbeb"
+dependencies = [
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5242,6 +5896,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls 0.23.37",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -5296,6 +5961,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "rustls-pemfile",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "totp-rs"
 version = "5.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5316,8 +6011,11 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -6015,6 +6713,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/runtime/plaid-stl/src/gcp/bigquery.rs
+++ b/runtime/plaid-stl/src/gcp/bigquery.rs
@@ -175,7 +175,7 @@ pub fn query_table(
         filter,
     };
 
-    const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
+    const RETURN_BUFFER_SIZE: usize = 10 * 1000 * 1000; // 10 MB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
     let params = serde_json::to_string(&params).unwrap();

--- a/runtime/plaid-stl/src/gcp/bigquery.rs
+++ b/runtime/plaid-stl/src/gcp/bigquery.rs
@@ -163,6 +163,7 @@ pub fn query_table(
     table: impl Display,
     columns: &[impl Display],
     filter: Option<Filter>,
+    return_buffer_size: usize,
 ) -> Result<QueryTableResponse, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(gcp_bigquery, query_table);
@@ -175,8 +176,7 @@ pub fn query_table(
         filter,
     };
 
-    const RETURN_BUFFER_SIZE: usize = 10 * 1000 * 1000; // 10 MB
-    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+    let mut return_buffer = vec![0; return_buffer_size];
 
     let params = serde_json::to_string(&params).unwrap();
     let res = unsafe {
@@ -184,7 +184,7 @@ pub fn query_table(
             params.as_bytes().as_ptr(),
             params.as_bytes().len(),
             return_buffer.as_mut_ptr(),
-            RETURN_BUFFER_SIZE,
+            return_buffer_size,
         )
     };
 

--- a/runtime/plaid-stl/src/gcp/bigquery.rs
+++ b/runtime/plaid-stl/src/gcp/bigquery.rs
@@ -39,7 +39,7 @@ pub struct ReadTableRequest {
 ///
 /// println!("{} rows returned", rows.len());
 /// ```
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct ReadTableResponse {
     pub rows: Vec<HashMap<String, Value>>,
 }

--- a/runtime/plaid-stl/src/gcp/bigquery.rs
+++ b/runtime/plaid-stl/src/gcp/bigquery.rs
@@ -1,0 +1,121 @@
+use std::{
+    collections::HashMap,
+    fmt::Display,
+    ops::{Deref, DerefMut},
+};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::PlaidFunctionError;
+
+/// Request sent to the runtime to read rows from a BigQuery table.
+#[derive(Deserialize, Serialize)]
+pub struct ReadTableRequest {
+    pub dataset: String,
+    pub table: String,
+    /// Columns to select. Must be non-empty; the runtime does not support
+    /// `SELECT *` so that callers are always explicit about what data they
+    /// need and the runtime can return named results.
+    pub columns: Vec<String>,
+}
+
+/// Response returned by the runtime for a BigQuery read.
+///
+/// Each row is a [`HashMap`] keyed by column name. NULL database values are
+/// represented as [`Value::Null`].
+///
+/// `ReadTableResponse` implements [`Deref`] to `[HashMap<String, Value>]` and
+/// both consuming and borrowing [`IntoIterator`], so it can be used directly as
+/// a collection without accessing the inner field:
+///
+/// ```ignore
+/// let rows = read_from_table("my_dataset", "events", &["user_id", "count"])?;
+///
+/// for row in &rows {
+///     let user = &row["user_id"];   // Value::String
+///     let count = &row["count"];    // Value::Number (if schema declares integer)
+/// }
+///
+/// println!("{} rows returned", rows.len());
+/// ```
+#[derive(Deserialize, Serialize)]
+pub struct ReadTableResponse {
+    pub rows: Vec<HashMap<String, Value>>,
+}
+
+impl Deref for ReadTableResponse {
+    type Target = [HashMap<String, Value>];
+    fn deref(&self) -> &Self::Target {
+        &self.rows
+    }
+}
+
+impl DerefMut for ReadTableResponse {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.rows
+    }
+}
+
+impl IntoIterator for ReadTableResponse {
+    type Item = HashMap<String, Value>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.rows.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a ReadTableResponse {
+    type Item = &'a HashMap<String, Value>;
+    type IntoIter = std::slice::Iter<'a, HashMap<String, Value>>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.rows.iter()
+    }
+}
+
+/// Read rows from a BigQuery table.
+///
+/// `columns` must be non-empty. Specify exactly which columns you need;
+/// the runtime will reject requests that do not name at least one column.
+///
+/// Returns a [`ReadTableResponse`] that can be iterated directly or indexed
+/// like a slice. Each row is a [`HashMap`] keyed by the column names supplied
+/// in `columns`. NULL database values are represented as [`Value::Null`].
+pub fn query_table(
+    dataset: impl Display,
+    table: impl Display,
+    columns: &[impl Display],
+) -> Result<ReadTableResponse, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(bigquery, query_table);
+    }
+
+    let params = ReadTableRequest {
+        dataset: dataset.to_string(),
+        table: table.to_string(),
+        columns: columns.iter().map(|c| c.to_string()).collect(),
+    };
+
+    const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let params = serde_json::to_string(&params).unwrap();
+    let res = unsafe {
+        bigquery_query_table(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+
+    let response = String::from_utf8(return_buffer).unwrap();
+
+    serde_json::from_str(&response).map_err(|_| PlaidFunctionError::InternalApiError)
+}

--- a/runtime/plaid-stl/src/gcp/bigquery.rs
+++ b/runtime/plaid-stl/src/gcp/bigquery.rs
@@ -26,9 +26,7 @@ pub struct QueryTableRequest {
 
 /// A node in a WHERE clause expression tree.
 ///
-/// Conditions can be nested arbitrarily using `And` and `Or`. The runtime
-/// validates all column names and renders the tree into safe BigQuery SQL —
-/// modules never construct raw SQL strings.
+/// Conditions can be nested using `And` and `Or`.
 ///
 /// # Example
 ///

--- a/runtime/plaid-stl/src/gcp/bigquery.rs
+++ b/runtime/plaid-stl/src/gcp/bigquery.rs
@@ -87,7 +87,7 @@ pub fn query_table(
     columns: &[impl Display],
 ) -> Result<ReadTableResponse, PlaidFunctionError> {
     extern "C" {
-        new_host_function_with_error_buffer!(bigquery, query_table);
+        new_host_function_with_error_buffer!(gcp_bigquery, query_table);
     }
 
     let params = ReadTableRequest {
@@ -101,7 +101,7 @@ pub fn query_table(
 
     let params = serde_json::to_string(&params).unwrap();
     let res = unsafe {
-        bigquery_query_table(
+        gcp_bigquery_query_table(
             params.as_bytes().as_ptr(),
             params.as_bytes().len(),
             return_buffer.as_mut_ptr(),

--- a/runtime/plaid-stl/src/gcp/bigquery.rs
+++ b/runtime/plaid-stl/src/gcp/bigquery.rs
@@ -89,7 +89,6 @@ pub enum FilterValue {
     Integer(i64),
     Float(f64),
     Boolean(bool),
-    Null,
     Timestamp(String),
 }
 
@@ -97,21 +96,6 @@ pub enum FilterValue {
 ///
 /// Each row is a [`HashMap`] keyed by column name. NULL database values are
 /// represented as [`Value::Null`].
-///
-/// `QueryTableResponse` implements [`Deref`] to `[HashMap<String, Value>]` and
-/// both consuming and borrowing [`IntoIterator`], so it can be used directly as
-/// a collection without accessing the inner field:
-///
-/// ```ignore
-/// let rows = query_table("my_dataset", "events", &["user_id", "count"])?;
-///
-/// for row in &rows {
-///     let user = &row["user_id"];   // Value::String
-///     let count = &row["count"];    // Value::Number (if schema declares integer)
-/// }
-///
-/// println!("{} rows returned", rows.len());
-/// ```
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct QueryTableResponse {
     pub rows: Vec<HashMap<String, Value>>,

--- a/runtime/plaid-stl/src/gcp/bigquery.rs
+++ b/runtime/plaid-stl/src/gcp/bigquery.rs
@@ -90,6 +90,7 @@ pub enum FilterValue {
     Float(f64),
     Boolean(bool),
     Timestamp(String),
+    Null,
 }
 
 /// Response returned by the runtime for a BigQuery query.

--- a/runtime/plaid-stl/src/gcp/bigquery.rs
+++ b/runtime/plaid-stl/src/gcp/bigquery.rs
@@ -145,7 +145,7 @@ impl<'a> IntoIterator for &'a QueryTableResponse {
 pub fn query_table(
     dataset: impl Display,
     table: impl Display,
-    columns: &[impl Display],
+    columns: impl Iterator<Item = impl Display>,
     filter: Option<Filter>,
     return_buffer_size: usize,
 ) -> Result<QueryTableResponse, PlaidFunctionError> {
@@ -156,7 +156,7 @@ pub fn query_table(
     let params = QueryTableRequest {
         dataset: dataset.to_string(),
         table: table.to_string(),
-        columns: columns.iter().map(|c| c.to_string()).collect(),
+        columns: columns.map(|c| c.to_string()).collect(),
         filter,
     };
 

--- a/runtime/plaid-stl/src/gcp/bigquery.rs
+++ b/runtime/plaid-stl/src/gcp/bigquery.rs
@@ -90,6 +90,7 @@ pub enum FilterValue {
     Float(f64),
     Boolean(bool),
     Null,
+    Timestamp(String),
 }
 
 /// Response returned by the runtime for a BigQuery query.

--- a/runtime/plaid-stl/src/gcp/mod.rs
+++ b/runtime/plaid-stl/src/gcp/mod.rs
@@ -1,1 +1,2 @@
+pub mod bigquery;
 pub mod google_docs;

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -15,7 +15,7 @@ aws = [
 ]
 cranelift = ["wasmer/cranelift"]
 llvm = ["wasmer/llvm"]
-gcp = []
+gcp = ["google-cloud-bigquery"]
 
 [dependencies]
 aes = "0.7"
@@ -30,7 +30,7 @@ aws-sdk-sqs = { version = "1.41.0", optional = true }
 base64 = "0.13"
 block-modes = "0.8"
 fastbloom = "0.14"
-chrono = "0.4.41"
+chrono = "=0.4.39"
 clap = { version = "4", default-features = false, features = [
     "std",
     "help",
@@ -95,7 +95,7 @@ wasmer-middlewares = "7"
 x509-parser = "0.18.0"
 thiserror = "2.0.17"
 pulldown-cmark = "0.13.0"
-
+google-cloud-bigquery = { version = "0.15.0", optional = true, default-features = true }
 
 [[example]]
 name = "github-tailer"

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -95,7 +95,10 @@ wasmer-middlewares = "7"
 x509-parser = "0.18.0"
 thiserror = "2.0.17"
 pulldown-cmark = "0.13.0"
-google-cloud-bigquery = { version = "0.15.0", optional = true, default-features = true }
+google-cloud-bigquery = { version = "0.15.0", optional = true, default-features = false, features = [
+    "rustls-tls",
+    "auth",
+] }
 
 [[example]]
 name = "github-tailer"

--- a/runtime/plaid/resources/config/apis.toml
+++ b/runtime/plaid/resources/config/apis.toml
@@ -338,3 +338,27 @@ rules_and_actions = { "some_rule.wasm"  = ["Encrypt", "Decrypt"] }
 
 [apis.bloom_filter]
 # nothing here
+
+# =============================================================================
+# BigQuery example configuration
+# =============================================================================
+# [apis.gcp.bigquery]
+# project_id = ""
+# client_email = ""
+# private_key_id = ""
+# private_key = """
+# <some-private-key>
+# """
+# timeout_ms = 30000   # optional, defaults to 50000
+
+# # Read access map: module → dataset → list of permitted tables
+# [apis.gcp.bigquery.r."<some-module>.wasm"]
+# "<some-dataset>" = ["table1", "table2"]
+
+# # Column type schemas: dataset → table → column → type
+# # Supported types: "string" | "integer" | "float" | "boolean"
+# # Columns not listed here default to "string".
+# [apis.gcp.bigquery.schemas."<some-dataset>"."table1"]
+# column1 = "string"
+# colum2 = "float"
+

--- a/runtime/plaid/src/apis/gcp/bigquery.rs
+++ b/runtime/plaid/src/apis/gcp/bigquery.rs
@@ -1,0 +1,326 @@
+use std::{collections::HashMap, sync::Arc};
+
+use google_cloud_bigquery::{
+    client::{google_cloud_auth, Client, ClientConfig},
+    http::job::query::QueryRequest,
+    query::row::Row,
+};
+use plaid_stl::gcp::bigquery::{ReadTableRequest, ReadTableResponse};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::{apis::ApiError, loader::PlaidModule};
+use log::error;
+
+const TOKEN_URI: &str = "https://oauth2.googleapis.com/token";
+
+#[derive(Error, Debug)]
+pub enum BigQueryError {
+    #[error("Authentication error: {0}")]
+    Auth(#[from] google_cloud_auth::error::Error),
+    #[error("Client initialization error: {0}")]
+    Client(String),
+    #[error("Query error: {0}")]
+    QueryError(#[from] google_cloud_bigquery::client::QueryError),
+    #[error("Row iteration error: {0}")]
+    IterError(#[from] google_cloud_bigquery::query::Error),
+    #[error("Row decode error: {0}")]
+    RowError(#[from] google_cloud_bigquery::query::row::Error),
+}
+
+/// The BigQuery type a column should be decoded into.
+///
+/// The BigQuery HTTP API returns all values as strings on the wire, so without
+/// explicit type information the runtime would always produce
+/// `serde_json::Value::String`. Providing a `ColumnType` in the schema causes
+/// the runtime to parse the raw string into the correct JSON primitive before
+/// returning it to the module.
+#[derive(Deserialize, Serialize, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum ColumnType {
+    /// UTF-8 text. Produces `Value::String`. This is the default when no
+    /// schema entry is present for a column.
+    String,
+    /// 64-bit signed integer. Produces `Value::Number`.
+    Integer,
+    /// 64-bit IEEE 754 float. Produces `Value::Number`.
+    Float,
+    /// Boolean. Produces `Value::Bool`.
+    Boolean,
+}
+
+/// Mirrors the fields of a GCP service account JSON key file that are required
+/// to authenticate as a service account. Credentials are supplied inline in the
+/// Plaid config rather than via a key file on disk.
+#[derive(Deserialize)]
+pub struct BigQueryConfig {
+    /// GCP project ID (e.g. "my-gcp-project")
+    project_id: String,
+    /// Service account email (e.g. "my-sa@my-project.iam.gserviceaccount.com")
+    client_email: String,
+    /// RSA private key in PEM format (the `private_key` field from the JSON key file)
+    private_key: String,
+    /// Private key ID (the `private_key_id` field from the JSON key file)
+    private_key_id: String,
+    /// Read access map: module name → dataset → list of tables the module may query
+    r: HashMap<String, HashMap<String, Vec<String>>>,
+    /// Column type schema: dataset → table → column name → [`ColumnType`].
+    ///
+    /// Columns not present in the schema are decoded as `String`. Providing a
+    /// schema entry ensures numeric and boolean values arrive with the correct
+    /// JSON type rather than being silently coerced to strings.
+    #[serde(default)]
+    schemas: HashMap<String, HashMap<String, HashMap<String, ColumnType>>>,
+    /// Timeout (in milliseconds) applied to all queries
+    #[serde(default = "default_timeout_ms")]
+    timeout_ms: i64,
+}
+
+/// The default timeout if none is provided.
+fn default_timeout_ms() -> i64 {
+    50000
+}
+
+pub struct BigQuery {
+    client: Client,
+    project_id: String,
+    config: BigQueryConfig,
+}
+
+impl BigQuery {
+    pub async fn new(config: BigQueryConfig) -> Result<Self, BigQueryError> {
+        // Build a CredentialsFile JSON from our config fields
+        let credentials_json = serde_json::json!({
+            "type": "service_account",
+            "project_id": config.project_id,
+            "client_email": config.client_email,
+            "private_key_id": config.private_key_id,
+            "private_key": config.private_key,
+            "token_uri": TOKEN_URI,
+        });
+
+        let credentials = google_cloud_auth::credentials::CredentialsFile::new_from_str(
+            &credentials_json.to_string(),
+        )
+        .await?;
+
+        let (client_config, resolved_project_id) =
+            ClientConfig::new_with_credentials(credentials).await?;
+
+        // The project ID resolved from the credentials should match config.project_id,
+        // but we fall back to config.project_id if the token source didn't return one.
+        let project_id = resolved_project_id.unwrap_or_else(|| config.project_id.clone());
+
+        let client = Client::new(client_config)
+            .await
+            .map_err(|e| BigQueryError::Client(e.to_string()))?;
+
+        Ok(BigQuery {
+            client,
+            project_id,
+            config,
+        })
+    }
+
+    /// Executes a `SELECT` query against a BigQuery table and returns the
+    /// results serialised as a [`ReadTableResponse`] JSON string.
+    ///
+    /// # Flow
+    ///
+    /// 1. Deserializes `params` into a [`ReadTableRequest`] (dataset, table,
+    ///    columns). Returns `BadRequest` if the payload is malformed.
+    /// 2. Calls [`build_query_request`][Self::build_query_request], which
+    ///    enforces module permissions and validates all identifiers.
+    /// 3. Issues the query via the BigQuery client and drains the async
+    ///    iterator into a `Vec` of rows.
+    /// 4. For each cell, looks up the column's [`ColumnType`] from the
+    ///    configured schema (defaulting to `String` when absent) and calls
+    ///    [`decode_column`] to produce the correct `serde_json::Value` variant.
+    /// 5. Wraps the rows in a [`ReadTableResponse`] and serializes to JSON.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ApiError::BadRequest` if permissions or identifier validation
+    /// fails, and `ApiError::BigQueryError` for any network or decoding error.
+    pub async fn query_table(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
+        let params =
+            serde_json::from_str::<ReadTableRequest>(params).map_err(|_| ApiError::BadRequest)?;
+
+        let query_request = self.build_query_request(&module, &params)?;
+
+        let mut iter = self
+            .client
+            .query::<Row>(&self.project_id, query_request)
+            .await
+            .map_err(BigQueryError::from)?;
+
+        // Resolve the column type schema once for the requested table so we
+        // don't repeat the map lookups inside the hot row-iteration loop.
+        let table_schema = self
+            .config
+            .schemas
+            .get(&params.dataset)
+            .and_then(|d| d.get(&params.table));
+
+        let mut rows = Vec::new();
+        while let Some(row) = iter.next().await.map_err(BigQueryError::from)? {
+            let mut map = HashMap::new();
+            for (i, col_name) in params.columns.iter().enumerate() {
+                let col_type = table_schema
+                    .and_then(|s| s.get(col_name))
+                    .copied()
+                    .unwrap_or(ColumnType::String);
+                let value = decode_column(&row, i, col_type).map_err(BigQueryError::from)?;
+                map.insert(col_name.clone(), value);
+            }
+            rows.push(map);
+        }
+
+        let response = ReadTableResponse { rows };
+        serde_json::to_string(&response).map_err(|_| ApiError::ImpossibleError)
+    }
+
+    /// Returns `Ok(())` if the module has an entry in `r` for the given dataset
+    /// that includes the requested table.
+    fn check_module_permission(
+        &self,
+        module: &Arc<PlaidModule>,
+        dataset: &str,
+        table: &str,
+    ) -> Result<(), ApiError> {
+        let Some(datasets) = self.config.r.get(&module.to_string()) else {
+            error!("[{module}] attempted to read BigQuery table [{dataset}.{table}] but has no BigQuery permissions configured");
+            return Err(ApiError::BadRequest);
+        };
+
+        let Some(tables) = datasets.get(dataset) else {
+            error!("[{module}] attempted to read BigQuery table [{dataset}.{table}] but is not permitted to access dataset [{dataset}]");
+            return Err(ApiError::BadRequest);
+        };
+
+        if !tables.iter().any(|t| t == table) {
+            error!("[{module}] attempted to read BigQuery table [{dataset}.{table}] but [{table}] is not in the permitted tables for dataset [{dataset}]");
+            return Err(ApiError::BadRequest);
+        }
+
+        Ok(())
+    }
+
+    /// Validates permissions and constructs a [`QueryRequest`] ready to send to
+    /// BigQuery.
+    ///
+    /// Combines the two validation steps that must both pass before a query is
+    /// issued:
+    ///
+    /// 1. **Permission check** — asserts that `module` is allowed to read from
+    ///    `params.dataset` and `params.table` according to the `r` config map.
+    /// 2. **Query construction** — delegates to [`build_query_string`], which
+    ///    validates all identifiers against a strict allowlist and assembles the
+    ///    `SELECT` statement.
+    ///
+    /// Returns `ApiError::BadRequest` if either check fails.
+    fn build_query_request(
+        &self,
+        module: &Arc<PlaidModule>,
+        params: &ReadTableRequest,
+    ) -> Result<QueryRequest, ApiError> {
+        self.check_module_permission(module, &params.dataset, &params.table)?;
+        let query = build_query_string(&params.dataset, &params.table, &params.columns)?;
+        Ok(QueryRequest {
+            timeout_ms: Some(self.config.timeout_ms),
+            query,
+            ..Default::default()
+        })
+    }
+}
+
+/// Validates that every identifier (dataset, table, column names) contains
+/// only ASCII letters, digits, and underscores, then builds the SELECT query
+/// with each column wrapped in backticks.
+///
+/// Backtick-quoting alone is not sufficient — a column name containing a
+/// literal backtick would break out of the quoting. Rejecting any name that
+/// is not a clean identifier is the safest approach and the correct thing to
+/// do in a controlled API: callers supply column names, not arbitrary SQL.
+fn build_query_string(dataset: &str, table: &str, columns: &[String]) -> Result<String, ApiError> {
+    if !is_valid_identifier(dataset) || !is_valid_identifier(table) {
+        return Err(ApiError::BadRequest);
+    }
+
+    if columns.is_empty() {
+        return Err(ApiError::BadRequest);
+    }
+
+    for col in columns {
+        if !is_valid_identifier(col) {
+            return Err(ApiError::BadRequest);
+        }
+    }
+
+    let column_list = columns
+        .iter()
+        .map(|c| format!("`{c}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    Ok(format!("SELECT {column_list} FROM `{dataset}`.`{table}`"))
+}
+
+/// Extracts the value at `index` from `row`, parsing it into the
+/// `serde_json::Value` variant that corresponds to `col_type`.
+///
+/// The BigQuery HTTP API returns every value as a raw string on the wire.
+/// Without schema information, `String` is the only safe choice. When a
+/// `ColumnType` is provided the raw string is re-parsed into the correct
+/// primitive so that modules receive `Value::Number` or `Value::Bool` instead
+/// of a stringly-typed number that they would have to parse themselves.
+fn decode_column(
+    row: &Row,
+    index: usize,
+    col_type: ColumnType,
+) -> Result<serde_json::Value, google_cloud_bigquery::query::row::Error> {
+    Ok(match col_type {
+        ColumnType::String => {
+            let v: Option<String> = row.column(index)?;
+            v.map(serde_json::Value::String)
+                .unwrap_or(serde_json::Value::Null)
+        }
+        ColumnType::Integer => {
+            let v: Option<i64> = row.column(index)?;
+            v.map(|n| serde_json::Value::Number(n.into()))
+                .unwrap_or(serde_json::Value::Null)
+        }
+        ColumnType::Float => {
+            let v: Option<f64> = row.column(index)?;
+            v.and_then(serde_json::Number::from_f64)
+                .map(serde_json::Value::Number)
+                .unwrap_or(serde_json::Value::Null)
+        }
+        ColumnType::Boolean => {
+            let v: Option<bool> = row.column(index)?;
+            v.map(serde_json::Value::Bool)
+                .unwrap_or(serde_json::Value::Null)
+        }
+    })
+}
+
+/// Returns `true` if `s` is a valid BigQuery identifier: non-empty, starts
+/// with an ASCII letter or underscore, and contains only ASCII letters, digits,
+/// and underscores (`[A-Za-z_][A-Za-z0-9_]*`).
+///
+/// This is a strict allowlist. Any character outside that set — including
+/// spaces, quotes, backticks, semicolons, parentheses, and comment markers
+/// (`--`, `/*`) — causes the function to return `false`, making SQL injection
+/// via crafted identifier names impossible regardless of the surrounding query
+/// structure.
+fn is_valid_identifier(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}

--- a/runtime/plaid/src/apis/gcp/bigquery.rs
+++ b/runtime/plaid/src/apis/gcp/bigquery.rs
@@ -80,7 +80,7 @@ pub struct BigQueryConfig {
 
 /// The default timeout if none is provided.
 fn default_timeout_ms() -> i64 {
-    50000
+    5000
 }
 
 pub struct BigQuery {

--- a/runtime/plaid/src/apis/gcp/bigquery.rs
+++ b/runtime/plaid/src/apis/gcp/bigquery.rs
@@ -6,7 +6,7 @@ use google_cloud_bigquery::{
     query::row::Row,
 };
 use plaid_stl::gcp::bigquery::{
-    Filter, FilterValue, Operator, ReadTableRequest, ReadTableResponse,
+    Filter, FilterValue, Operator, QueryTableRequest, QueryTableResponse,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -150,7 +150,7 @@ impl BigQuery {
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         let params =
-            serde_json::from_str::<ReadTableRequest>(params).map_err(|_| ApiError::BadRequest)?;
+            serde_json::from_str::<QueryTableRequest>(params).map_err(|_| ApiError::BadRequest)?;
 
         let query_request = self.build_query_request(&module, &params)?;
 
@@ -189,7 +189,7 @@ impl BigQuery {
             rows.push(map);
         }
 
-        let response = ReadTableResponse { rows };
+        let response = QueryTableResponse { rows };
         serde_json::to_string(&response).map_err(|_| ApiError::ImpossibleError)
     }
 
@@ -235,7 +235,7 @@ impl BigQuery {
     fn build_query_request(
         &self,
         module: &Arc<PlaidModule>,
-        params: &ReadTableRequest,
+        params: &QueryTableRequest,
     ) -> Result<QueryRequest, ApiError> {
         self.check_module_permission(module, &params.dataset, &params.table)?;
         let query = build_query_string(

--- a/runtime/plaid/src/apis/gcp/bigquery.rs
+++ b/runtime/plaid/src/apis/gcp/bigquery.rs
@@ -348,7 +348,7 @@ fn build_condition_sql(
 
     let op_str = match op {
         Operator::Eq => "=",
-        Operator::Ne => "<>",
+        Operator::Ne => "!=",
         Operator::Lt => "<",
         Operator::Le => "<=",
         Operator::Gt => ">",

--- a/runtime/plaid/src/apis/gcp/bigquery.rs
+++ b/runtime/plaid/src/apis/gcp/bigquery.rs
@@ -125,7 +125,7 @@ impl BigQuery {
     }
 
     /// Executes a `SELECT` query against a BigQuery table and returns the
-    /// results serialised as a [`ReadTableResponse`] JSON string.
+    /// results serialised as a [`QueryTableResponse`] JSON string.
     ///
     /// # Flow
     ///
@@ -138,7 +138,7 @@ impl BigQuery {
     /// 4. For each cell, looks up the column's [`ColumnType`] from the
     ///    configured schema (defaulting to `String` when absent) and calls
     ///    [`decode_column`] to produce the correct `serde_json::Value` variant.
-    /// 5. Wraps the rows in a [`ReadTableResponse`] and serializes to JSON.
+    /// 5. Wraps the rows in a [`QueryTableResponse`] and serializes to JSON.
     ///
     /// # Errors
     ///

--- a/runtime/plaid/src/apis/gcp/bigquery.rs
+++ b/runtime/plaid/src/apis/gcp/bigquery.rs
@@ -462,6 +462,7 @@ fn push_value_param(
         }
         FilterValue::Boolean(b) => ("BOOL", Some(b.to_string())),
         FilterValue::Timestamp(t) => ("TIMESTAMP", Some(t.to_string())),
+        FilterValue::Null => ("STRING", None),
     };
 
     params.push(QueryParameter {

--- a/runtime/plaid/src/apis/gcp/bigquery.rs
+++ b/runtime/plaid/src/apis/gcp/bigquery.rs
@@ -20,11 +20,11 @@ use log::error;
 const TOKEN_URI: &str = "https://oauth2.googleapis.com/token";
 
 /// Maximum `And`/`Or` nesting depth for a [`Filter`] tree.
-const MAX_FILTER_DEPTH: usize = 4;
+const MAX_FILTER_DEPTH: usize = 2;
 
 /// Maximum number of sibling conditions allowed inside a single `And`/`Or`
 /// node. Prevents unbounded SQL string growth from a flat list of conditions.
-const MAX_FILTER_CHILDREN: usize = 16;
+const MAX_FILTER_CHILDREN: usize = 8;
 
 #[derive(Error, Debug)]
 pub enum BigQueryError {
@@ -40,6 +40,14 @@ pub enum BigQueryError {
     RowError(#[from] google_cloud_bigquery::query::row::Error),
     #[error("Response too large: accumulated row data exceeded the configured max_response_size")]
     ResponseTooLarge,
+    #[error("Invalid identifer value: {0}")]
+    InvalidIdentifier(String),
+    #[error("No columns provided")]
+    NoColumnsProvided,
+    #[error("Invalid filter provided: {0}")]
+    InvalidFilter(String),
+    #[error("Module not permitted")]
+    ModuleNotPermitted,
 }
 
 /// The BigQuery type a column should be decoded into.
@@ -95,6 +103,11 @@ pub struct BigQueryConfig {
     max_response_size: usize,
 }
 
+/// The default timeout if none is provided.
+fn default_timeout_ms() -> i64 {
+    5000
+}
+
 fn default_max_response_size() -> usize {
     1024 * 1024 // 1 MiB
 }
@@ -116,14 +129,18 @@ impl io::Write for CountWriter {
     }
 }
 
-/// The default timeout if none is provided.
-fn default_timeout_ms() -> i64 {
-    5000
-}
-
+/// BigQuery API wrapper for Plaid modules.
+///
+/// Owns the BigQuery client plus the resolved project and
+/// runtime configuration needed to validate module access, build parameterized
+/// queries, and decode query results.
 pub struct BigQuery {
+    /// BigQuery client used to submit queries.
     client: Client,
+    /// GCP project ID used for BigQuery jobs.
     project_id: String,
+    /// Runtime configuration, including credentials, access rules, schema
+    /// hints, timeout, and response size limits.
     config: BigQueryConfig,
 }
 
@@ -177,13 +194,6 @@ impl BigQuery {
     ///    configured schema (defaulting to `String` when absent) and calls
     ///    [`decode_column`] to produce the correct `serde_json::Value` variant.
     /// 5. Wraps the rows in a [`QueryTableResponse`] and serializes to JSON.
-    ///
-    /// # Errors
-    ///
-    /// Returns `ApiError::BadRequest` if permissions or identifier validation
-    /// fails, `ApiError::BigQueryError(BigQueryError::ResponseTooLarge)` if the
-    /// accumulated decoded row data exceeds `max_response_size`, and
-    /// `ApiError::BigQueryError` for any other network or decoding error.
     pub async fn query_table(
         &self,
         params: &str,
@@ -253,20 +263,20 @@ impl BigQuery {
         module: &Arc<PlaidModule>,
         dataset: &str,
         table: &str,
-    ) -> Result<(), ApiError> {
+    ) -> Result<(), BigQueryError> {
         let Some(datasets) = self.config.r.get(&module.to_string()) else {
             error!("[{module}] attempted to read BigQuery table [{dataset}.{table}] but has no BigQuery permissions configured");
-            return Err(ApiError::BadRequest);
+            return Err(BigQueryError::ModuleNotPermitted);
         };
 
         let Some(tables) = datasets.get(dataset) else {
             error!("[{module}] attempted to read BigQuery table [{dataset}.{table}] but is not permitted to access dataset [{dataset}]");
-            return Err(ApiError::BadRequest);
+            return Err(BigQueryError::ModuleNotPermitted);
         };
 
         if !tables.iter().any(|t| t == table) {
             error!("[{module}] attempted to read BigQuery table [{dataset}.{table}] but [{table}] is not in the permitted tables for dataset [{dataset}]");
-            return Err(ApiError::BadRequest);
+            return Err(BigQueryError::ModuleNotPermitted);
         }
 
         Ok(())
@@ -283,19 +293,22 @@ impl BigQuery {
     /// 2. **Query construction** — delegates to [`build_query_string`], which
     ///    validates all identifiers against a strict allowlist and assembles the
     ///    `SELECT` statement.
-    ///
-    /// Returns `ApiError::BadRequest` if either check fails.
     fn build_query_request(
         &self,
         module: &Arc<PlaidModule>,
         params: &QueryTableRequest,
-    ) -> Result<QueryRequest, ApiError> {
+    ) -> Result<QueryRequest, BigQueryError> {
         // Validate dataset and table identifiers before the permission check so
         // that the names logged inside check_module_permission are guaranteed to
         // be safe ASCII identifiers
-        if !is_valid_identifier(&params.dataset) || !is_valid_identifier(&params.table) {
-            return Err(ApiError::BadRequest);
+        if !is_valid_identifier(&params.dataset) {
+            return Err(BigQueryError::InvalidIdentifier(params.dataset.to_string()));
         }
+
+        if !is_valid_identifier(&params.table) {
+            return Err(BigQueryError::InvalidIdentifier(params.table.to_string()));
+        }
+
         self.check_module_permission(module, &params.dataset, &params.table)?;
         let (query, query_parameters) = build_query_string(
             &params.dataset,
@@ -332,20 +345,24 @@ fn build_query_string(
     table: &str,
     columns: &[String],
     filter: Option<&Filter>,
-) -> Result<(String, Vec<QueryParameter>), ApiError> {
+) -> Result<(String, Vec<QueryParameter>), BigQueryError> {
     if columns.is_empty() {
-        return Err(ApiError::BadRequest);
+        return Err(BigQueryError::NoColumnsProvided);
     }
 
-    if columns.iter().any(|col| !is_valid_identifier(col)) {
-        return Err(ApiError::BadRequest);
+    if let Some(ident) = columns.iter().find(|col| !is_valid_identifier(col)) {
+        return Err(BigQueryError::InvalidIdentifier(ident.to_string()));
     }
 
-    let column_list = columns
-        .iter()
-        .map(|c| format!("`{c}`"))
-        .collect::<Vec<_>>()
-        .join(", ");
+    let mut column_list = String::new();
+    for (i, c) in columns.iter().enumerate() {
+        if i > 0 {
+            column_list.push_str(", ");
+        }
+        column_list.push('`');
+        column_list.push_str(c);
+        column_list.push('`');
+    }
 
     let mut sql = format!("SELECT {column_list} FROM `{dataset}`.`{table}`");
     let mut params: Vec<QueryParameter> = Vec::new();
@@ -363,7 +380,7 @@ fn build_query_string(
 /// Column names inside `Condition` nodes are validated with
 /// [`is_valid_identifier`] before use. `And` and `Or` nodes must contain at
 /// least one child and no more than [`MAX_FILTER_CHILDREN`]. Nesting depth is
-/// limited to [`MAX_FILTER_DEPTH`]; exceeding either limit returns `BadRequest`.
+/// limited to [`MAX_FILTER_DEPTH`]; exceeding either limit returns `InvalidFilter`.
 ///
 /// Leaf values are not inlined as SQL literals — they are appended to `params`
 /// as typed [`QueryParameter`] entries and referenced via `@pN` placeholders.
@@ -371,17 +388,19 @@ fn build_filter_sql(
     filter: &Filter,
     depth: usize,
     params: &mut Vec<QueryParameter>,
-) -> Result<String, ApiError> {
+) -> Result<String, BigQueryError> {
     if depth > MAX_FILTER_DEPTH {
-        return Err(ApiError::BadRequest);
+        return Err(BigQueryError::InvalidFilter(
+            "provided filter exceeds max depth".to_string(),
+        ));
     }
     match filter {
-        Filter::And(children) | Filter::Or(children) if children.is_empty() => {
-            Err(ApiError::BadRequest)
-        }
+        Filter::And(children) | Filter::Or(children) if children.is_empty() => Err(
+            BigQueryError::InvalidFilter("no children present".to_string()),
+        ),
         Filter::And(children) => {
             if children.len() > MAX_FILTER_CHILDREN {
-                return Err(ApiError::BadRequest);
+                return Err(BigQueryError::InvalidFilter(format!("provided AND filter has {} children, but only {MAX_FILTER_CHILDREN} are allowed", children.len())));
             }
             let parts = children
                 .iter()
@@ -391,7 +410,7 @@ fn build_filter_sql(
         }
         Filter::Or(children) => {
             if children.len() > MAX_FILTER_CHILDREN {
-                return Err(ApiError::BadRequest);
+                return Err(BigQueryError::InvalidFilter(format!("provided OR filter has {} children, but only {MAX_FILTER_CHILDREN} are allowed", children.len())));
             }
             let parts = children
                 .iter()
@@ -405,7 +424,7 @@ fn build_filter_sql(
             value,
         } => {
             if !is_valid_identifier(column) {
-                return Err(ApiError::BadRequest);
+                return Err(BigQueryError::InvalidIdentifier(column.to_string()));
             }
             build_condition_sql(column, operator, value, params)
         }
@@ -422,7 +441,7 @@ fn build_condition_sql(
     op: &Operator,
     value: &FilterValue,
     params: &mut Vec<QueryParameter>,
-) -> Result<String, ApiError> {
+) -> Result<String, BigQueryError> {
     let col = format!("`{column}`");
 
     let op_str = match op {
@@ -448,7 +467,7 @@ fn build_condition_sql(
 fn push_value_param(
     value: &FilterValue,
     params: &mut Vec<QueryParameter>,
-) -> Result<String, ApiError> {
+) -> Result<String, BigQueryError> {
     let name = format!("p{}", params.len());
 
     let (type_str, scalar_value) = match value {
@@ -456,7 +475,9 @@ fn push_value_param(
         FilterValue::Integer(n) => ("INT64", Some(n.to_string())),
         FilterValue::Float(f) => {
             if f.is_nan() || f.is_infinite() {
-                return Err(ApiError::BadRequest);
+                return Err(BigQueryError::InvalidIdentifier(
+                    "invalid float value provided in filter".to_string(),
+                ));
             }
             ("FLOAT64", Some(f.to_string()))
         }

--- a/runtime/plaid/src/apis/gcp/bigquery.rs
+++ b/runtime/plaid/src/apis/gcp/bigquery.rs
@@ -216,7 +216,7 @@ impl BigQuery {
         // strings. Columns absent from the schema fall back to String, which is
         // always safe to attempt.
         //
-        // Memory safety: each decoded row is serialised to JSON to measure its
+        // Memory safety: each decoded row is serialized to JSON to measure its
         // wire size, and the running total is checked against max_response_size
         // before the row is buffered. This gives us a hard cap below BigQuery's
         // own 10 MB server-side limit and prevents a large result set from
@@ -304,9 +304,6 @@ impl BigQuery {
             params.filter.as_ref(),
         )?;
 
-        info!("{query}");
-        info!("{query_parameters:#?}");
-
         let parameter_mode = if query_parameters.is_empty() {
             None
         } else {
@@ -336,18 +333,12 @@ fn build_query_string(
     columns: &[String],
     filter: Option<&Filter>,
 ) -> Result<(String, Vec<QueryParameter>), ApiError> {
-    if !is_valid_identifier(dataset) || !is_valid_identifier(table) {
-        return Err(ApiError::BadRequest);
-    }
-
     if columns.is_empty() {
         return Err(ApiError::BadRequest);
     }
 
-    for col in columns {
-        if !is_valid_identifier(col) {
-            return Err(ApiError::BadRequest);
-        }
+    if columns.iter().any(|col| !is_valid_identifier(col)) {
+        return Err(ApiError::BadRequest);
     }
 
     let column_list = columns
@@ -474,6 +465,7 @@ fn push_value_param(
             ("FLOAT64", Some(f.to_string()))
         }
         FilterValue::Boolean(b) => ("BOOL", Some(b.to_string())),
+        FilterValue::Timestamp(t) => ("TIMESTAMP", Some(t.to_string())),
         FilterValue::Null => ("STRING", None),
     };
 

--- a/runtime/plaid/src/apis/gcp/bigquery.rs
+++ b/runtime/plaid/src/apis/gcp/bigquery.rs
@@ -2,7 +2,10 @@ use std::{collections::HashMap, io, sync::Arc};
 
 use google_cloud_bigquery::{
     client::{google_cloud_auth, Client, ClientConfig},
-    http::job::query::QueryRequest,
+    http::{
+        job::query::QueryRequest,
+        types::{QueryParameter, QueryParameterType, QueryParameterValue},
+    },
     query::row::Row,
 };
 use plaid_stl::gcp::bigquery::{
@@ -294,32 +297,45 @@ impl BigQuery {
             return Err(ApiError::BadRequest);
         }
         self.check_module_permission(module, &params.dataset, &params.table)?;
-        let query = build_query_string(
+        let (query, query_parameters) = build_query_string(
             &params.dataset,
             &params.table,
             &params.columns,
             params.filter.as_ref(),
         )?;
+
+        info!("{query}");
+        info!("{query_parameters:#?}");
+
+        let parameter_mode = if query_parameters.is_empty() {
+            None
+        } else {
+            Some("NAMED".to_string())
+        };
         Ok(QueryRequest {
             timeout_ms: Some(self.config.timeout_ms),
             query,
+            parameter_mode,
+            query_parameters,
             ..Default::default()
         })
     }
 }
 
 /// Validates every identifier and builds the full `SELECT … FROM … [WHERE …]`
-/// query string.
+/// query string together with its associated named query parameters.
 ///
 /// Column names, dataset, and table are validated against a strict identifier
 /// allowlist. The optional `filter` is rendered via [`build_filter_sql`], which
-/// recursively validates all column names inside the condition tree.
+/// recursively validates all column names inside the condition tree. Filter
+/// values are not inlined — they are returned as [`QueryParameter`] entries to
+/// be bound by the BigQuery API.
 fn build_query_string(
     dataset: &str,
     table: &str,
     columns: &[String],
     filter: Option<&Filter>,
-) -> Result<String, ApiError> {
+) -> Result<(String, Vec<QueryParameter>), ApiError> {
     if !is_valid_identifier(dataset) || !is_valid_identifier(table) {
         return Err(ApiError::BadRequest);
     }
@@ -341,13 +357,14 @@ fn build_query_string(
         .join(", ");
 
     let mut sql = format!("SELECT {column_list} FROM `{dataset}`.`{table}`");
+    let mut params: Vec<QueryParameter> = Vec::new();
 
     if let Some(f) = filter {
         sql.push_str(" WHERE ");
-        sql.push_str(&build_filter_sql(f, 0)?);
+        sql.push_str(&build_filter_sql(f, 0, &mut params)?);
     }
 
-    Ok(sql)
+    Ok((sql, params))
 }
 
 /// Recursively renders a [`Filter`] tree into a WHERE clause fragment.
@@ -356,7 +373,14 @@ fn build_query_string(
 /// [`is_valid_identifier`] before use. `And` and `Or` nodes must contain at
 /// least one child and no more than [`MAX_FILTER_CHILDREN`]. Nesting depth is
 /// limited to [`MAX_FILTER_DEPTH`]; exceeding either limit returns `BadRequest`.
-fn build_filter_sql(filter: &Filter, depth: usize) -> Result<String, ApiError> {
+///
+/// Leaf values are not inlined as SQL literals — they are appended to `params`
+/// as typed [`QueryParameter`] entries and referenced via `@pN` placeholders.
+fn build_filter_sql(
+    filter: &Filter,
+    depth: usize,
+    params: &mut Vec<QueryParameter>,
+) -> Result<String, ApiError> {
     if depth > MAX_FILTER_DEPTH {
         return Err(ApiError::BadRequest);
     }
@@ -370,7 +394,7 @@ fn build_filter_sql(filter: &Filter, depth: usize) -> Result<String, ApiError> {
             }
             let parts = children
                 .iter()
-                .map(|c| build_filter_sql(c, depth + 1))
+                .map(|c| build_filter_sql(c, depth + 1, params))
                 .collect::<Result<Vec<_>, _>>()?;
             Ok(format!("({})", parts.join(" AND ")))
         }
@@ -380,7 +404,7 @@ fn build_filter_sql(filter: &Filter, depth: usize) -> Result<String, ApiError> {
             }
             let parts = children
                 .iter()
-                .map(|c| build_filter_sql(c, depth + 1))
+                .map(|c| build_filter_sql(c, depth + 1, params))
                 .collect::<Result<Vec<_>, _>>()?;
             Ok(format!("({})", parts.join(" OR ")))
         }
@@ -392,18 +416,21 @@ fn build_filter_sql(filter: &Filter, depth: usize) -> Result<String, ApiError> {
             if !is_valid_identifier(column) {
                 return Err(ApiError::BadRequest);
             }
-            build_condition_sql(column, operator, value)
+            build_condition_sql(column, operator, value, params)
         }
     }
 }
 
 /// Renders a single `column OP value` condition.
 ///
-/// `IsNull` and `IsNotNull` ignore `value` entirely.
+/// `IsNull` and `IsNotNull` emit `IS NULL` / `IS NOT NULL` directly and leave
+/// `params` unchanged. All other operators append a typed named parameter to
+/// `params` and emit `column OP @pN`.
 fn build_condition_sql(
     column: &str,
     op: &Operator,
     value: &FilterValue,
+    params: &mut Vec<QueryParameter>,
 ) -> Result<String, ApiError> {
     let col = format!("`{column}`");
     match op {
@@ -423,33 +450,46 @@ fn build_condition_sql(
         Operator::IsNull | Operator::IsNotNull => unreachable!(), // safety: returns above
     };
 
-    Ok(format!("{col} {op_str} {}", build_value_sql(value)?))
+    let placeholder = push_value_param(value, params)?;
+    Ok(format!("{col} {op_str} {placeholder}"))
 }
 
-/// Formats a [`FilterValue`] as a safe SQL literal.
+/// Appends a typed [`QueryParameter`] to `params` and returns the corresponding
+/// `@pN` placeholder string.
 ///
-/// Strings are wrapped in single quotes. BigQuery Standard SQL recognises both
-/// `''` and `\'` as a literal single quote inside a string, so backslashes must
-/// be doubled first — otherwise a trailing `\` would turn our closing `''` into
-/// an escape sequence and allow injection. The order is critical: `\` → `\\`,
-/// then `'` → `''`. NaN and infinite floats are rejected because BigQuery has
-/// no SQL representation for them.
-fn build_value_sql(value: &FilterValue) -> Result<String, ApiError> {
-    match value {
-        FilterValue::String(s) => {
-            let escaped = s.replace('\\', "\\\\").replace('\'', "''");
-            Ok(format!("'{escaped}'"))
-        }
-        FilterValue::Integer(n) => Ok(n.to_string()),
+/// NaN and infinite floats are rejected because BigQuery has no wire representation for them.
+fn push_value_param(
+    value: &FilterValue,
+    params: &mut Vec<QueryParameter>,
+) -> Result<String, ApiError> {
+    let name = format!("p{}", params.len());
+
+    let (type_str, scalar_value) = match value {
+        FilterValue::String(s) => ("STRING", Some(s.clone())),
+        FilterValue::Integer(n) => ("INT64", Some(n.to_string())),
         FilterValue::Float(f) => {
             if f.is_nan() || f.is_infinite() {
                 return Err(ApiError::BadRequest);
             }
-            Ok(f.to_string())
+            ("FLOAT64", Some(f.to_string()))
         }
-        FilterValue::Boolean(b) => Ok(if *b { "TRUE" } else { "FALSE" }.to_string()),
-        FilterValue::Null => Ok("NULL".to_string()),
-    }
+        FilterValue::Boolean(b) => ("BOOL", Some(b.to_string())),
+        FilterValue::Null => ("STRING", None),
+    };
+
+    params.push(QueryParameter {
+        name: Some(name.clone()),
+        parameter_type: QueryParameterType {
+            parameter_type: type_str.to_string(),
+            ..Default::default()
+        },
+        parameter_value: QueryParameterValue {
+            value: scalar_value,
+            ..Default::default()
+        },
+    });
+
+    Ok(format!("@{name}"))
 }
 
 /// Extracts the value at `index` from `row`, parsing it into the

--- a/runtime/plaid/src/apis/gcp/bigquery.rs
+++ b/runtime/plaid/src/apis/gcp/bigquery.rs
@@ -424,11 +424,6 @@ fn build_condition_sql(
     params: &mut Vec<QueryParameter>,
 ) -> Result<String, ApiError> {
     let col = format!("`{column}`");
-    match op {
-        Operator::IsNull => return Ok(format!("{col} IS NULL")),
-        Operator::IsNotNull => return Ok(format!("{col} IS NOT NULL")),
-        _ => {}
-    }
 
     let op_str = match op {
         Operator::Eq => "=",
@@ -438,7 +433,8 @@ fn build_condition_sql(
         Operator::Gt => ">",
         Operator::Ge => ">=",
         Operator::Like => "LIKE",
-        Operator::IsNull | Operator::IsNotNull => unreachable!(), // safety: returns above
+        Operator::IsNull => return Ok(format!("{col} IS NULL")),
+        Operator::IsNotNull => return Ok(format!("{col} IS NOT NULL")),
     };
 
     let placeholder = push_value_param(value, params)?;
@@ -466,7 +462,6 @@ fn push_value_param(
         }
         FilterValue::Boolean(b) => ("BOOL", Some(b.to_string())),
         FilterValue::Timestamp(t) => ("TIMESTAMP", Some(t.to_string())),
-        FilterValue::Null => ("STRING", None),
     };
 
     params.push(QueryParameter {
@@ -528,9 +523,7 @@ fn decode_column(
 ///
 /// This is a strict allowlist. Any character outside that set — including
 /// spaces, quotes, backticks, semicolons, parentheses, and comment markers
-/// (`--`, `/*`) — causes the function to return `false`, making SQL injection
-/// via crafted identifier names impossible regardless of the surrounding query
-/// structure.
+/// (`--`, `/*`) — causes the function to return `false`
 fn is_valid_identifier(s: &str) -> bool {
     !s.is_empty()
         && s.chars()

--- a/runtime/plaid/src/apis/gcp/mod.rs
+++ b/runtime/plaid/src/apis/gcp/mod.rs
@@ -1,18 +1,23 @@
 use serde::Deserialize;
 
+use bigquery::{BigQuery, BigQueryConfig};
 use google_docs::{GoogleDocs, GoogleDocsConfig};
 
+pub mod bigquery;
 pub mod google_docs;
 
 #[derive(Deserialize)]
 pub struct GcpConfig {
     pub google_docs: Option<GoogleDocsConfig>,
+    pub bigquery: Option<BigQueryConfig>,
 }
 
 /// Contains all GCP services that Plaid implements APIs for
 pub struct Gcp {
     /// Google Docs
     pub google_docs: Option<GoogleDocs>,
+    /// BigQuery
+    pub bigquery: Option<BigQuery>,
 }
 
 impl Gcp {
@@ -22,6 +27,18 @@ impl Gcp {
             None => None,
         };
 
-        Gcp { google_docs }
+        let bigquery = match config.bigquery {
+            Some(conf) => Some(
+                BigQuery::new(conf)
+                    .await
+                    .expect("Failed to initialize BigQuery client"),
+            ),
+            None => None,
+        };
+
+        Gcp {
+            google_docs,
+            bigquery,
+        }
     }
 }

--- a/runtime/plaid/src/apis/mod.rs
+++ b/runtime/plaid/src/apis/mod.rs
@@ -129,6 +129,8 @@ pub enum ApiError {
     S3Error(aws::s3::S3Errors),
     #[cfg(feature = "gcp")]
     GoogleDocsError(gcp::google_docs::GoogleDocsError),
+    #[cfg(feature = "gcp")]
+    BigQueryError(gcp::bigquery::BigQueryError),
     #[cfg(feature = "aws")]
     KmsError(aws::kms::KmsErrors),
     NetworkError(reqwest::Error),
@@ -165,6 +167,13 @@ impl From<S3Errors> for ApiError {
 impl From<KmsErrors> for ApiError {
     fn from(e: KmsErrors) -> Self {
         Self::KmsError(e)
+    }
+}
+
+#[cfg(feature = "gcp")]
+impl From<gcp::bigquery::BigQueryError> for ApiError {
+    fn from(e: gcp::bigquery::BigQueryError) -> Self {
+        Self::BigQueryError(e)
     }
 }
 

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -530,7 +530,7 @@ impl_new_sub_module_function_with_error_buffer!(
     DISALLOW_IN_TEST_MODE
 );
 #[cfg(feature = "gcp")]
-impl_new_sub_module_function_with_error_buffer!(gcp, bigquery, query_table, DISALLOW_IN_TEST_MODE);
+impl_new_sub_module_function_with_error_buffer!(gcp, bigquery, query_table, ALLOW_IN_TEST_MODE);
 
 // Npm Functions
 impl_new_function_with_error_buffer!(npm, publish_empty_stub, DISALLOW_IN_TEST_MODE);

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -825,11 +825,7 @@ define_api_functions! {
         #[cfg(feature = "gcp")] "gcp_google_docs_create_folder"            => gcp_google_docs_create_folder,
         #[cfg(feature = "gcp")] "gcp_google_docs_create_doc_from_markdown" => gcp_google_docs_create_doc_from_markdown,
         #[cfg(feature = "gcp")] "gcp_google_docs_create_sheet_from_csv"    => gcp_google_docs_create_sheet_from_csv,
-
-        #[cfg(feature = "gcp")]
-        "gcp_bigquery_query_table" => {
-            Function::new_typed_with_env(&mut store, &env, gcp_bigquery_query_table)
-        }
+        #[cfg(feature = "gcp")] "gcp_bigquery_query_table"                 => gcp_bigquery_query_table,
 
         // PagerDuty Calls
         "pagerduty_trigger_incident" => pagerduty_trigger_incident,

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -529,6 +529,8 @@ impl_new_sub_module_function_with_error_buffer!(
     create_sheet_from_csv,
     DISALLOW_IN_TEST_MODE
 );
+#[cfg(feature = "gcp")]
+impl_new_sub_module_function_with_error_buffer!(gcp, bigquery, query_table, DISALLOW_IN_TEST_MODE);
 
 // Npm Functions
 impl_new_function_with_error_buffer!(npm, publish_empty_stub, DISALLOW_IN_TEST_MODE);
@@ -823,6 +825,11 @@ define_api_functions! {
         #[cfg(feature = "gcp")] "gcp_google_docs_create_folder"            => gcp_google_docs_create_folder,
         #[cfg(feature = "gcp")] "gcp_google_docs_create_doc_from_markdown" => gcp_google_docs_create_doc_from_markdown,
         #[cfg(feature = "gcp")] "gcp_google_docs_create_sheet_from_csv"    => gcp_google_docs_create_sheet_from_csv,
+
+        #[cfg(feature = "gcp")]
+        "gcp_bigquery_query_table" => {
+            Function::new_typed_with_env(&mut store, &env, gcp_bigquery_query_table)
+        }
 
         // PagerDuty Calls
         "pagerduty_trigger_incident" => pagerduty_trigger_incident,


### PR DESCRIPTION
## Summary

Implements a new BigQuery API that allows modules to query tables via the `gcp::bigquery::query_table` function. Modules specify dataset, table, columns, and optional WHERE filters; the runtime enforces permission checks, validates all identifiers against a strict allowlist, and uses named query parameter. Column type schemas ensure numeric and boolean values arrive with correct JSON types rather than being coerced to strings.

## Changes

**Standard library (`plaid-stl`)**
- Added `gcp::bigquery` module with `query_table` function, `Filter` condition tree types (`And`, `Or`, `Condition`), `Operator` enum, and `FilterValue` for type-safe WHERE clauses
- Added `QueryTableRequest` and `QueryTableResponse` types with iterator support

**Runtime (`runtime/plaid`)**
- Implemented `BigQuery` client using `google-cloud-bigquery` SDK with service account authentication
- Added permission model: config maps module → dataset → table access
- Built SQL query generator with recursive filter rendering, identifier validation (`[A-Za-z_][A-Za-z0-9_]*`), and named parameter binding
- Added configurable column type schemas (dataset → table → column → `ColumnType`) to decode `integer`, `float`, `boolean`, and `timestamp` values correctly
- Registered `gcp_bigquery_query_table` host function

## Security Considerations

**Authorization**  
Modules must be explicitly granted read access to each dataset and table in `apis.toml`.

**SQL injection prevention**  
All identifiers (datasets, tables, columns) are validated with `is_valid_identifier` before query construction. Only ASCII letters, digits, and underscores are permitted; quotes, semicolons, comment markers (`--`, `/*`), and other special characters cause immediate rejection. Filter values are bound as typed named parameters