### PR TITLE
feat: thread_ts support and chat.update Slack API

### DIFF
--- a/runtime/plaid-stl/src/slack/mod.rs
+++ b/runtime/plaid-stl/src/slack/mod.rs
@@ -193,14 +193,21 @@ pub fn post_message_with_blocks(
     post_message_with_blocks_detailed(bot, channel, text).map(|_| ())
 }
 
+/// Slack API response for message operations (chat.postMessage, chat.update).
+#[derive(Serialize, Deserialize)]
+pub struct SlackMessageResponse {
+    pub ok: bool,
+    pub channel: String,
+    pub ts: String,
+}
+
 /// Post a Block Kit message as a thread reply under an existing message.
-/// Returns the full Slack API response (including the new message's `ts`).
-pub fn post_message_with_blocks_in_thread_detailed(
+pub fn post_message_with_blocks_in_thread(
     bot: &str,
     channel: &str,
     blocks: &str,
     thread_ts: &str,
-) -> Result<String, PlaidFunctionError> {
+) -> Result<SlackMessageResponse, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(slack, post_message);
     }
@@ -236,17 +243,7 @@ pub fn post_message_with_blocks_in_thread_detailed(
     return_buffer.truncate(res as usize);
     let res = String::from_utf8(return_buffer).unwrap();
 
-    Ok(res)
-}
-
-/// Post a Block Kit message as a thread reply under an existing message.
-pub fn post_message_with_blocks_in_thread(
-    bot: &str,
-    channel: &str,
-    blocks: &str,
-    thread_ts: &str,
-) -> Result<(), PlaidFunctionError> {
-    post_message_with_blocks_in_thread_detailed(bot, channel, blocks, thread_ts).map(|_| ())
+    serde_json::from_str(&res).map_err(|_| PlaidFunctionError::Unknown)
 }
 
 /// Data to be sent to the runtime to open a view
@@ -668,17 +665,16 @@ pub struct UpdateMessage {
 }
 
 /// Update an existing Slack message with new Block Kit content (chat.update).
-/// Returns the full Slack API response.
 /// - `bot`: configured bot name
-/// - `channel`: channel containing the message
+/// - `channel`: channel ID containing the message
 /// - `ts`: timestamp of the message to update
 /// - `blocks`: new Block Kit JSON content
-pub fn update_message_with_blocks_detailed(
+pub fn update_message_with_blocks(
     bot: &str,
     channel: &str,
     ts: &str,
     blocks: &str,
-) -> Result<String, PlaidFunctionError> {
+) -> Result<SlackMessageResponse, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(slack, update_message);
     }
@@ -714,15 +710,5 @@ pub fn update_message_with_blocks_detailed(
     return_buffer.truncate(res as usize);
     let res = String::from_utf8(return_buffer).unwrap();
 
-    Ok(res)
-}
-
-/// Update an existing Slack message with new Block Kit content (chat.update).
-pub fn update_message_with_blocks(
-    bot: &str,
-    channel: &str,
-    ts: &str,
-    blocks: &str,
-) -> Result<(), PlaidFunctionError> {
-    update_message_with_blocks_detailed(bot, channel, ts, blocks).map(|_| ())
+    serde_json::from_str(&res).map_err(|_| PlaidFunctionError::Unknown)
 }

