### PR TITLE
Update Dependencies and Make API Startup Fallible

### DIFF
--- a/.github/workflows/DependencyCheck.yaml
+++ b/.github/workflows/DependencyCheck.yaml
@@ -1,0 +1,28 @@
+name: Dependency Minimum Age Check
+
+on:
+  pull_request:
+    paths:
+      - "runtime/Cargo.lock"
+      - ".github/workflows/DependencyCheck.yaml"
+
+jobs:
+  runtime:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Build and run the dependency check tool
+        run: cd runtime && cargo run --example=dependency-check -- Cargo.lock --min-age-days 14 --include-missing
+

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.39.5"
+version = "0.40.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -841,8 +841,8 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
+ "rustls 0.23.40",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -995,6 +995,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base32"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1033,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bigdecimal"
@@ -1163,6 +1175,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-lock"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06acb4f71407ba205a07cb453211e0e6a67b21904e47f6ba1f9589e38f2e454"
+dependencies = [
+ "semver",
+ "serde",
+ "toml 0.8.23",
+ "url",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,6 +1350,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -1377,16 +1440,6 @@ dependencies = [
  "serde_json",
  "time",
  "url",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1599,7 +1652,7 @@ checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
 dependencies = [
  "chrono",
  "once_cell",
- "winnow",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -1652,6 +1705,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,6 +1733,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1730,6 +1822,17 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "der-parser"
@@ -1799,6 +1902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.6",
  "subtle",
 ]
@@ -1810,7 +1914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "285743a676ccb6b3e116bc14cc69319b957867930ae9c4822f8e0f54509d7243"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
 ]
 
@@ -1847,10 +1951,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1934,7 +2097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1960,6 +2123,22 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -2147,6 +2326,7 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2226,7 +2406,7 @@ dependencies = [
  "google-cloud-metadata",
  "google-cloud-token",
  "home",
- "jsonwebtoken",
+ "jsonwebtoken 9.3.1",
  "reqwest",
  "serde",
  "serde_json",
@@ -2314,6 +2494,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,6 +2587,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "headers"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2636,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -2603,25 +2809,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
-dependencies = [
- "futures-util",
- "http 1.4.0",
- "hyper 1.8.1",
- "hyper-util",
- "log",
- "rustls 0.22.4",
- "rustls-native-certs 0.7.3",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.25.0",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
@@ -2629,8 +2816,9 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
- "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
+ "log",
+ "rustls 0.23.40",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -2668,7 +2856,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2944,10 +3132,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+dependencies = [
+ "base64 0.22.1",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
+ "js-sys",
+ "p256",
+ "p384",
+ "pem 3.0.6",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "signature",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.8",
+]
 
 [[package]]
 name = "leb128"
@@ -3358,6 +3572,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3438,27 +3668,28 @@ dependencies = [
 
 [[package]]
 name = "octocrab"
-version = "0.37.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dedddd64be5eb5ea9311d1934a09ce32ef9be22fd29990bb2a5552c17712306e"
+checksum = "ce7ace5d83b077dd50ff01214a81feea17e258b8f677590c2286add76dc8238e"
 dependencies = [
  "arc-swap",
  "async-trait",
  "base64 0.22.1",
  "bytes",
+ "cargo_metadata",
  "cfg-if",
  "chrono",
- "either",
  "futures",
  "futures-util",
+ "getrandom 0.2.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
- "hyper-rustls 0.26.0",
+ "hyper-rustls 0.27.7",
  "hyper-timeout",
  "hyper-util",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "once_cell",
  "percent-encoding",
  "pin-project",
@@ -3469,10 +3700,11 @@ dependencies = [
  "serde_urlencoded",
  "snafu",
  "tokio",
- "tower 0.4.13",
- "tower-http 0.5.2",
+ "tower 0.5.3",
+ "tower-http",
  "tracing",
  "url",
+ "web-time",
 ]
 
 [[package]]
@@ -3507,12 +3739,6 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -3522,6 +3748,30 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "parking_lot"
@@ -3594,6 +3844,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -3678,6 +3937,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3685,10 +3965,11 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.39.5"
+version = "0.40.0"
 dependencies = [
  "aes",
  "alkali",
+ "anyhow",
  "async-trait",
  "aws-config",
  "aws-sdk-dynamodb",
@@ -3698,6 +3979,7 @@ dependencies = [
  "aws-sdk-sqs",
  "base64 0.13.1",
  "block-modes",
+ "cargo-lock",
  "chrono",
  "clap",
  "cron",
@@ -3709,21 +3991,21 @@ dependencies = [
  "google-cloud-bigquery",
  "hex",
  "http 1.4.0",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "log",
  "lru",
  "octocrab",
  "paste",
  "plaid_stl",
  "pulldown-cmark",
- "rand 0.8.5",
+ "rand 0.9.2",
  "rcgen",
  "redis",
  "regex",
  "reqwest",
  "reqwest_cookie_store",
  "ring 0.17.14",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "serde_with",
@@ -3734,9 +4016,9 @@ dependencies = [
  "time",
  "tokio",
  "tokio-rustls 0.26.4",
- "tokio-tungstenite 0.23.1",
+ "tokio-tungstenite 0.24.0",
  "tokio-util",
- "toml",
+ "toml 0.5.11",
  "totp-rs",
  "url",
  "urlencoding",
@@ -3749,7 +4031,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.39.5"
+version = "0.40.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -3797,6 +4079,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -3929,8 +4220,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
- "socket2 0.6.2",
+ "rustls 0.23.40",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3939,9 +4230,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -3949,7 +4240,7 @@ dependencies = [
  "rand 0.9.2",
  "ring 0.17.14",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3967,9 +4258,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4268,7 +4559,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4278,7 +4569,7 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
- "tower-http 0.6.8",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4316,6 +4607,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4346,13 +4647,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.13.0",
  "munge",
  "ptr_meta",
@@ -4365,9 +4666,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4379,6 +4680,26 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -4420,7 +4741,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4451,9 +4772,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4467,27 +4788,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe 0.1.6",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -4619,25 +4927,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "secrecy"
-version = "0.8.0"
+name = "sec1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "security-framework"
-version = "2.11.1"
+name = "secrecy"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
+ "zeroize",
 ]
 
 [[package]]
@@ -4647,7 +4956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4674,6 +4983,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -4747,6 +5060,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4855,6 +5177,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4975,6 +5307,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "sshcerts"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5085,7 +5427,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5267,7 +5609,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -5296,18 +5638,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.37",
- "rustls-native-certs 0.7.3",
+ "rustls 0.23.40",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
- "tungstenite 0.23.0",
+ "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -5331,6 +5673,47 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -5406,25 +5789,7 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags 2.11.0",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "iri-string",
- "pin-project-lite",
- "tower 0.4.13",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5446,6 +5811,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5519,9 +5885,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
 dependencies = [
  "byteorder",
  "bytes",
@@ -5530,7 +5896,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
@@ -6065,6 +6431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -6119,7 +6486,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6357,6 +6724,15 @@ name = "winnow"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.39.5"
+version = "0.40.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.39.5"
+version = "0.40.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -44,13 +44,13 @@ flate2 = "1.0"
 futures-util = "0.3.30"
 hex = "0.4.3"
 http = "1"
-jsonwebtoken = { version = "9.2" }
+jsonwebtoken = { version = "10" }
 log = "0.4"
 lru = "0.16"
-octocrab = "0.37"
+octocrab = "0.50"
 paste = "1.0"
 plaid_stl = { path = "../plaid-stl" }
-rand = "0.8"
+rand = "0.9"
 rcgen = { version = "0.10", features = ["x509-parser"] }
 redis = { version = "0.32", features = [
     "aio",
@@ -67,20 +67,18 @@ reqwest = { version = "0.12", default-features = false, features = [
     "stream",
 ] }
 reqwest_cookie_store = "0.8.0"
-rustls = { version = "0.23.17", features = ["ring"] }
+rustls = { version = "0.23", features = ["ring"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 serde_with = { version = "3", features = ["macros"] }
 sled = { version = "0.34.7", optional = true }
 sshcerts = { version = "0.13.2", default-features = false }
-tar = "0.4.41"
+tar = "0.4"
 time = "0.3"
 tokio = { version = "1", features = ["full"] }
-tokio-rustls = "0.26.4"
+tokio-rustls = "0.26"
 tokio-util = "0.7.12"
-tokio-tungstenite = { version = "0.23.1", features = [
-    "rustls-tls-native-roots",
-] }
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
 toml = "0.5"
 totp-rs = "5.6.0"
 uuid = { version = "1", features = ["v4"] }
@@ -97,9 +95,20 @@ google-cloud-bigquery = { version = "0.15.0", optional = true, default-features 
     "auth",
 ] }
 
+[dev-dependencies]
+anyhow = "1"
+cargo-lock = "10"
+
+
 [[example]]
 name = "github-tailer"
 path = "examples/tailers/github.rs"
+
+# This is not in examples because it's not one but I marked it as one
+# so it gets access to dev-dependencies
+[[example]]
+name = "dependency-check"
+path = "tools/dependency_check.rs"
 
 [[bin]]
 name = "plaid"

--- a/runtime/plaid/examples/tailers/github.rs
+++ b/runtime/plaid/examples/tailers/github.rs
@@ -56,7 +56,7 @@ async fn main() {
 
     let (logger_tx, logger_rx) = bounded(2048);
 
-    let mut gh = Github::new(config, logger_tx);
+    let mut gh = Github::new(config, logger_tx).unwrap();
 
     loop {
         //println!("Start of log group");

--- a/runtime/plaid/src/apis/blockchain/evm/selector.rs
+++ b/runtime/plaid/src/apis/blockchain/evm/selector.rs
@@ -1,5 +1,5 @@
 use crate::apis::blockchain::evm::NodeConfig;
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Selection strategy for choosing EVM nodes
@@ -43,7 +43,7 @@ impl NodeSelector {
                 let index = current_index.load(Ordering::Relaxed) % self.nodes.len();
                 self.nodes.get(index).cloned()
             }
-            SelectionStrategy::Random => self.nodes.choose(&mut rand::thread_rng()).cloned(),
+            SelectionStrategy::Random => self.nodes.choose(&mut rand::rng()).cloned(),
         }
     }
 

--- a/runtime/plaid/src/apis/github/mod.rs
+++ b/runtime/plaid/src/apis/github/mod.rs
@@ -85,18 +85,18 @@ pub enum GitHubError {
 }
 
 impl Github {
-    pub fn new(config: GithubConfig) -> Self {
-        let client = build_github_client(&config.authentication);
+    pub fn new(config: GithubConfig) -> Result<Self, ApiError> {
+        let client = build_github_client(&config.authentication)?;
 
         // Create all the validators and compile all the regexes. If the module contains
         // any invalid regexes it will panic.
         let validators = validators::create_validators();
 
-        Self {
+        Ok(Self {
             config,
             client,
             validators,
-        }
+        })
     }
 
     /// Make a generic get request to the GitHub API using the GitHub app library. This exists
@@ -228,7 +228,7 @@ impl Github {
 }
 
 /// Builds an instance of a Github API client
-pub fn build_github_client(authentication: &Authentication) -> Octocrab {
+pub fn build_github_client(authentication: &Authentication) -> Result<Octocrab, ApiError> {
     let client_builder = match authentication {
         Authentication::NoAuth {} => {
             info!("Configuring GitHub client without authentication");
@@ -245,7 +245,7 @@ pub fn build_github_client(authentication: &Authentication) -> Octocrab {
         } => {
             info!("Configuring GitHub client with GitHub App");
             let encoding_key = EncodingKey::from_rsa_pem(private_key.as_bytes())
-                .expect("Failed to create encoding key from private key for GitHub API");
+                .map_err(|_| ApiError::GitHubError(GitHubError::InvalidInput(format!("Failed to create encoding key from private key for GitHub API"))))?;
 
             Octocrab::builder().app((*app_id).into(), encoding_key)
         }
@@ -257,14 +257,17 @@ pub fn build_github_client(authentication: &Authentication) -> Octocrab {
 
     let mut client = client_builder
         .build()
-        .expect("Failed to create GitHub client");
+        .map_err(|e| ApiError::GitHubError(GitHubError::ClientError(e)))?;
 
     if let Authentication::App {
         installation_id, ..
     } = authentication
     {
-        client = client.installation((*installation_id).into());
+        match client.installation((*installation_id).into()) {
+            Ok(installation_client) => client = installation_client,
+            Err(e) => return Err(ApiError::GitHubError(GitHubError::ClientError(e))),
+        }
     }
 
-    client
+    Ok(client)
 }

--- a/runtime/plaid/src/apis/mod.rs
+++ b/runtime/plaid/src/apis/mod.rs
@@ -148,6 +148,7 @@ pub enum ApiError {
     NetworkResponseTooLarge,
     TlsError(String),
     BloomFilterError(String),
+    CouldNotInstatiateRuntime(String),
 }
 
 impl From<evm::EvmCallError> for ApiError {
@@ -182,7 +183,7 @@ impl Api {
         config: ApiConfigs,
         log_sender: Sender<Message>,
         delayed_log_sender: Sender<DelayedMessage>,
-    ) -> Self {
+    ) -> Result<Self, ApiError> {
         let cryptography = match config.cryptography {
             Some(cryptography) => Some(Cryptography::new(cryptography)),
             _ => None,
@@ -216,7 +217,7 @@ impl Api {
         };
 
         let github = match config.github {
-            Some(gh) => Some(Github::new(gh)),
+            Some(gh) => Some(Github::new(gh)?),
             _ => None,
         };
 
@@ -277,8 +278,8 @@ impl Api {
             _ => None,
         };
 
-        Self {
-            runtime: Runtime::new().unwrap(),
+        Ok(Self {
+            runtime: Runtime::new().map_err(|e| ApiError::CouldNotInstatiateRuntime(format!("Failed to create runtime: {}", e)))?,
             #[cfg(feature = "aws")]
             aws,
             #[cfg(feature = "gcp")]
@@ -297,7 +298,7 @@ impl Api {
             splunk,
             yubikey,
             web,
-        }
+        })
     }
 }
 

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -4,6 +4,7 @@ extern crate log;
 use futures_util::{Stream, StreamExt};
 use performance::ModulePerformanceMetadata;
 use plaid::{
+    apis::ApiError,
     cache::Cache,
     config::{
         CachingMode, ConfigurationWithRoles, GetMode, ResponseMode, WebhookConfig,
@@ -37,12 +38,17 @@ use warp::{http::HeaderMap, path, Filter};
 #[derive(Debug)]
 enum Errors {
     FailedToStartDataSystem,
+    FailedToStartApiSystem(ApiError),
     FailedToLoadModules,
 }
 
 impl std::fmt::Display for Errors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            Errors::FailedToStartDataSystem => write!(f, "Failed to start data system"),
+            Errors::FailedToStartApiSystem(e) => write!(f, "Failed to start API system: {:?}", e),
+            Errors::FailedToLoadModules => write!(f, "Failed to load modules"),
+        }
     }
 }
 
@@ -314,7 +320,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Configuring APIs for Modules");
     // Create the API that powers all the wrapped calls that modules can make
-    let api = Api::new(config.apis, log_sender.clone(), delayed_log_sender).await;
+    let api = Api::new(config.apis, log_sender.clone(), delayed_log_sender)
+        .await
+        .map_err(|e| Errors::FailedToStartApiSystem(e))?;
 
     // Create an Arc so all the handlers have access to our API object
     let api = Arc::new(api);

--- a/runtime/plaid/src/cryptography/aes_128_cbc.rs
+++ b/runtime/plaid/src/cryptography/aes_128_cbc.rs
@@ -11,7 +11,7 @@ type Aes128Cbc = Cbc<Aes128, Pkcs7>;
 /// Returns base64(iv||ciphertext).
 pub fn encrypt(key: &[u8], plaintext: &str) -> Result<String, Errors> {
     let mut iv = [0u8; 16];
-    rand::thread_rng().fill_bytes(&mut iv);
+    rand::rng().fill_bytes(&mut iv);
     let cipher = Aes128Cbc::new_from_slices(key, &iv)
         .map_err(|_| Errors::AesEncryptionFailure("Failed to load key".to_string()))?;
     let ct = cipher.encrypt_vec(plaintext.as_bytes());

--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -1,4 +1,5 @@
 use crate::apis::github::{build_github_client, Authentication};
+use crate::apis::ApiError;
 use crate::executor::Message;
 use crate::parse_duration;
 use crossbeam_channel::Sender;
@@ -171,17 +172,23 @@ pub struct Github {
 }
 
 impl Github {
-    pub fn new(config: GithubConfig, logger: Sender<Message>) -> Self {
-        let client = build_github_client(&config.authentication);
-        let lru_cache_size = config.lru_cache_size;
+    pub fn new(config: GithubConfig, logger: Sender<Message>) -> Result<Self, ApiError> {
+        let client = build_github_client(&config.authentication)?;
+        let lru_cache_size = match config.lru_cache_size {
+            0 => {
+                warn!("GitHub API: The LRU cache size must be greater than 0. Using default value of {}.", default_lru_cache_size());
+                NonZeroUsize::new(default_lru_cache_size()).unwrap()
+            }
+            size => NonZeroUsize::new(size).unwrap(),
+        };
 
-        Self {
+        Ok(Self {
             config,
             client,
             last_seen: OffsetDateTime::now_utc(),
-            seen_logs_uuid: LruCache::new(NonZeroUsize::new(lru_cache_size).unwrap()),
+            seen_logs_uuid: LruCache::new(lru_cache_size),
             logger,
-        }
+        })
     }
 }
 

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -7,6 +7,7 @@ mod sqs;
 mod websocket;
 
 use crate::{
+    apis::ApiError,
     executor::Message,
     logging::Logger,
     storage::{Storage, StorageError},
@@ -63,12 +64,14 @@ pub struct Data {}
 #[derive(Debug)]
 pub enum DataError {
     StorageError(StorageError),
+    ApiError(ApiError),
 }
 
 impl std::fmt::Display for DataError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::StorageError(e) => write!(f, "DataError | StorageError: {}", e),
+            Self::ApiError(e) => write!(f, "DataError | ApiError: {:?}", e),
         }
     }
 }
@@ -84,7 +87,8 @@ impl DataInternal {
     ) -> Result<Self, DataError> {
         let github = config
             .github
-            .map(|gh| github::Github::new(gh, logger.clone()));
+            .map(|gh| github::Github::new(gh, logger.clone()).map_err(DataError::ApiError))
+            .transpose()?;
 
         let okta = config
             .okta

--- a/runtime/plaid/tools/dependency_check.rs
+++ b/runtime/plaid/tools/dependency_check.rs
@@ -1,0 +1,206 @@
+use anyhow::{Context, Result};
+use cargo_lock::Lockfile;
+use chrono::{DateTime, Utc};
+use clap::Parser;
+use reqwest::Client;
+use serde::Deserialize;
+use std::cmp::Ordering;
+use std::path::PathBuf;
+use std::process::ExitCode;
+use tokio::time::{sleep, Duration};
+
+const USER_AGENT: &str = "cargo-lock-age-check/1.0";
+
+// Allow these packages if they are too new or not found
+const EXEMPTIONS: &[&str] = &["plaid", "plaid_stl"];
+
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+struct Args {
+    /// Path to Cargo.lock
+    cargo_lock: PathBuf,
+
+    /// Return non-zero if any package is newer than this many days
+    #[arg(long)]
+    min_age_days: Option<i64>,
+
+    /// HTTP timeout in seconds
+    #[arg(long, default_value_t = 10)]
+    timeout: u64,
+
+    /// Include crates whose publish date could not be determined
+    #[arg(long)]
+    include_missing: bool,
+}
+
+#[derive(Debug)]
+struct PackageInfo {
+    name: String,
+    version: String,
+    published_at: Option<DateTime<Utc>>,
+}
+
+impl PackageInfo {
+    fn age_days(&self) -> Option<i64> {
+        self.published_at.map(|published| {
+            let now = Utc::now();
+            (now - published).num_days()
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CratesIoResponse {
+    version: VersionInfo,
+}
+
+#[derive(Debug, Deserialize)]
+struct VersionInfo {
+    created_at: String,
+}
+
+async fn fetch_publish_date(
+    client: &Client,
+    crate_name: &str,
+    version: &str,
+) -> Option<DateTime<Utc>> {
+    let url = format!("https://crates.io/api/v1/crates/{}/{}", crate_name, version);
+
+    let response = client.get(url).send().await.ok()?;
+
+    if !response.status().is_success() {
+        return None;
+    }
+
+    let body: CratesIoResponse = response.json().await.ok()?;
+
+    DateTime::parse_from_rfc3339(&body.version.created_at)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    match run().await {
+        Ok(has_new_packages) => {
+            if has_new_packages {
+                ExitCode::from(1)
+            } else {
+                ExitCode::SUCCESS
+            }
+        }
+        Err(err) => {
+            eprintln!("ERROR: {:#}", err);
+            ExitCode::from(2)
+        }
+    }
+}
+
+async fn run() -> Result<bool> {
+    let args = Args::parse();
+
+    let lockfile = Lockfile::load(&args.cargo_lock)
+        .with_context(|| format!("failed to load lockfile: {}", args.cargo_lock.display()))?;
+
+    let client = Client::builder()
+        .user_agent(USER_AGENT)
+        .timeout(Duration::from_secs(args.timeout))
+        .build()
+        .with_context(|| "failed to build HTTP client".to_string())?;
+
+    let mut packages = Vec::new();
+
+    println!(
+        "Checking publish dates for {} packages from {}...",
+        lockfile.packages.len(),
+        args.cargo_lock.display()
+    );
+
+    for pkg in &lockfile.packages {
+        println!("Checking crate {} {}", pkg.name, pkg.version);
+
+        if EXEMPTIONS.contains(&pkg.name.as_str()) {
+            println!("  Skipping {} since it's on the exemption list", pkg.name);
+            continue;
+        }
+
+        let name = pkg.name.to_string();
+        let version = pkg.version.to_string();
+
+        let published_at = fetch_publish_date(&client, &name, &version).await;
+
+        packages.push(PackageInfo {
+            name,
+            version,
+            published_at,
+        });
+
+        // Try to avoid crates.io rate limits.
+        sleep(Duration::from_millis(25)).await;
+    }
+
+    if !args.include_missing {
+        packages.retain(|p| p.published_at.is_some());
+    }
+
+    packages.sort_by(|a, b| match (&a.published_at, &b.published_at) {
+        (Some(a_dt), Some(b_dt)) => a_dt.cmp(b_dt),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    });
+
+    println!();
+
+    for pkg in &packages {
+        match pkg.published_at {
+            Some(published_at) => {
+                let age = pkg.age_days().unwrap_or(-1);
+
+                println!(
+                    "{} | {:>14} | {} {}",
+                    published_at.date_naive(),
+                    format!("{age} days old"),
+                    pkg.name,
+                    pkg.version
+                );
+            }
+            None => {
+                println!("UNKNOWN DATE | ??? days old | {} {}", pkg.name, pkg.version);
+            }
+        }
+    }
+
+    let mut too_new = Vec::new();
+
+    if let Some(min_age_days) = args.min_age_days {
+        for pkg in &packages {
+            if let Some(age_days) = pkg.age_days() {
+                if age_days < min_age_days {
+                    too_new.push((pkg, age_days));
+                }
+            } else {
+                // If we don't know the age, and --include-missing is set, consider it too new
+                if args.include_missing {
+                    too_new.push((pkg, -1));
+                }
+            }
+        }
+    }
+
+    if !too_new.is_empty() {
+        eprintln!(
+            "\nERROR: {} package(s) newer than --min-age-days={}\n",
+            too_new.len(),
+            args.min_age_days.unwrap()
+        );
+
+        for (pkg, age_days) in &too_new {
+            eprintln!("  {} {} ({} days old)", pkg.name, pkg.version, age_days);
+        }
+
+        return Ok(true);
+    }
+
+    Ok(false)
+}


### PR DESCRIPTION
I was working to address the Dependabot PR where we needed to bump `jsonwebtoken`. This meant I needed to update `Octocrab`, which in turn meant I needed to make API start up fallible.

Thus this was a pretty large change to the code because of this. I then did a `cargo update` to resolve a bunch of other minor security issues.

We should look through this with a more skeptical eye due to this core change and all these new dependency versions. This weekend I'm going to sweep for deps newer than two weeks.