### PR TITLE
Configurable per-webhook body size limit

### DIFF
--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -171,37 +171,6 @@ async fn read_body_with_limit(
     Ok(full_body)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use futures_util::stream;
-    use tokio_util::bytes::Bytes;
-
-    #[tokio::test]
-    async fn read_body_with_limit_allows_body_at_limit() {
-        let body = stream::iter(vec![
-            Ok::<_, warp::Error>(Bytes::from_static(b"hello")),
-            Ok::<_, warp::Error>(Bytes::from_static(b" world")),
-        ]);
-
-        let result = read_body_with_limit(body, 11).await.unwrap();
-
-        assert_eq!(result, b"hello world");
-    }
-
-    #[tokio::test]
-    async fn read_body_with_limit_rejects_body_over_limit() {
-        let body = stream::iter(vec![
-            Ok::<_, warp::Error>(Bytes::from_static(b"hello")),
-            Ok::<_, warp::Error>(Bytes::from_static(b" world")),
-        ]);
-
-        let result = read_body_with_limit(body, 10).await;
-
-        assert!(result.is_err());
-    }
-}
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -48,8 +48,6 @@ impl std::fmt::Display for Errors {
 
 impl std::error::Error for Errors {}
 
-const MAX_WEBHOOK_BODY_SIZE: usize = 1024 * 256; // 256KiB
-
 async fn post_handler(
     webhook: String,
     body: impl Stream<Item = Result<impl Buf, warp::Error>> + Unpin + Send + Sync,
@@ -68,7 +66,8 @@ async fn post_handler(
         let logbacks_allowed = webhook_configuration.logbacks_allowed.clone();
 
         // Read the body with size limit
-        let full_body = match read_body_with_limit(body, MAX_WEBHOOK_BODY_SIZE).await {
+        let full_body = match read_body_with_limit(body, webhook_configuration.max_body_size).await
+        {
             Ok(bytes) => bytes,
             Err(e) => {
                 error!("Error reading body for webhook: {webhook}: {e}");
@@ -170,6 +169,37 @@ async fn read_body_with_limit(
     );
 
     Ok(full_body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::stream;
+    use tokio_util::bytes::Bytes;
+
+    #[tokio::test]
+    async fn read_body_with_limit_allows_body_at_limit() {
+        let body = stream::iter(vec![
+            Ok::<_, warp::Error>(Bytes::from_static(b"hello")),
+            Ok::<_, warp::Error>(Bytes::from_static(b" world")),
+        ]);
+
+        let result = read_body_with_limit(body, 11).await.unwrap();
+
+        assert_eq!(result, b"hello world");
+    }
+
+    #[tokio::test]
+    async fn read_body_with_limit_rejects_body_over_limit() {
+        let body = stream::iter(vec![
+            Ok::<_, warp::Error>(Bytes::from_static(b"hello")),
+            Ok::<_, warp::Error>(Bytes::from_static(b" world")),
+        ]);
+
+        let result = read_body_with_limit(body, 10).await;
+
+        assert!(result.is_err());
+    }
 }
 
 #[tokio::main]
@@ -452,7 +482,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 let (response_send, response_recv) = tokio::sync::oneshot::channel();
 
                                 // Read the body with size limit
-                                let body_bytes = match read_body_with_limit(body, MAX_WEBHOOK_BODY_SIZE).await {
+                                let body_bytes = match read_body_with_limit(body, webhook_configuration.max_body_size).await {
                                     Ok(bytes) => bytes,
                                     Err(e) => {
                                         error!("Error reading body for get request to {webhook}: {e}");

--- a/runtime/plaid/src/config.rs
+++ b/runtime/plaid/src/config.rs
@@ -2,7 +2,7 @@ use clap::{Arg, ArgAction, Command};
 
 use plaid_stl::messages::LogbacksAllowed;
 use ring::digest::{self, digest};
-use serde::{de, Deserialize};
+use serde::{de, Deserialize, Deserializer};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -15,8 +15,6 @@ use super::data::DataConfig;
 use super::loader::Configuration as LoaderConfiguration;
 use super::logging::LoggingConfiguration;
 use super::storage::Config as StorageConfig;
-
-pub const DEFAULT_WEBHOOK_BODY_SIZE: usize = 1024 * 256; // 256KiB
 
 /// How should responses to GET requests be cached.
 #[derive(Default, Deserialize, Clone)]
@@ -77,9 +75,12 @@ pub struct WebhookConfig {
     pub log_type: String,
     /// What headers do you want forwarded to the logging channel
     pub headers: Vec<String>,
-    /// The maximum size of a request body that will be processed.
+    /// The maximum size, in bytes, of a request body that will be processed.
     /// Defaults to 256KiB if no value is provided.
-    #[serde(default = "default_webhook_body_size")]
+    #[serde(
+        default = "default_webhook_body_size",
+        deserialize_with = "validate_webhook_body_size"
+    )]
     pub max_body_size: usize,
     /// See GetMode
     pub get_mode: Option<GetMode>,
@@ -176,7 +177,21 @@ fn default_log_queue_size() -> usize {
 }
 
 fn default_webhook_body_size() -> usize {
-    DEFAULT_WEBHOOK_BODY_SIZE
+    1024 * 256
+}
+
+/// Validate that the webhook body size limit is not zero.
+fn validate_webhook_body_size<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = usize::deserialize(deserializer)?;
+    if value == 0 {
+        return Err(serde::de::Error::custom(
+            "Webhook body size limit must not be 0",
+        ));
+    }
+    Ok(value)
 }
 
 /// All errors that can be encountered while configuring Plaid

--- a/runtime/plaid/src/config.rs
+++ b/runtime/plaid/src/config.rs
@@ -16,6 +16,8 @@ use super::loader::Configuration as LoaderConfiguration;
 use super::logging::LoggingConfiguration;
 use super::storage::Config as StorageConfig;
 
+pub const DEFAULT_WEBHOOK_BODY_SIZE: usize = 1024 * 256; // 256KiB
+
 /// How should responses to GET requests be cached.
 #[derive(Default, Deserialize, Clone)]
 #[serde(tag = "type")]
@@ -75,6 +77,10 @@ pub struct WebhookConfig {
     pub log_type: String,
     /// What headers do you want forwarded to the logging channel
     pub headers: Vec<String>,
+    /// The maximum size of a request body that will be processed.
+    /// Defaults to 256KiB if no value is provided.
+    #[serde(default = "default_webhook_body_size")]
+    pub max_body_size: usize,
     /// See GetMode
     pub get_mode: Option<GetMode>,
     /// An optional label for the webhook. If this is populated, it will be
@@ -167,6 +173,10 @@ pub struct ConfigurationWithRoles {
 /// This function provides the default log queue size in the event that one isn't provided
 fn default_log_queue_size() -> usize {
     2048
+}
+
+fn default_webhook_body_size() -> usize {
+    DEFAULT_WEBHOOK_BODY_SIZE
 }
 
 /// All errors that can be encountered while configuring Plaid


### PR DESCRIPTION
Adds a per-webhook body size limit to allow increasing the body size limit for certain webhooks. Keeps the same default if not omitted. Also, the deserializer will reject if the limit is set to 0.