### PR TITLE
Add GH API to list org secrets a repo has access to

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.39.4"
+version = "0.39.5"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3685,7 +3685,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.39.4"
+version = "0.39.5"
 dependencies = [
  "aes",
  "alkali",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.39.4"
+version = "0.39.5"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.39.4"
+version = "0.39.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/github/secrets.rs
+++ b/runtime/plaid-stl/src/github/secrets.rs
@@ -1,6 +1,11 @@
 use std::fmt::Display;
 
-use crate::{github::AddOrRemoveRepoToOrgSecretParams, PlaidFunctionError};
+use serde::Deserialize;
+
+use crate::{
+    github::{AddOrRemoveRepoToOrgSecretParams, ListOrgSecretsForRepoParams},
+    PlaidFunctionError,
+};
 
 /// Add a repo to the list of repos that have access to an organization secret
 pub fn add_repo_to_org_secret(
@@ -58,4 +63,76 @@ pub fn remove_repo_from_org_secret(
     }
 
     Ok(())
+}
+
+/// List the organization secrets that a repository has access to
+pub fn list_org_secrets_for_repo(
+    org: impl Display,
+    repository: impl Display,
+) -> Result<Vec<String>, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(github, list_org_secrets_for_repo);
+    }
+
+    let mut page = 0;
+    let mut secret_names = Vec::new();
+
+    const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
+
+    // Internal structs just for deserializing the response
+    #[derive(Deserialize)]
+    struct Secret {
+        name: String,
+    }
+
+    #[derive(Deserialize)]
+    struct SecretsPage {
+        total_count: u32,
+        secrets: Vec<Secret>,
+    }
+
+    loop {
+        page += 1;
+        let params = ListOrgSecretsForRepoParams {
+            org: org.to_string(),
+            repository: repository.to_string(),
+            per_page: None,
+            page: Some(page),
+        };
+        let params = serde_json::to_string(&params).unwrap();
+        let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+        let res = unsafe {
+            github_list_org_secrets_for_repo(
+                params.as_bytes().as_ptr(),
+                params.as_bytes().len(),
+                return_buffer.as_mut_ptr(),
+                RETURN_BUFFER_SIZE,
+            )
+        };
+
+        if res < 0 {
+            return Err(res.into());
+        }
+
+        return_buffer.truncate(res as usize);
+        // This should be safe because unless the Plaid runtime is expressly trying
+        // to mess with us, this came from a String in the API module.
+        let this_page = String::from_utf8(return_buffer).unwrap();
+
+        // Parse and process the page
+        let this_page = serde_json::from_str::<SecretsPage>(&this_page)
+            .map_err(|_| PlaidFunctionError::InternalApiError)?;
+        if this_page.secrets.is_empty() {
+            break;
+        }
+        secret_names.extend(this_page.secrets.into_iter().map(|s| s.name));
+
+        // Shortcut: if we've seen as many secrets as the total count (which is the same for every page), we know there are no more pages to fetch, so we can stop.
+        // Keeping the other check around doesn't hurt either.
+        if secret_names.len() as u32 >= this_page.total_count {
+            break;
+        }
+    }
+
+    Ok(secret_names)
 }

--- a/runtime/plaid-stl/src/github/types.rs
+++ b/runtime/plaid-stl/src/github/types.rs
@@ -487,3 +487,11 @@ pub struct AddOrRemoveRepoToOrgSecretParams {
     pub secret_name: String,
     pub repository: String,
 }
+
+#[derive(Serialize, Deserialize)]
+pub struct ListOrgSecretsForRepoParams {
+    pub org: String,
+    pub repository: String,
+    pub per_page: Option<u32>,
+    pub page: Option<u32>,
+}

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.39.4"
+version = "0.39.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/github/secrets.rs
+++ b/runtime/plaid/src/apis/github/secrets.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 use alkali::asymmetric::seal;
-use plaid_stl::github::AddOrRemoveRepoToOrgSecretParams;
+use plaid_stl::github::{AddOrRemoveRepoToOrgSecretParams, ListOrgSecretsForRepoParams};
 use serde::Serialize;
 use serde_json::Value;
 use std::{collections::HashMap, fmt::Display, sync::Arc};
@@ -246,5 +246,42 @@ impl Github {
 
         self.execute_org_secret_action(&request, RepoToOrgSecretAction::Remove, module)
             .await
+    }
+
+    /// List the organization secrets that a repository has access to
+    /// https://docs.github.com/en/rest/actions/secrets?apiVersion=2026-03-10#list-repository-organization-secrets
+    pub async fn list_org_secrets_for_repo(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
+        let request: ListOrgSecretsForRepoParams =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let org = self.validate_org(&request.org)?;
+        let repository = self.validate_repository_name(&request.repository)?;
+
+        // Note: we do not validate these values because they come in encoded as u32, and that's all we need.
+        // Therefore, the validation is in the fact that they were able to be deserialized.
+        let per_page = request.per_page.unwrap_or(30);
+        let page = request.page.unwrap_or(1);
+
+        info!("Listing organization secrets that can be accessed by repository [{repository}] on behalf of [{module}]");
+
+        let url = format!("/repos/{org}/{repository}/actions/organization-secrets?per_page={per_page}&page={page}");
+
+        match self.make_generic_get_request(url, module).await {
+            Ok((status, Ok(body))) => {
+                if status == 200 {
+                    Ok(body)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
     }
 }

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -448,6 +448,7 @@ impl_new_function_with_error_buffer!(github, get_repo_id_from_repo_name, ALLOW_I
 impl_new_function_with_error_buffer!(github, get_repo_name_from_repo_id, ALLOW_IN_TEST_MODE);
 impl_new_function!(github, add_repo_to_org_secret, DISALLOW_IN_TEST_MODE);
 impl_new_function!(github, remove_repo_from_org_secret, DISALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(github, list_org_secrets_for_repo, ALLOW_IN_TEST_MODE);
 
 // GitHub Functions only available with GitHub App authentication
 impl_new_function!(github, review_fpat_requests_for_org, DISALLOW_IN_TEST_MODE);
@@ -782,6 +783,7 @@ define_api_functions! {
         "github_remove_outside_collaborator_from_org"      => github_remove_outside_collaborator_from_org,
         "github_add_repo_to_org_secret"                    => github_add_repo_to_org_secret,
         "github_remove_repo_from_org_secret"               => github_remove_repo_from_org_secret,
+        "github_list_org_secrets_for_repo"                 => github_list_org_secrets_for_repo,
 
         // Slack Calls
         "slack_post_to_named_webhook"     => slack_post_to_named_webhook,


### PR DESCRIPTION
Adding this API to the runtime: https://docs.github.com/en/rest/actions/secrets?apiVersion=2026-03-10#list-repository-organization-secrets