### PR TITLE
Add support for logging to InfluxDB

### DIFF
--- a/runtime/plaid/examples/tailers/github.rs
+++ b/runtime/plaid/examples/tailers/github.rs
@@ -60,7 +60,7 @@ async fn main() {
 
     loop {
         //println!("Start of log group");
-        get_and_process_dg_logs(&mut gh, None).await.unwrap();
+        get_and_process_dg_logs(&mut gh, None, None).await.unwrap();
 
         while let Ok(log) = logger_rx.recv_timeout(Duration::from_secs(0)) {
             let log: GitHubLog = serde_json::from_slice(&log.data).unwrap();

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -105,7 +105,7 @@ impl DataInternal {
 
         let websocket_external = config
             .websocket
-            .map(|ws| websocket::WebsocketGenerator::new(ws, logger.clone(), els));
+            .map(|ws| websocket::WebsocketGenerator::new(ws, logger.clone(), els.clone()));
 
         Ok(Self {
             github,
@@ -127,7 +127,7 @@ impl Data {
         els: Logger,
         roles: &InstanceRoles,
     ) -> Result<Option<Sender<DelayedMessage>>, DataError> {
-        let di = DataInternal::new(config, sender, storage.clone(), els).await?;
+        let di = DataInternal::new(config, sender, storage.clone(), els.clone()).await?;
         let handle = tokio::runtime::Handle::current();
 
         if roles.data_generators {
@@ -136,10 +136,15 @@ impl Data {
                 let storage_clone = storage.clone();
                 // Update the DG's state from the storage: this recovers the last_seen and seen_logs_uuid from a previous run
                 update_dg_from_storage(&mut gh, Some(storage_clone.clone())).await;
+                let els_clone = els.clone();
                 handle.spawn(async move {
                     loop {
-                        if let Err(_) =
-                            get_and_process_dg_logs(&mut gh, Some(storage_clone.clone())).await
+                        if let Err(_) = get_and_process_dg_logs(
+                            &mut gh,
+                            Some(storage_clone.clone()),
+                            Some(els_clone.clone()),
+                        )
+                        .await
                         {
                             error!("GitHub Data Fetch Error")
                         }
@@ -152,12 +157,17 @@ impl Data {
             // Start the Okta System Logs task if there is one
             if let Some(mut okta) = di.okta {
                 let storage_clone = storage.clone();
+                let els_clone = els.clone();
                 // Update the DG's state from the storage: this recovers the last_seen and seen_logs_uuid from a previous run
                 update_dg_from_storage(&mut okta, Some(storage_clone.clone())).await;
                 handle.spawn(async move {
                     loop {
-                        if let Err(_) =
-                            get_and_process_dg_logs(&mut okta, Some(storage_clone.clone())).await
+                        if let Err(_) = get_and_process_dg_logs(
+                            &mut okta,
+                            Some(storage_clone.clone()),
+                            Some(els_clone.clone()),
+                        )
+                        .await
                         {
                             error!("Okta Data Fetch Error")
                         }
@@ -446,6 +456,7 @@ async fn update_dg_from_storage<T: DataGenerator>(dg: &mut T, storage: Option<Ar
 pub async fn get_and_process_dg_logs(
     dg: &mut impl DataGenerator,
     storage: Option<Arc<Storage>>,
+    els: Option<Logger>,
 ) -> Result<(), ()> {
     let sleep_duration = dg.get_sleep_duration();
 
@@ -541,6 +552,7 @@ pub async fn get_and_process_dg_logs(
                 dg.set_last_seen(log.timestamp);
             }
         }
+
         // If there have been no new logs sent for processing, we exit.
         // Exiting here will result in a 10 second wait between restarts
         if sent_for_processing == 0 {
@@ -551,6 +563,7 @@ pub async fn get_and_process_dg_logs(
             );
             return Ok(());
         }
+
         // If we are here, then we sent something for processing: we update the DG's state in the storage so that,
         // in case of a reboot, we can continue from where we had left off.
         if let Some(ref storage) = storage {
@@ -593,6 +606,15 @@ pub async fn get_and_process_dg_logs(
             dg.get_name(),
             dg.get_last_seen()
         );
+
+        if let Some(ref els) = els {
+            let _ = els
+                .log_ts(
+                    format!("{}_dg_processed", dg.get_name()),
+                    sent_for_processing.into(),
+                )
+                .inspect_err(|e| error!("Could not log sent_for_processing to ELS: {e}"));
+        }
 
         // Wait for the specified period before making another request
         tokio::time::sleep(sleep_duration).await

--- a/runtime/plaid/src/logging/influxdb.rs
+++ b/runtime/plaid/src/logging/influxdb.rs
@@ -1,0 +1,134 @@
+//! This module provides a way for Plaid to log to InfluxDB.
+
+use std::{collections::HashMap, time::Duration};
+
+use crate::logging::Log;
+
+use super::{LoggingError, PlaidLogger, WrappedLog};
+
+use serde::Deserialize;
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum InfluxDbError {
+    SendError,
+    UnexpectedStatusCode(u16),
+}
+
+/// Configuration for the InfluxDB logger.
+#[derive(Deserialize)]
+pub struct Config {
+    /// The endpoint of the InfluxDB instance (e.g. "http://localhost").
+    pub endpoint: String,
+    /// The port of the InfluxDB instance (e.g. 8181).
+    pub port: u16,
+    /// The authentication token for the InfluxDB instance.
+    pub token: String,
+    /// The name of the InfluxDB database to write to.
+    pub database: String,
+    /// The timeout for sending logs to the InfluxDB instance, in seconds.
+    pub client_timeout: Option<u8>,
+}
+
+/// A logger that sends logs to an InfluxDB instance.
+pub struct InfluxDBLogger {
+    /// The URL of the InfluxDB instance (e.g. "http://localhost:8181").
+    url: String,
+    /// The authentication token for the InfluxDB instance.
+    token: String,
+    /// The name of the InfluxDB database to write to.
+    database: String,
+    /// The HTTP client used to send requests to the InfluxDB instance.
+    client: reqwest::Client,
+}
+
+impl InfluxDBLogger {
+    pub fn new(config: Config) -> Self {
+        let mut timeout = config.client_timeout.unwrap_or(30);
+        if timeout == 0 {
+            timeout = 30; // Default to 30 seconds if the provided timeout is 0
+        }
+        // Unwrap is safe here because we are providing a valid timeout value and reqwest's ClientBuilder should not fail with a valid timeout.
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(timeout.into()))
+            .build()
+            .unwrap();
+
+        Self {
+            url: format!("{}:{}", config.endpoint, config.port),
+            token: config.token,
+            database: config.database,
+            client,
+        }
+    }
+
+    /// Send a log to the InfluxDB instance using InfluxDB's line protocol.
+    async fn send_line_protocol(
+        &self,
+        table: &str,
+        tags: Option<HashMap<&str, &str>>,
+        fields: HashMap<&str, &str>,
+        timestamp: Option<u64>,
+    ) -> Result<(), InfluxDbError> {
+        let line = format!(
+            "{},{} {} {}",
+            table,
+            tags.map(|t| t
+                .into_iter()
+                .map(|(k, v)| format!("{}={}", k, v))
+                .collect::<Vec<_>>()
+                .join(","))
+                .unwrap_or_default(),
+            fields
+                .into_iter()
+                .map(|(k, v)| format!("{}={}", k, v))
+                .collect::<Vec<_>>()
+                .join(","),
+            timestamp.map(|t| t.to_string()).unwrap_or_default()
+        );
+
+        let response = self
+            .client
+            .post(format!("{}/api/v3/write_lp?db={}", self.url, self.database))
+            .header("Authorization", format!("Bearer {}", self.token))
+            .body(line)
+            .send()
+            .await
+            .map_err(|_| InfluxDbError::SendError)?;
+
+        if !response.status().is_success() {
+            error!(
+                "Failed to send log to InfluxDB. Status: {}",
+                response.status()
+            );
+            return Err(InfluxDbError::UnexpectedStatusCode(
+                response.status().as_u16(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl PlaidLogger for InfluxDBLogger {
+    async fn send_log(&self, log: &WrappedLog) -> Result<(), LoggingError> {
+        match log.log {
+            Log::TimeseriesPoint {
+                ref measurement,
+                value,
+            } => self
+                .send_line_protocol(
+                    &measurement,
+                    None,
+                    [("value", value.to_string().as_str())].into(),
+                    None,
+                )
+                .await
+                .map_err(LoggingError::InfluxDbError),
+            _ => {
+                // For now, we only support timeseries points for InfluxDB logging
+                Ok(())
+            }
+        }
+    }
+}

--- a/runtime/plaid/src/logging/influxdb.rs
+++ b/runtime/plaid/src/logging/influxdb.rs
@@ -70,22 +70,27 @@ impl InfluxDBLogger {
         fields: HashMap<&str, &str>,
         timestamp: Option<u64>,
     ) -> Result<(), InfluxDbError> {
-        let line = format!(
-            "{},{} {} {}",
-            table,
-            tags.map(|t| t
-                .into_iter()
-                .map(|(k, v)| format!("{}={}", k, v))
-                .collect::<Vec<_>>()
-                .join(","))
-                .unwrap_or_default(),
-            fields
-                .into_iter()
-                .map(|(k, v)| format!("{}={}", k, v))
-                .collect::<Vec<_>>()
-                .join(","),
-            timestamp.map(|t| t.to_string()).unwrap_or_default()
-        );
+        let tags_str = tags
+            .map(|t| {
+                format!(
+                    ",{}",
+                    t.into_iter()
+                        .map(|(k, v)| format!("{}={}", k, v))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+            })
+            .unwrap_or_default();
+
+        let fields_str = fields
+            .into_iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let timestamp_str = timestamp.map(|t| format!(" {}", t)).unwrap_or_default();
+
+        let line = format!("{}{} {}{}", table, tags_str, fields_str, timestamp_str);
 
         let response = self
             .client

--- a/runtime/plaid/src/logging/mod.rs
+++ b/runtime/plaid/src/logging/mod.rs
@@ -1,7 +1,7 @@
+mod influxdb;
 mod splunk;
-mod webhook;
-
 mod stdout;
+mod webhook;
 
 use crossbeam_channel::{bounded, Receiver, RecvTimeoutError, Sender};
 
@@ -94,6 +94,9 @@ pub struct LoggingConfiguration {
     /// so it's easy to operate on Plaid events. It's likely in future the
     /// Splunk logger code will be a specific instantiation of this.
     webhook: Option<webhook::Config>,
+    /// Log to InfluxDB for timeseries data. The influxdb module contains more
+    /// information on configuring this logger.
+    influxdb: Option<influxdb::Config>,
     /// Determines whether logs forwarded to rules are output to the configured logging destinations when a module fails.
     /// When set to `true`, logs are displayed for debugging; when `false`, they are omitted.
     /// Defaults to `true` if not explicitly configured.
@@ -118,6 +121,8 @@ pub enum LoggingError {
     CommunicationError(String),
     /// Logging system has gone away
     LoggingSystemDead,
+    /// Errors specific to InfluxDB logging
+    InfluxDbError(influxdb::InfluxDbError),
 }
 
 impl std::fmt::Display for LoggingError {
@@ -126,6 +131,7 @@ impl std::fmt::Display for LoggingError {
             LoggingError::SerializationError(e) => write!(f, "Logging serialization error: {}", e),
             LoggingError::CommunicationError(e) => write!(f, "Logging communication error: {}", e),
             LoggingError::LoggingSystemDead => write!(f, "Logging system has gone away"),
+            LoggingError::InfluxDbError(e) => write!(f, "InfluxDB logging error: {:?}", e),
         }
     }
 }
@@ -133,7 +139,7 @@ impl std::fmt::Display for LoggingError {
 /// To implement a new logger, it must implement the `send_log` function
 /// and return success or failure.
 trait PlaidLogger {
-    fn send_log(&self, log: &WrappedLog) -> Result<(), LoggingError>;
+    async fn send_log(&self, log: &WrappedLog) -> Result<(), LoggingError>;
 }
 
 #[derive(Clone)]
@@ -205,7 +211,7 @@ impl Logger {
     /// will send a heartbeat message instead. For stdout, and influx, this is
     /// a noop and will not actually be sent to the backend (or logged to the
     /// screen).
-    fn logging_thread_loop(
+    async fn logging_thread_loop(
         config: LoggingConfiguration,
         log_receiver: Receiver<Log>,
     ) -> Result<(), LoggingError> {
@@ -242,6 +248,14 @@ impl Logger {
             None => None,
         };
 
+        let influxdb_logger = match config.influxdb {
+            Some(config) => {
+                info!("Configured logger: influxdb");
+                Some(influxdb::InfluxDBLogger::new(config))
+            }
+            None => None,
+        };
+
         // Main logging loop
         loop {
             let log = match log_receiver.recv_timeout(Duration::from_secs(heartbeat_interval)) {
@@ -256,20 +270,26 @@ impl Logger {
             };
 
             if let Some(logger) = &stdout_logger {
-                if let Err(_) = logger.send_log(&log) {
+                if let Err(_) = logger.send_log(&log).await {
                     error!("Could not send logs to stdout");
                 }
             }
 
             if let Some(logger) = &splunk_logger {
-                if let Err(_) = logger.send_log(&log) {
+                if let Err(_) = logger.send_log(&log).await {
                     error!("Could not send logs to Splunk");
                 }
             }
 
             if let Some(logger) = &webhook_logger {
-                if let Err(_) = logger.send_log(&log) {
+                if let Err(_) = logger.send_log(&log).await {
                     error!("Could not send logs to webhook");
+                }
+            }
+
+            if let Some(logger) = &influxdb_logger {
+                if let Err(_) = logger.send_log(&log).await {
+                    error!("Could not send logs to InfluxDB");
                 }
             }
         }
@@ -281,7 +301,10 @@ impl Logger {
     pub fn start(config: LoggingConfiguration) -> (Self, JoinHandle<Result<(), LoggingError>>) {
         let (sender, rx) = bounded(CHANNEL_CAPACITY);
         let show_log_on_error = config.show_log_on_error;
-        let _handle = thread::spawn(move || Self::logging_thread_loop(config, rx));
+        let _handle = thread::spawn(move || {
+            let runtime = Runtime::new().unwrap();
+            runtime.block_on(Self::logging_thread_loop(config, rx))
+        });
 
         (
             Self {

--- a/runtime/plaid/src/logging/splunk.rs
+++ b/runtime/plaid/src/logging/splunk.rs
@@ -67,7 +67,7 @@ impl PlaidLogger for SplunkLogger {
     /// will not block sending logs to other services (like stdout) but it
     /// does mean we cannot return a proper LoggingError to the caller since
     /// we cannot wait for it to complete.
-    fn send_log(&self, log: &WrappedLog) -> Result<(), LoggingError> {
+    async fn send_log(&self, log: &WrappedLog) -> Result<(), LoggingError> {
         let splunk_log = SplunkLogWrapper { event: log };
 
         let res = self

--- a/runtime/plaid/src/logging/stdout.rs
+++ b/runtime/plaid/src/logging/stdout.rs
@@ -16,7 +16,7 @@ impl StdoutLogger {
 }
 
 impl PlaidLogger for StdoutLogger {
-    fn send_log(&self, log: &WrappedLog) -> Result<(), LoggingError> {
+    async fn send_log(&self, log: &WrappedLog) -> Result<(), LoggingError> {
         match &log.log {
             Log::InternalMessage { severity, message } => match severity {
                 Severity::Error => error!("{}", message),

--- a/runtime/plaid/src/logging/webhook.rs
+++ b/runtime/plaid/src/logging/webhook.rs
@@ -20,16 +20,16 @@ pub struct Config {
 pub struct WebhookLogger {
     /// A tokio runtime to send logs on
     runtime: Handle,
-    /// A reqwest client configured with the Splunk endpoint and authentication
+    /// A reqwest client configured with the webhook endpoint and authentication
     client: reqwest::Client,
     /// The configuration struct
     config: Config,
 }
 
 impl WebhookLogger {
-    /// Implement the new function for the Splunk logger. This converts
+    /// Implement the new function for the Webhook logger. This converts
     /// the configuration struct into a type that can handle sending
-    /// logs directly to a Splunk HEC endpoint.
+    /// logs directly to a webhook endpoint.
     pub fn new(config: Config, handle: Handle) -> Self {
         // I don't think this can fail with our settings so we do an unwrap
         let client = reqwest::Client::builder()
@@ -50,7 +50,7 @@ impl PlaidLogger for WebhookLogger {
     /// will not block sending logs to other services (like stdout) but it
     /// does mean we cannot return a proper LoggingError to the caller since
     /// we cannot wait for it to complete.
-    fn send_log(&self, log: &WrappedLog) -> Result<(), LoggingError> {
+    async fn send_log(&self, log: &WrappedLog) -> Result<(), LoggingError> {
         let data = match serde_json::to_string(&log) {
             Ok(json) => json,
             Err(e) => return Err(LoggingError::SerializationError(e.to_string())),


### PR DESCRIPTION
## Summary

  Add InfluxDB as a supported logging backend and wire data generators to emit simple timeseries metrics through the existing logging pipeline.

  ## Changes

  - add influxdb logger configuration and implementation
  - make the logging pipeline async so backends can await network sends
  - start a Tokio runtime inside the logging thread to support async logger execution
  - emit `*_dg_processed` timeseries points from data generators with the number of processed logs
  - update call sites and logger trait implementations to match the new async interface
  - clean up a few webhook logger comments