### PR TITLE
Add aggregate function support to BigQuery `query_table` API

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3685,7 +3685,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "aes",
  "alkali",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.39.2"
+version = "0.39.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/gcp/bigquery.rs
+++ b/runtime/plaid-stl/src/gcp/bigquery.rs
@@ -19,9 +19,34 @@ pub struct QueryTableRequest {
     /// Columns to select. Must be non-empty; the runtime does not support
     /// `SELECT *` so that callers are always explicit about what data they
     /// need and the runtime can return named results.
-    pub columns: Vec<String>,
+    pub columns: Vec<Column>,
     /// Optional WHERE clause. When `None` the query returns all rows.
     pub filter: Option<Filter>,
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+pub struct Column {
+    /// Name fo the column to select
+    pub identifier: String,
+    /// Optional aggregate function to apply to the column
+    pub function: Option<ColumnFunction>,
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+pub enum ColumnFunction {
+    Count,
+    Max,
+    Min,
+}
+
+impl Display for ColumnFunction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Count => write!(f, "COUNT"),
+            Self::Max => write!(f, "MAX"),
+            Self::Min => write!(f, "MIN"),
+        }
+    }
 }
 
 /// A node in a WHERE clause expression tree.
@@ -145,7 +170,7 @@ impl<'a> IntoIterator for &'a QueryTableResponse {
 pub fn query_table(
     dataset: impl Display,
     table: impl Display,
-    columns: impl Iterator<Item = impl Display>,
+    columns: Vec<Column>,
     filter: Option<Filter>,
     return_buffer_size: usize,
 ) -> Result<QueryTableResponse, PlaidFunctionError> {
@@ -156,7 +181,7 @@ pub fn query_table(
     let params = QueryTableRequest {
         dataset: dataset.to_string(),
         table: table.to_string(),
-        columns: columns.map(|c| c.to_string()).collect(),
+        columns,
         filter,
     };
 

--- a/runtime/plaid-stl/src/gcp/bigquery.rs
+++ b/runtime/plaid-stl/src/gcp/bigquery.rs
@@ -26,7 +26,7 @@ pub struct QueryTableRequest {
 
 #[derive(Deserialize, Serialize, Clone)]
 pub struct Column {
-    /// Name fo the column to select
+    /// Name of the column to select
     pub identifier: String,
     /// Optional aggregate function to apply to the column
     pub function: Option<ColumnFunction>,

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.39.2"
+version = "0.39.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/gcp/bigquery.rs
+++ b/runtime/plaid/src/apis/gcp/bigquery.rs
@@ -9,7 +9,7 @@ use google_cloud_bigquery::{
     query::row::Row,
 };
 use plaid_stl::gcp::bigquery::{
-    Filter, FilterValue, Operator, QueryTableRequest, QueryTableResponse,
+    Column, Filter, FilterValue, Operator, QueryTableRequest, QueryTableResponse,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -235,7 +235,9 @@ impl BigQuery {
         let mut bytes_accumulated: usize = 0;
         while let Some(row) = iter.next().await.map_err(BigQueryError::from)? {
             let mut map = HashMap::new();
-            for (i, col_name) in params.columns.iter().enumerate() {
+            for (i, column) in params.columns.iter().enumerate() {
+                let col_name = &column.identifier;
+
                 let col_type = table_schema
                     .and_then(|s| s.get(col_name))
                     .copied()
@@ -343,15 +345,18 @@ impl BigQuery {
 fn build_query_string(
     dataset: &str,
     table: &str,
-    columns: &[String],
+    columns: &[Column],
     filter: Option<&Filter>,
 ) -> Result<(String, Vec<QueryParameter>), BigQueryError> {
     if columns.is_empty() {
         return Err(BigQueryError::NoColumnsProvided);
     }
 
-    if let Some(ident) = columns.iter().find(|col| !is_valid_identifier(col)) {
-        return Err(BigQueryError::InvalidIdentifier(ident.to_string()));
+    if let Some(column) = columns
+        .iter()
+        .find(|col| !is_valid_identifier(&col.identifier))
+    {
+        return Err(BigQueryError::InvalidIdentifier(column.identifier.clone()));
     }
 
     let mut column_list = String::new();
@@ -359,9 +364,20 @@ fn build_query_string(
         if i > 0 {
             column_list.push_str(", ");
         }
+        let function = c.function.as_ref().map(|c| c.to_string());
+
+        if let Some(ref f) = function {
+            column_list.push_str(f);
+            column_list.push('(');
+        }
+
         column_list.push('`');
-        column_list.push_str(c);
+        column_list.push_str(&c.identifier);
         column_list.push('`');
+
+        if function.is_some() {
+            column_list.push(')');
+        }
     }
 
     let mut sql = format!("SELECT {column_list} FROM `{dataset}`.`{table}`");

--- a/runtime/plaid/src/apis/gcp/bigquery.rs
+++ b/runtime/plaid/src/apis/gcp/bigquery.rs
@@ -9,7 +9,7 @@ use google_cloud_bigquery::{
     query::row::Row,
 };
 use plaid_stl::gcp::bigquery::{
-    Column, Filter, FilterValue, Operator, QueryTableRequest, QueryTableResponse,
+    Column, ColumnFunction, Filter, FilterValue, Operator, QueryTableRequest, QueryTableResponse,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -44,6 +44,8 @@ pub enum BigQueryError {
     InvalidIdentifier(String),
     #[error("No columns provided")]
     NoColumnsProvided,
+    #[error("Invalid column combination: {0}")]
+    InvalidColumnCombination(String),
     #[error("Invalid filter provided: {0}")]
     InvalidFilter(String),
     #[error("Module not permitted")]
@@ -236,14 +238,18 @@ impl BigQuery {
         while let Some(row) = iter.next().await.map_err(BigQueryError::from)? {
             let mut map = HashMap::new();
             for (i, column) in params.columns.iter().enumerate() {
-                let col_name = &column.identifier;
-
-                let col_type = table_schema
-                    .and_then(|s| s.get(col_name))
-                    .copied()
-                    .unwrap_or(ColumnType::String);
+                // COUNT always returns INTEGER regardless of the underlying
+                // column type. MAX/MIN and plain columns look up the schema by
+                // raw identifier, falling back to String when absent.
+                let col_type = match &column.function {
+                    Some(ColumnFunction::Count) => ColumnType::Integer,
+                    _ => table_schema
+                        .and_then(|s| s.get(&column.identifier))
+                        .copied()
+                        .unwrap_or(ColumnType::String),
+                };
                 let value = decode_column(&row, i, col_type).map_err(BigQueryError::from)?;
-                map.insert(col_name.clone(), value);
+                map.insert(column.identifier.clone(), value);
             }
             let mut counter = CountWriter(0);
             serde_json::to_writer(&mut counter, &map).map_err(|_| ApiError::ImpossibleError)?;
@@ -359,13 +365,23 @@ fn build_query_string(
         return Err(BigQueryError::InvalidIdentifier(column.identifier.clone()));
     }
 
+    // Without GROUP BY, mixing aggregate and raw columns produces invalid SQL.
+    // Enforce that aggregate queries select exactly one column.
+    let has_aggregate = columns.iter().any(|c| c.function.is_some());
+    if has_aggregate && columns.len() > 1 {
+        return Err(BigQueryError::InvalidColumnCombination(
+            "aggregate functions require exactly one column (GROUP BY is not supported)"
+                .to_string(),
+        ));
+    }
+
     let mut column_list = String::new();
     for (i, c) in columns.iter().enumerate() {
         if i > 0 {
             column_list.push_str(", ");
         }
-        let function = c.function.as_ref().map(|c| c.to_string());
 
+        let function = c.function.as_ref().map(|c| c.to_string());
         if let Some(ref f) = function {
             column_list.push_str(f);
             column_list.push('(');


### PR DESCRIPTION
## Summary

Extends the `query_table` BigQuery API to support aggregate column functions (`COUNT`, `MAX`, `MIN`).
Previously, columns were plain strings; they are now typed `Column` structs that carry an optional `ColumnFunction`.
When a function is specified, the generated SQL wraps the column identifier accordingly (e.g., `COUNT(col)`).

## Changes

**Code**
- `runtime/plaid-stl/src/gcp/bigquery.rs`: Added `Column` struct with `identifier: String` and `function: Option<ColumnFunction>`; added `ColumnFunction` enum (`Count`, `Max`, `Min`) with `Display` impl; updated `QueryTableRequest.columns` from `Vec<String>` to `Vec<Column>`; updated `query_table` signature to accept `Vec<Column>`.
- `runtime/plaid/src/apis/gcp/bigquery.rs`: Updated `build_query_string` parameter from `&[String]` to `&[Column]`; identifier validation and column-list construction now read `col.identifier` and optionally emit `FUNCTION(identifier)` syntax.

## Rationale

Aggregate functions are a common need when querying tables. Encoding the function in the column type keeps the query-building logic centralized and validated server-side, avoiding raw SQL injection risks from caller-supplied function strings.

## Security Considerations

Identifier validation now operates on `col.identifier` as before, ensuring that only allowlisted or validated identifiers pass through. The `ColumnFunction` enum is a closed set of known-safe SQL keywords rendered via `Display`, so no user-supplied function names reach the generated SQL. No authentication or authorization surface changes.

## Breaking Changes

`query_table` and `QueryTableRequest` now require `Vec<Column>` instead of `Vec<String>` / `impl Iterator<Item = impl Display>`. Callers must be updated to construct `Column` values; a plain column with no function is `Column { identifier: "col".into(), function: None }`.