### PR TITLE
Support fetching repos teams and collaborators with direct access

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3626,7 +3626,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "aes 0.7.5",
  "alkali",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.38.0"
+version = "0.38.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/github/repo.rs
+++ b/runtime/plaid-stl/src/github/repo.rs
@@ -132,12 +132,32 @@ pub fn get_all_repository_collaborators(
     owner: impl Display,
     repo: impl Display,
 ) -> Result<Vec<RepositoryCollaborator>, PlaidFunctionError> {
+    get_all_repository_collaborators_detailed(owner, repo, None)
+}
+
+/// Get all collaborators on a repository with direct access.
+pub fn get_all_repository_collaborators_direct_access(
+    owner: impl Display,
+    repo: impl Display,
+) -> Result<Vec<RepositoryCollaborator>, PlaidFunctionError> {
+    get_all_repository_collaborators_detailed(owner, repo, Some("direct"))
+}
+
+/// Get all collaborators on a repository with affiliation filter.
+pub fn get_all_repository_collaborators_detailed(
+    owner: impl Display,
+    repo: impl Display,
+    affiliation: Option<&str>,
+) -> Result<Vec<RepositoryCollaborator>, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, get_repository_collaborators);
     }
     let mut params: HashMap<&str, String> = HashMap::new();
     params.insert("owner", owner.to_string());
     params.insert("repo", repo.to_string());
+    if let Some(affiliation) = affiliation {
+        params.insert("affiliation", affiliation.to_string());
+    }
 
     let mut collaborators = Vec::<RepositoryCollaborator>::new();
     let mut page = 0;

--- a/runtime/plaid-stl/src/github/team.rs
+++ b/runtime/plaid-stl/src/github/team.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fmt::Display};
 
-use crate::PlaidFunctionError;
+use crate::{github::GitHubRepoTeam, PlaidFunctionError};
 
 // TODO: Do not use this function, it is deprecated and will be removed soon
 pub fn add_user_to_team(team: &str, user: &str, org: &str, role: &str) -> Result<(), i32> {
@@ -141,4 +141,58 @@ pub fn remove_repo_from_team(
     }
 
     Ok(())
+}
+
+/// Get the teams that have access to a repository.
+pub fn get_repo_teams(
+    org: impl Display,
+    repo: impl Display,
+) -> Result<Vec<GitHubRepoTeam>, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(github, get_repo_teams);
+    }
+
+    let mut params: HashMap<&str, String> = HashMap::new();
+    params.insert("org", org.to_string());
+    params.insert("repo", repo.to_string());
+
+    const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
+
+    let mut teams = Vec::<GitHubRepoTeam>::new();
+    let mut page = 0;
+    loop {
+        page += 1;
+        params.insert("page", page.to_string());
+
+        let request = serde_json::to_string(&params).unwrap();
+
+        let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+        let res = unsafe {
+            github_get_repo_teams(
+                request.as_bytes().as_ptr(),
+                request.as_bytes().len(),
+                return_buffer.as_mut_ptr(),
+                RETURN_BUFFER_SIZE,
+            )
+        };
+
+        if res < 0 {
+            return Err(res.into());
+        }
+
+        return_buffer.truncate(res as usize);
+        // This should be safe because unless the Plaid runtime is expressly trying
+        // to mess with us, this came from a String in the API module.
+        let this_page = String::from_utf8(return_buffer).unwrap();
+        if this_page == "[]" {
+            break;
+        }
+        teams.extend(
+            serde_json::from_str::<Vec<GitHubRepoTeam>>(&this_page)
+                .map_err(|_| PlaidFunctionError::InternalApiError)?,
+        );
+    }
+
+    Ok(teams)
 }

