### PR TITLE
Add file content parameter to GitHub code search API

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3626,7 +3626,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "aes 0.7.5",
  "alkali",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.37.3"
+version = "0.38.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.37.3"
+version = "0.38.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/github/search.rs
+++ b/runtime/plaid-stl/src/github/search.rs
@@ -18,6 +18,7 @@ pub fn search_code(
     filename: Option<impl Display>,
     extension: Option<impl Display>,
     path: Option<impl Display>,
+    file_content: Option<impl Display>,
     search_criteria: Option<&CodeSearchCriteria>,
 ) -> Result<Vec<FileSearchResultItem>, PlaidFunctionError> {
     extern "C" {
@@ -33,6 +34,9 @@ pub fn search_code(
     }
     if let Some(path) = path {
         params.insert("path", path.to_string());
+    }
+    if let Some(content) = file_content {
+        params.insert("file_content", content.to_string());
     }
 
     // If we are given selection criteria, then we divide them between

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.37.3"
+version = "0.38.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/github/code.rs
+++ b/runtime/plaid/src/apis/github/code.rs
@@ -28,6 +28,11 @@ impl Github {
         We simply validate individual parameters if present.
         */
 
+        let file_content = match request.get("file_content") {
+            None => String::new(),
+            Some(content) => content.to_string(),
+        };
+
         let filename = match request.get("filename") {
             None => String::new(),
             Some(filename) => format!("filename:{}", self.validate_filename(filename)?),
@@ -79,7 +84,7 @@ impl Github {
             .map_err(|_| ApiError::BadRequest)?;
 
         // Construct the query with the piece we have. Multiple spaces, if present, do not cause problems.
-        let query = format!("{filename} {extension} {path} {org_and_repo}");
+        let query = format!("{file_content} {filename} {extension} {path} {org_and_repo}");
 
         // Log what we are doing
         info!("Searching code in GH with query [{query}] on behalf of [{module}]");


### PR DESCRIPTION
## Summary

Updates the GitHub code search functionality to accept an optional `file_content` parameter, enabling searches based on file contents in addition to existing filters (filename, extension, path, repository)

## Changes

- **`runtime/plaid-stl/src/github/search.rs`**: Added optional `file_content` parameter to the `search_code` function signature and parameter map
- **`runtime/plaid/src/apis/github/code.rs`**: Extracted `file_content` from request body and integrated it into the search query string

## Rationale

The existing code search only supported metadata-based filtering (filename, extension, path, org/repo). Adding file content search enables more targeted queries when users know specific code patterns or strings they want to find. 

## Breaking Changes

The `search_code` function signature in `plaid-stl` has been modified to include a new `file_content` parameter. Existing callers must update their invocations to provide this parameter (can pass `None` to maintain previous behavior)