### PR TITLE
Add PagerDuty incident alerts runtime API

### DIFF
--- a/runtime/plaid-stl/src/pagerduty/mod.rs
+++ b/runtime/plaid-stl/src/pagerduty/mod.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::PlaidFunctionError;
 
@@ -75,4 +75,67 @@ pub fn trigger_incident_detailed(
         3 => Ok(TriggerIncidentResult::TriggerFailed),
         n => Ok(TriggerIncidentResult::Unknown(n as u32)),
     }
+}
+
+#[derive(Serialize)]
+struct GetIncidentAlertsRequest {
+    incident_id: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct IncidentAlertsResponse {
+    #[serde(default)]
+    pub alerts: Vec<IncidentAlert>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct IncidentAlert {
+    pub body: Option<IncidentAlertBody>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct IncidentAlertBody {
+    pub details: Option<IncidentAlertDetails>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct IncidentAlertDetails {
+    pub firing: Option<serde_json::Value>,
+}
+
+/// Retrieve the alerts attached to a PagerDuty incident.
+pub fn get_incident_alerts(
+    incident_id: &str,
+) -> Result<IncidentAlertsResponse, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(pagerduty, get_incident_alerts);
+    }
+
+    let request = GetIncidentAlertsRequest {
+        incident_id: incident_id.to_owned(),
+    };
+    let request =
+        serde_json::to_string(&request).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+
+    const RETURN_BUFFER_SIZE: usize = 1024 * 1024;
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let res = unsafe {
+        pagerduty_get_incident_alerts(
+            request.as_bytes().as_ptr(),
+            request.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    let res =
+        String::from_utf8(return_buffer).map_err(|_| PlaidFunctionError::ParametersNotUtf8)?;
+
+    serde_json::from_str(&res).map_err(|_| PlaidFunctionError::Unknown)
 }

--- a/runtime/plaid-stl/src/slack/mod.rs
+++ b/runtime/plaid-stl/src/slack/mod.rs
@@ -18,6 +18,24 @@ pub struct SlackMessageWithBlocks {
     thread_ts: Option<String>,
 }
 
+#[derive(Serialize)]
+struct SlackMessageWithBlocksAndAttachments {
+    channel: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    blocks: Option<serde_json::Value>,
+    attachments: serde_json::Value,
+}
+
+fn optional_blocks(blocks: &str) -> Result<Option<serde_json::Value>, PlaidFunctionError> {
+    let blocks: serde_json::Value =
+        serde_json::from_str(blocks).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+
+    match blocks {
+        serde_json::Value::Array(items) if items.is_empty() => Ok(None),
+        blocks => Ok(Some(blocks)),
+    }
+}
+
 #[inline]
 fn slack_format(msg: &str) -> String {
     #[derive(Serialize)]
@@ -191,6 +209,52 @@ pub fn post_message_with_blocks(
     text: &str,
 ) -> Result<(), PlaidFunctionError> {
     post_message_with_blocks_detailed(bot, channel, text).map(|_| ())
+}
+
+/// Post a Slack message with top-level Block Kit blocks and attachments.
+pub fn post_message_with_blocks_and_attachments(
+    bot: &str,
+    channel: &str,
+    blocks: &str,
+    attachments: &str,
+) -> Result<SlackMessageResponse, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(slack, post_message);
+    }
+
+    let message = SlackMessageWithBlocksAndAttachments {
+        channel: channel.to_owned(),
+        blocks: optional_blocks(blocks)?,
+        attachments: serde_json::from_str(attachments)
+            .map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?,
+    };
+
+    const RETURN_BUFFER_SIZE: usize = 32 * 1024; // 32 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let params = serde_json::to_string(&PostMessage {
+        bot: bot.to_string(),
+        body: serde_json::to_string(&message).unwrap(),
+    })
+    .unwrap();
+
+    let res = unsafe {
+        slack_post_message(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    let res = String::from_utf8(return_buffer).unwrap();
+
+    serde_json::from_str(&res).map_err(|_| PlaidFunctionError::Unknown)
 }
 
 /// Slack API response for message operations (chat.postMessage, chat.update).
@@ -657,6 +721,15 @@ struct SlackUpdateMessageWithBlocks {
     blocks: String,
 }
 
+#[derive(Serialize)]
+struct SlackUpdateMessageWithBlocksAndAttachments {
+    channel: String,
+    ts: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    blocks: Option<serde_json::Value>,
+    attachments: serde_json::Value,
+}
+
 /// Data to be sent to the Plaid runtime for updating a message
 #[derive(Serialize, Deserialize)]
 pub struct UpdateMessage {
@@ -683,6 +756,54 @@ pub fn update_message_with_blocks(
         channel: channel.to_owned(),
         ts: ts.to_owned(),
         blocks: blocks.to_owned(),
+    };
+
+    const RETURN_BUFFER_SIZE: usize = 32 * 1024; // 32 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let params = serde_json::to_string(&UpdateMessage {
+        bot: bot.to_string(),
+        body: serde_json::to_string(&message).unwrap(),
+    })
+    .unwrap();
+
+    let res = unsafe {
+        slack_update_message(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    let res = String::from_utf8(return_buffer).unwrap();
+
+    serde_json::from_str(&res).map_err(|_| PlaidFunctionError::Unknown)
+}
+
+/// Update a Slack message with top-level Block Kit blocks and attachments.
+pub fn update_message_with_blocks_and_attachments(
+    bot: &str,
+    channel: &str,
+    ts: &str,
+    blocks: &str,
+    attachments: &str,
+) -> Result<SlackMessageResponse, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(slack, update_message);
+    }
+
+    let message = SlackUpdateMessageWithBlocksAndAttachments {
+        channel: channel.to_owned(),
+        ts: ts.to_owned(),
+        blocks: optional_blocks(blocks)?,
+        attachments: serde_json::from_str(attachments)
+            .map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?,
     };
 
     const RETURN_BUFFER_SIZE: usize = 32 * 1024; // 32 KiB

--- a/runtime/plaid/resources/config/apis.toml
+++ b/runtime/plaid/resources/config/apis.toml
@@ -143,6 +143,13 @@ root_certificate = """
 # Nothing here means no authentication
 [apis."github".graphql_queries]
 
+# [apis."pagerduty"]
+# [apis."pagerduty".rest]
+# token = "{plaid-secret{pagerduty-rest-api-token}}"
+# [apis."pagerduty".rest.incident_alerts]
+# allowed_rules = ["example_rule.wasm"]
+# available_in_test_mode = false
+
 [apis."slack"]
 [apis."slack"."webhooks"]
 test_webhook = "{plaid-secret{test-webhook-secret}}"

--- a/runtime/plaid/src/apis/pagerduty/incident_alerts.rs
+++ b/runtime/plaid/src/apis/pagerduty/incident_alerts.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+
+use super::{PagerDuty, PagerDutyRestConfig};
+use crate::{apis::ApiError, loader::PlaidModule};
+use plaid_stl::pagerduty::IncidentAlertsResponse;
+use serde::Deserialize;
+
+const PAGERDUTY_API_ADDRESS: &str = "https://api.pagerduty.com";
+
+#[derive(Deserialize)]
+struct GetIncidentAlertsRequest {
+    incident_id: String,
+}
+
+impl PagerDuty {
+    /// Get alerts for an existing PagerDuty incident.
+    pub async fn get_incident_alerts(
+        &self,
+        request: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
+        let request: GetIncidentAlertsRequest =
+            serde_json::from_str(request).map_err(|_| ApiError::BadRequest)?;
+
+        let rest_config = self.rest_config_for_incident_alerts(module)?;
+        let url = format!(
+            "{PAGERDUTY_API_ADDRESS}/incidents/{}/alerts",
+            request.incident_id
+        );
+
+        let response = self
+            .client
+            .get(url)
+            .header("Accept", "application/vnd.pagerduty+json;version=2")
+            .header(
+                "Authorization",
+                format!("Token token={}", rest_config.token),
+            )
+            .send()
+            .await
+            .map_err(|e| ApiError::PagerDutyError(super::PagerDutyError::NetworkError(e)))?;
+
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(ApiError::PagerDutyError(
+                super::PagerDutyError::UnexpectedStatusCode(status.as_u16()),
+            ));
+        }
+
+        let parsed: IncidentAlertsResponse = serde_json::from_str(&body)
+            .map_err(|_| ApiError::PagerDutyError(super::PagerDutyError::UnexpectedPayload))?;
+
+        serde_json::to_string(&parsed).map_err(|_| ApiError::ImpossibleError)
+    }
+
+    fn rest_config_for_incident_alerts(
+        &self,
+        module: Arc<PlaidModule>,
+    ) -> Result<&PagerDutyRestConfig, ApiError> {
+        let rest_config = self.config.rest.as_ref().ok_or_else(|| {
+            ApiError::ConfigurationError("PagerDuty REST API is not configured".into())
+        })?;
+
+        if !rest_config
+            .incident_alerts
+            .allowed_rules
+            .contains(&module.to_string())
+        {
+            error!("{module} tried to get PagerDuty incident alerts without permission");
+            return Err(ApiError::BadRequest);
+        }
+
+        if module.test_mode && !rest_config.incident_alerts.available_in_test_mode {
+            error!("{module} tried to get PagerDuty incident alerts in test mode");
+            return Err(ApiError::TestMode);
+        }
+
+        Ok(rest_config)
+    }
+}

--- a/runtime/plaid/src/apis/pagerduty/mod.rs
+++ b/runtime/plaid/src/apis/pagerduty/mod.rs
@@ -5,6 +5,7 @@ use std::{collections::HashMap, time::Duration};
 
 use super::default_timeout_seconds;
 
+mod incident_alerts;
 mod trigger;
 
 #[derive(Deserialize)]
@@ -12,11 +13,28 @@ pub struct PagerDutyConfig {
     /// This is a mapping from service name (that is visible to the service) and to
     /// the integration key relevant to creating an incident in PagerDuty under that
     /// same service
+    #[serde(default)]
     services: HashMap<String, String>,
+    /// REST API configuration for read operations.
+    #[serde(default)]
+    rest: Option<PagerDutyRestConfig>,
     /// The number of seconds until an external API request times out.
     /// If no value is provided, the result of `default_timeout_seconds()` will be used.
     #[serde(default = "default_timeout_seconds")]
     api_timeout_seconds: u64,
+}
+
+#[derive(Deserialize)]
+struct PagerDutyRestConfig {
+    token: String,
+    incident_alerts: PagerDutyRestEndpointConfig,
+}
+
+#[derive(Deserialize)]
+struct PagerDutyRestEndpointConfig {
+    allowed_rules: Vec<String>,
+    #[serde(default)]
+    available_in_test_mode: bool,
 }
 
 /// Object to interact with the PagerDuty API
@@ -30,6 +48,8 @@ pub struct PagerDuty {
 #[derive(Debug)]
 pub enum PagerDutyError {
     NetworkError(reqwest::Error),
+    UnexpectedStatusCode(u16),
+    UnexpectedPayload,
 }
 
 impl PagerDuty {

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -555,6 +555,7 @@ impl_new_function_with_error_buffer!(okta, get_user_data, ALLOW_IN_TEST_MODE);
 
 // PagerDuty Functions
 impl_new_function!(pagerduty, trigger_incident, DISALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(pagerduty, get_incident_alerts, ALLOW_IN_TEST_MODE);
 
 // Rustica Functions
 impl_new_function_with_error_buffer!(rustica, new_mtls_cert, DISALLOW_IN_TEST_MODE);
@@ -1000,6 +1001,9 @@ pub fn to_api_function(
         // PagerDuty Calls
         "pagerduty_trigger_incident" => {
             Function::new_typed_with_env(&mut store, &env, pagerduty_trigger_incident)
+        }
+        "pagerduty_get_incident_alerts" => {
+            Function::new_typed_with_env(&mut store, &env, pagerduty_get_incident_alerts)
         }
 
         // Rustica Calls


### PR DESCRIPTION
Adds two small runtime/STL extensions needed by rules that enrich and update Slack notifications from PagerDuty incidents.

- Adds a narrow PagerDuty REST host function, `pagerduty_get_incident_alerts`, for fetching alerts attached to an existing PagerDuty incident.
- Exposes the new PagerDuty API through `plaid_stl::pagerduty::get_incident_alerts` with explicit response structs.
- Keeps the existing PagerDuty trigger-only configuration compatible by making REST config optional.
- Adds per-endpoint rule allowlisting for PagerDuty incident alert reads.
- Adds Slack STL helpers for posting and updating messages that include both top-level Block Kit blocks and attachments.
- Returns typed Slack message responses so rules can persist `channel` and `ts` for later `chat.update` calls.