--- a/runtime/plaid-stl/src/slack/mod.rs
+++ b/runtime/plaid-stl/src/slack/mod.rs
@@ -14,6 +14,8 @@ pub struct SlackMessage {
 pub struct SlackMessageWithBlocks {
     channel: String,
     blocks: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thread_ts: Option<String>,
 }
 
 #[inline]
@@ -152,6 +154,7 @@ pub fn post_message_with_blocks_detailed(
     let message = SlackMessageWithBlocks {
         channel: channel.to_owned(),
         blocks: text.to_owned(),
+        thread_ts: None,
     };
 
     const RETURN_BUFFER_SIZE: usize = 32 * 1024; // 32 KiB
@@ -188,6 +191,62 @@ pub fn post_message_with_blocks(
     text: &str,
 ) -> Result<(), PlaidFunctionError> {
     post_message_with_blocks_detailed(bot, channel, text).map(|_| ())
+}
+
+/// Post a Block Kit message as a thread reply under an existing message.
+/// Returns the full Slack API response (including the new message's `ts`).
+pub fn post_message_with_blocks_in_thread_detailed(
+    bot: &str,
+    channel: &str,
+    blocks: &str,
+    thread_ts: &str,
+) -> Result<String, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(slack, post_message);
+    }
+
+    let message = SlackMessageWithBlocks {
+        channel: channel.to_owned(),
+        blocks: blocks.to_owned(),
+        thread_ts: Some(thread_ts.to_owned()),
+    };
+
+    const RETURN_BUFFER_SIZE: usize = 32 * 1024; // 32 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let params = serde_json::to_string(&PostMessage {
+        bot: bot.to_string(),
+        body: serde_json::to_string(&message).unwrap(),
+    })
+    .unwrap();
+
+    let res = unsafe {
+        slack_post_message(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    let res = String::from_utf8(return_buffer).unwrap();
+
+    Ok(res)
+}
+
+/// Post a Block Kit message as a thread reply under an existing message.
+pub fn post_message_with_blocks_in_thread(
+    bot: &str,
+    channel: &str,
+    blocks: &str,
+    thread_ts: &str,
+) -> Result<(), PlaidFunctionError> {
+    post_message_with_blocks_in_thread_detailed(bot, channel, blocks, thread_ts).map(|_| ())
 }
 
 /// Data to be sent to the runtime to open a view
@@ -592,4 +651,78 @@ pub fn invite_to_channel(
     }
 
     Ok(())
+}
+
+#[derive(Serialize)]
+struct SlackUpdateMessageWithBlocks {
+    channel: String,
+    ts: String,
+    blocks: String,
+}
+
+/// Data to be sent to the Plaid runtime for updating a message
+#[derive(Serialize, Deserialize)]
+pub struct UpdateMessage {
+    pub bot: String,
+    pub body: String,
+}
+
+/// Update an existing Slack message with new Block Kit content (chat.update).
+/// Returns the full Slack API response.
+/// - `bot`: configured bot name
+/// - `channel`: channel containing the message
+/// - `ts`: timestamp of the message to update
+/// - `blocks`: new Block Kit JSON content
+pub fn update_message_with_blocks_detailed(
+    bot: &str,
+    channel: &str,
+    ts: &str,
+    blocks: &str,
+) -> Result<String, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(slack, update_message);
+    }
+
+    let message = SlackUpdateMessageWithBlocks {
+        channel: channel.to_owned(),
+        ts: ts.to_owned(),
+        blocks: blocks.to_owned(),
+    };
+
+    const RETURN_BUFFER_SIZE: usize = 32 * 1024; // 32 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let params = serde_json::to_string(&UpdateMessage {
+        bot: bot.to_string(),
+        body: serde_json::to_string(&message).unwrap(),
+    })
+    .unwrap();
+
+    let res = unsafe {
+        slack_update_message(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    let res = String::from_utf8(return_buffer).unwrap();
+
+    Ok(res)
+}
+
+/// Update an existing Slack message with new Block Kit content (chat.update).
+pub fn update_message_with_blocks(
+    bot: &str,
+    channel: &str,
+    ts: &str,
+    blocks: &str,
+) -> Result<(), PlaidFunctionError> {
+    update_message_with_blocks_detailed(bot, channel, ts, blocks).map(|_| ())
 }

--- a/runtime/plaid/src/apis/slack/api.rs
+++ b/runtime/plaid/src/apis/slack/api.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use plaid_stl::slack::{
     CreateChannel, CreateChannelResponse, GetDndInfo, GetDndInfoResponse, GetIdFromEmail,
-    GetPresence, GetPresenceResponse, InviteToChannel, PostMessage, UserInfo, UserInfoResponse,
-    ViewOpen,
+    GetPresence, GetPresenceResponse, InviteToChannel, PostMessage, UpdateMessage, UserInfo,
+    UserInfoResponse, ViewOpen,
 };
 use reqwest::{Client, RequestBuilder};
 
@@ -16,6 +16,7 @@ use super::Slack;
 
 enum Apis {
     PostMessage(plaid_stl::slack::PostMessage),
+    UpdateMessage(plaid_stl::slack::UpdateMessage),
     ViewsOpen(plaid_stl::slack::ViewOpen),
     LookupByEmail(plaid_stl::slack::GetIdFromEmail),
     GetPresence(plaid_stl::slack::GetPresence),
@@ -40,6 +41,10 @@ impl Apis {
         match self {
             Self::PostMessage(p) => client
                 .post(format!("{SLACK_API_URL}{api}", api = "chat.postMessage"))
+                .body(p.body.clone())
+                .header("Content-Type", "application/json; charset=utf-8"),
+            Self::UpdateMessage(p) => client
+                .post(format!("{SLACK_API_URL}{api}", api = "chat.update"))
                 .body(p.body.clone())
                 .header("Content-Type", "application/json; charset=utf-8"),
             Self::ViewsOpen(p) => client
@@ -80,6 +85,7 @@ impl std::fmt::Display for Apis {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::PostMessage(_) => write!(f, "PostMessage"),
+            Self::UpdateMessage(_) => write!(f, "UpdateMessage"),
             Self::ViewsOpen(_) => write!(f, "ViewsOpen"),
             Self::LookupByEmail(_) => write!(f, "LookupByEmail"),
             Self::GetPresence(_) => write!(f, "GetPresence"),
@@ -154,6 +160,33 @@ impl Slack {
         let p: PostMessage = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
         match self
             .call_slack(p.bot.clone(), Apis::PostMessage(p), module)
+            .await
+        {
+            Ok((200, response)) => {
+                let slack_response: GenericSlackResponse = serde_json::from_str(&response)
+                    .map_err(|_| {
+                        ApiError::SlackError(SlackError::UnexpectedPayload(response.clone()))
+                    })?;
+                if !slack_response.ok {
+                    return Err(ApiError::SlackError(SlackError::UnexpectedPayload(
+                        response,
+                    )));
+                }
+                Ok(response)
+            }
+            Ok((status, _)) => Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(
+                status,
+            ))),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Call the Slack chat.update API. Updates an existing message identified by its ts.
+    /// The bot must be configured in Plaid.
+    pub async fn update_message(&self, params: &str, module: Arc<PlaidModule>) -> Result<String> {
+        let p: UpdateMessage = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        match self
+            .call_slack(p.bot.clone(), Apis::UpdateMessage(p), module)
             .await
         {
             Ok((200, response)) => {

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -562,6 +562,7 @@ impl_new_function_with_error_buffer!(rustica, new_mtls_cert, DISALLOW_IN_TEST_MO
 // Slack Functions
 impl_new_function!(slack, views_open, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(slack, post_message, ALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(slack, update_message, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(slack, get_id_from_email, ALLOW_IN_TEST_MODE);
 impl_new_function!(slack, post_to_arbitrary_webhook, ALLOW_IN_TEST_MODE);
 impl_new_function!(slack, post_to_named_webhook, ALLOW_IN_TEST_MODE);
@@ -894,6 +895,9 @@ pub fn to_api_function(
             Function::new_typed_with_env(&mut store, &env, slack_post_to_arbitrary_webhook)
         }
         "slack_post_message" => Function::new_typed_with_env(&mut store, &env, slack_post_message),
+        "slack_update_message" => {
+            Function::new_typed_with_env(&mut store, &env, slack_update_message)
+        }
         "slack_views_open" => Function::new_typed_with_env(&mut store, &env, slack_views_open),
         "slack_get_id_from_email" => {
             Function::new_typed_with_env(&mut store, &env, slack_get_id_from_email)


### PR DESCRIPTION
Adds `thread_ts` support to `chat.postMessage` and a new `chat.update` API so WASM rules can post thread replies and update messages in-place.

New STL functions: `post_message_with_blocks_in_thread[_detailed]`, `update_message_with_blocks[_detailed]`

Note: chat.update requires channel ID, not name. Use the channel field from the `post_message` response.

Testing: All three operations (post, thread reply, in-place update) verified locally against a real Slack workspace.