--- a/runtime/plaid-stl/src/github/types.rs
+++ b/runtime/plaid-stl/src/github/types.rs
@@ -376,7 +376,7 @@ pub enum ReviewPatAction {
     Deny,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 /// Set of user permissions, as returned by GitHub's API
 pub struct Permission {
     pub pull: bool,
@@ -468,4 +468,11 @@ pub struct CommentOnPullRequestRequest {
     pub number: String,
     /// Comment to leave
     pub comment: String,
+}
+
+/// A team that has access to a repository, along with the permission level it has on the repository.
+#[derive(Serialize, Deserialize)]
+pub struct GitHubRepoTeam {
+    pub slug: String,
+    pub permissions: Permission,
 }

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.38.0"
+version = "0.38.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/github/repos.rs
+++ b/runtime/plaid/src/apis/github/repos.rs
@@ -338,6 +338,7 @@ impl Github {
             .unwrap_or(&"1")
             .parse::<u16>()
             .map_err(|_| ApiError::BadRequest)?;
+        let affiliation = request.get("affiliation").unwrap_or(&"all");
 
         if per_page > 100 {
             // GitHub supports up to 100 results per page
@@ -346,7 +347,7 @@ impl Github {
 
         info!("Fetching collaborators for [{repo}] on behalf of {module}");
         let address =
-            format!("/repos/{owner}/{repo}/collaborators?per_page={per_page}&page={page}");
+            format!("/repos/{owner}/{repo}/collaborators?per_page={per_page}&affiliation={affiliation}&page={page}");
 
         match self.make_generic_get_request(address, module).await {
             Ok((status, Ok(body))) => {

--- a/runtime/plaid/src/apis/github/repos.rs
+++ b/runtime/plaid/src/apis/github/repos.rs
@@ -339,6 +339,11 @@ impl Github {
             .parse::<u16>()
             .map_err(|_| ApiError::BadRequest)?;
         let affiliation = request.get("affiliation").unwrap_or(&"all");
+        // See https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2026-03-10#list-repository-collaborators
+        // for more details on the possible values for affiliation
+        if !["outside", "direct", "all"].contains(affiliation) {
+            return Err(ApiError::BadRequest);
+        }
 
         if per_page > 100 {
             // GitHub supports up to 100 results per page

--- a/runtime/plaid/src/apis/github/teams.rs
+++ b/runtime/plaid/src/apis/github/teams.rs
@@ -218,4 +218,47 @@ impl Github {
             Err(e) => Err(e),
         }
     }
+
+    /// Get the teams that have access to a repository.
+    pub async fn get_repo_teams(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
+        let request: HashMap<&str, &str> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        // Parse out all the parameters
+        let org = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
+        let repo =
+            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
+
+        let per_page: u8 = request
+            .get("per_page")
+            .unwrap_or(&"30")
+            .parse::<u8>()
+            .map_err(|_| ApiError::BadRequest)?;
+        let page: u16 = request
+            .get("page")
+            .unwrap_or(&"1")
+            .parse::<u16>()
+            .map_err(|_| ApiError::BadRequest)?;
+
+        info!("Getting teams with access to repo [{repo}] on behalf of [{module}]");
+        let address = format!("/repos/{org}/{repo}/teams?per_page={per_page}&page={page}");
+
+        match self.make_generic_get_request(address, module).await {
+            Ok((status, Ok(body))) => {
+                if status == 200 {
+                    Ok(body)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
+    }
 }

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -403,6 +403,7 @@ impl_new_function!(github, delete_deploy_key, DISALLOW_IN_TEST_MODE);
 impl_new_function!(github, require_signed_commits, DISALLOW_IN_TEST_MODE);
 impl_new_function!(github, add_repo_to_team, DISALLOW_IN_TEST_MODE);
 impl_new_function!(github, remove_repo_from_team, DISALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(github, get_repo_teams, ALLOW_IN_TEST_MODE);
 
 impl_new_function_with_error_buffer!(github, make_graphql_query, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, make_advanced_graphql_query, ALLOW_IN_TEST_MODE);
@@ -857,6 +858,9 @@ pub fn to_api_function(
         }
         "github_remove_repo_from_team" => {
             Function::new_typed_with_env(&mut store, &env, github_remove_repo_from_team)
+        }
+        "github_get_repo_teams" => {
+            Function::new_typed_with_env(&mut store, &env, github_get_repo_teams)
         }
         "github_get_reference" => {
             Function::new_typed_with_env(&mut store, &env, github_get_reference)


### PR DESCRIPTION
This PR introduces the possibility to

* Get the teams that have access to a repository, without unfurling their members
* Get the collaborators that have direct access to a repository

Together, these things should be equivalent to what one sees in the repo Settings in the GH web UI.