### PR TITLE
Implement `Error` for `PlaidFunctionError`

### DIFF
--- a/runtime/plaid-stl/src/lib.rs
+++ b/runtime/plaid-stl/src/lib.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 macro_rules! new_host_function_with_error_buffer {
     ($api:ident, $function_name:ident) => {
         paste::item! {
@@ -32,6 +34,8 @@ pub enum PlaidFunctionError {
     TimeoutElapsed,
     Unknown,
 }
+
+impl Error for PlaidFunctionError {}
 
 impl core::fmt::Display for PlaidFunctionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
This PR implements the `std::error::Error` trait for `PlaidFunctionError`. This change allows `PlaidFunctionError` to be integrated with error-handling libraries like anyhow, eyre, and the standard Result propagation patterns