### PR TITLE
Fixing More Dependencies

### DIFF
--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -285,12 +285,12 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
- "asn1-rs-derive 0.4.0",
- "asn1-rs-impl 0.1.0",
+ "asn1-rs-derive 0.5.1",
+ "asn1-rs-impl",
  "displaydoc",
  "nom",
  "num-traits",
@@ -306,7 +306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
  "asn1-rs-derive 0.6.0",
- "asn1-rs-impl 0.2.0",
+ "asn1-rs-impl",
  "displaydoc",
  "nom",
  "num-traits",
@@ -317,14 +317,14 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -335,19 +335,8 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "synstructure 0.13.2",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -358,7 +347,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -380,7 +369,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -391,7 +380,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -920,7 +909,7 @@ checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1074,7 +1063,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1152,7 +1141,7 @@ checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1318,7 +1307,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1777,7 +1766,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1801,7 +1790,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1812,7 +1801,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1854,11 +1843,11 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "8.2.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
- "asn1-rs 0.5.2",
+ "asn1-rs 0.6.2",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -1909,7 +1898,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn",
  "unicode-xid",
 ]
 
@@ -1945,7 +1934,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2060,7 +2049,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2081,7 +2070,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2296,7 +2285,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3065,7 +3054,7 @@ checksum = "63736175c9a30ea123f7018de9f26163e0b39cd6978990ae486b510c4f3bad69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3144,7 +3133,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3163,7 +3152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3200,7 +3189,7 @@ dependencies = [
  "js-sys",
  "p256",
  "p384",
- "pem 3.0.6",
+ "pem",
  "rand 0.8.6",
  "rsa",
  "serde",
@@ -3591,7 +3580,7 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3766,11 +3755,11 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
 dependencies = [
- "asn1-rs 0.5.2",
+ "asn1-rs 0.6.2",
 ]
 
 [[package]]
@@ -3886,15 +3875,6 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
-]
-
-[[package]]
-name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
@@ -3949,7 +3929,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3978,7 +3958,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4061,7 +4041,7 @@ dependencies = [
  "regex",
  "reqwest",
  "reqwest_cookie_store",
- "ring 0.17.14",
+ "ring",
  "rustls 0.23.40",
  "serde",
  "serde_json",
@@ -4135,7 +4115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4166,7 +4146,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4198,7 +4178,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4233,7 +4213,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4296,7 +4276,7 @@ dependencies = [
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.4",
- "ring 0.17.14",
+ "ring",
  "rustc-hash",
  "rustls 0.23.40",
  "rustls-pki-types",
@@ -4438,14 +4418,15 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.10.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
- "pem 1.1.1",
- "ring 0.16.20",
+ "pem",
+ "ring",
+ "rustls-pki-types",
  "time",
- "x509-parser 0.14.0",
+ "x509-parser 0.16.0",
  "yasna",
 ]
 
@@ -4518,7 +4499,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4677,21 +4658,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
@@ -4731,7 +4697,7 @@ checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4810,7 +4776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.14",
+ "ring",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -4822,7 +4788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -4838,7 +4804,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",
  "subtle",
@@ -4909,7 +4875,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.14",
+ "ring",
  "untrusted 0.9.0",
 ]
 
@@ -4919,7 +4885,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -4931,7 +4897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -5017,7 +4983,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.14",
+ "ring",
  "untrusted 0.9.0",
 ]
 
@@ -5130,7 +5096,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5206,7 +5172,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5381,7 +5347,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5403,12 +5369,6 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -5440,7 +5400,7 @@ checksum = "752ad8923d32fb5c117b8a9983266e294edc072401133720aa9af3959d63248d"
 dependencies = [
  "base64 0.13.1",
  "chrono",
- "ring 0.17.14",
+ "ring",
  "zeroize",
 ]
 
@@ -5464,17 +5424,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -5495,25 +5444,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5602,7 +5539,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5613,7 +5550,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5715,7 +5652,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5984,7 +5921,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6306,7 +6243,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -6478,7 +6415,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6664,7 +6601,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6675,7 +6612,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6956,7 +6893,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6972,7 +6909,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7022,18 +6959,17 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "x509-parser"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
- "asn1-rs 0.5.2",
- "base64 0.13.1",
+ "asn1-rs 0.6.2",
  "data-encoding",
- "der-parser 8.2.0",
+ "der-parser 9.0.0",
  "lazy_static",
  "nom",
- "oid-registry 0.6.1",
- "ring 0.16.20",
+ "oid-registry 0.7.1",
+ "ring",
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
@@ -7100,8 +7036,8 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "synstructure 0.13.2",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -7121,7 +7057,7 @@ checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -7141,8 +7077,8 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "synstructure 0.13.2",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -7162,7 +7098,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -7195,7 +7131,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -51,7 +51,7 @@ octocrab = "0.50"
 paste = "1.0"
 plaid_stl = { path = "../plaid-stl" }
 rand = "0.9"
-rcgen = { version = "0.10", features = ["x509-parser"] }
+rcgen = { version = "0.13", features = ["x509-parser"] }
 redis = { version = "0.32", features = [
     "aio",
     "tokio-comp",

--- a/runtime/plaid/src/apis/rustica/mod.rs
+++ b/runtime/plaid/src/apis/rustica/mod.rs
@@ -1,4 +1,4 @@
-use rcgen::{Certificate, CertificateParams, DistinguishedName, DnType, KeyPair};
+use rcgen::{CertificateParams, DistinguishedName, DnType, KeyPair};
 use serde::{Deserialize, Serialize};
 
 use std::{collections::HashMap, sync::Arc};
@@ -100,17 +100,20 @@ impl Rustica {
         dn.push(DnType::CommonName, &environment.mtls_cn);
 
         let mut mtls_ca_params = CertificateParams::default();
-        mtls_ca_params.key_pair = Some(ca_key);
-        mtls_ca_params.alg = alg;
         mtls_ca_params.distinguished_name = dn;
 
-        let ca = Certificate::from_params(mtls_ca_params).map_err(|_| {
+        let ca = mtls_ca_params.self_signed(&ca_key).map_err(|_| {
             ApiError::ConfigurationError(format!(
                 "Rustica environment [{environment_name}] has bad certificate and private key pair"
             ))
         })?;
 
-        let mut certificate_params = CertificateParams::new(vec![user_identity.to_string()]);
+        let mut certificate_params = CertificateParams::new(vec![user_identity.to_string()])
+            .map_err(|_| {
+                ApiError::RusticaError(RusticaError::UnserializableCertificate(
+                    user_identity.to_string(),
+                ))
+            })?;
         certificate_params
             .distinguished_name
             .push(DnType::CommonName, user_identity.to_string());
@@ -123,21 +126,23 @@ impl Rustica {
             .not_before
             .saturating_add(Duration::seconds(60 * 60 * 24 * 90));
 
-        let new_certificate = Certificate::from_params(certificate_params).map_err(|_| {
+        let user_key_pair = KeyPair::generate_for(alg).map_err(|_| {
             ApiError::RusticaError(RusticaError::UnserializableCertificate(
                 user_identity.to_string(),
             ))
         })?;
 
-        let user_private_key = new_certificate.serialize_private_key_pem();
-
-        let user_certificate = new_certificate
-            .serialize_pem_with_signer(&ca)
+        let new_certificate = certificate_params
+            .signed_by(&user_key_pair, &ca, &ca_key)
             .map_err(|_| {
                 ApiError::RusticaError(RusticaError::UnserializableCertificate(
                     user_identity.to_string(),
                 ))
             })?;
+
+        let user_private_key = user_key_pair.serialize_pem();
+
+        let user_certificate = new_certificate.pem();
 
         let server_config = ServerConfiguration {
             address: environment.server.clone(),

--- a/runtime/plaid/src/apis/rustica/mod.rs
+++ b/runtime/plaid/src/apis/rustica/mod.rs
@@ -58,6 +58,81 @@ impl Rustica {
 }
 
 impl Rustica {
+    pub(crate) fn generate_server_configuration(
+        environment_name: &str,
+        user_identity: &str,
+        environment: &Environment,
+    ) -> Result<ServerConfiguration, ApiError> {
+        let user_identity_owned = user_identity.to_string();
+
+        let ca_key = KeyPair::from_pem(&environment.mtls_key).map_err(|e| {
+            error!("Rustica Error: {:?}", e);
+            ApiError::ConfigurationError(format!(
+                "Rustica environment [{environment_name}] has an incorrectly formatted key"
+            ))
+        })?;
+
+        let alg = ca_key.compatible_algs().next().ok_or(
+            ApiError::ConfigurationError(format!(
+                "Rustica environment [{environment_name}] has a certificate with no known signature algorithm"
+            )),
+        )?;
+
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CommonName, &environment.mtls_cn);
+
+        let mut mtls_ca_params = CertificateParams::default();
+        mtls_ca_params.distinguished_name = dn;
+
+        let ca = mtls_ca_params.self_signed(&ca_key).map_err(|_| {
+            ApiError::ConfigurationError(format!(
+                "Rustica environment [{environment_name}] has bad certificate and private key pair"
+            ))
+        })?;
+
+        let mut certificate_params = CertificateParams::new(vec![user_identity_owned.clone()])
+            .map_err(|_| {
+                ApiError::RusticaError(RusticaError::UnserializableCertificate(
+                    user_identity_owned.clone(),
+                ))
+            })?;
+        certificate_params
+            .distinguished_name
+            .push(DnType::CommonName, user_identity_owned.clone());
+
+        // TODO: This should probably be the way to do it, but Rustica seems
+        // to want it in SAN DNS
+        //certificate_params.subject_alt_names = vec![SanType::Rfc822Name(user_identity_owned.clone())];
+        certificate_params.not_before = OffsetDateTime::now_utc();
+        certificate_params.not_after = certificate_params
+            .not_before
+            .saturating_add(Duration::seconds(60 * 60 * 24 * 90));
+
+        let user_key_pair = KeyPair::generate_for(alg).map_err(|_| {
+            ApiError::RusticaError(RusticaError::UnserializableCertificate(
+                user_identity_owned.clone(),
+            ))
+        })?;
+
+        let new_certificate = certificate_params
+            .signed_by(&user_key_pair, &ca, &ca_key)
+            .map_err(|_| {
+                ApiError::RusticaError(RusticaError::UnserializableCertificate(
+                    user_identity_owned.clone(),
+                ))
+            })?;
+
+        let user_private_key = user_key_pair.serialize_pem();
+        let user_certificate = new_certificate.pem();
+
+        Ok(ServerConfiguration {
+            address: environment.server.clone(),
+            ca_pem: environment.tls_ca.clone(),
+            mtls_cert: user_certificate,
+            mtls_key: user_private_key,
+        })
+    }
+
     /// Create a new mTLS certificate and return a serialized `ServerConfiguration` object
     pub async fn new_mtls_cert(
         &self,
@@ -82,79 +157,116 @@ impl Rustica {
                     environment_name.to_string(),
                 )))?;
 
-        let ca_key = KeyPair::from_pem(&environment.mtls_key).map_err(|e| {
-            error!("Rustica Error: {:?}", e);
-            ApiError::ConfigurationError(format!(
-                "Rustica environment [{environment_name}] has badly formatted key"
-            ))
-        })?;
-
-        let alg = ca_key
-            .compatible_algs()
-            .next()
-            .ok_or(ApiError::ConfigurationError(format!(
-                "Rustica environment [{environment_name}] has an certificate with no discernible signature algorithm"
-            )))?;
-
-        let mut dn = DistinguishedName::new();
-        dn.push(DnType::CommonName, &environment.mtls_cn);
-
-        let mut mtls_ca_params = CertificateParams::default();
-        mtls_ca_params.distinguished_name = dn;
-
-        let ca = mtls_ca_params.self_signed(&ca_key).map_err(|_| {
-            ApiError::ConfigurationError(format!(
-                "Rustica environment [{environment_name}] has bad certificate and private key pair"
-            ))
-        })?;
-
-        let mut certificate_params = CertificateParams::new(vec![user_identity.to_string()])
-            .map_err(|_| {
-                ApiError::RusticaError(RusticaError::UnserializableCertificate(
-                    user_identity.to_string(),
-                ))
-            })?;
-        certificate_params
-            .distinguished_name
-            .push(DnType::CommonName, user_identity.to_string());
-
-        // TODO: This should probably be the way to do it, but Rustica seems
-        // to want it in SAN DNS
-        //certificate_params.subject_alt_names = vec![SanType::Rfc822Name(user_identity.to_string())];
-        certificate_params.not_before = OffsetDateTime::now_utc();
-        certificate_params.not_after = certificate_params
-            .not_before
-            .saturating_add(Duration::seconds(60 * 60 * 24 * 90));
-
-        let user_key_pair = KeyPair::generate_for(alg).map_err(|_| {
-            ApiError::RusticaError(RusticaError::UnserializableCertificate(
-                user_identity.to_string(),
-            ))
-        })?;
-
-        let new_certificate = certificate_params
-            .signed_by(&user_key_pair, &ca, &ca_key)
-            .map_err(|_| {
-                ApiError::RusticaError(RusticaError::UnserializableCertificate(
-                    user_identity.to_string(),
-                ))
-            })?;
-
-        let user_private_key = user_key_pair.serialize_pem();
-
-        let user_certificate = new_certificate.pem();
-
-        let server_config = ServerConfiguration {
-            address: environment.server.clone(),
-            ca_pem: environment.tls_ca.clone(),
-            mtls_cert: user_certificate,
-            mtls_key: user_private_key,
-        };
+        let server_config =
+            Self::generate_server_configuration(environment_name, user_identity, environment)?;
 
         Ok(serde_json::to_string(&server_config).map_err(|_| {
             ApiError::RusticaError(RusticaError::UnserializableCertificate(
                 user_identity.to_string(),
             ))
         })?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rcgen::{BasicConstraints, IsCa};
+    use x509_parser::pem::parse_x509_pem;
+    use x509_parser::prelude::*;
+
+    /// Build a throwaway self-signed CA and return (ca_cert_pem, ca_key_pem).
+    fn generate_test_ca(cn: &str) -> (String, String) {
+        let ca_key = KeyPair::generate().expect("Test CA key generation failed");
+
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CommonName, cn);
+
+        let mut params = CertificateParams::default();
+        params.distinguished_name = dn;
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+
+        let cert = params
+            .self_signed(&ca_key)
+            .expect("Test CA self-signing failed");
+
+        (cert.pem(), ca_key.serialize_pem())
+    }
+
+    #[test]
+    fn test_generate_server_configuration_valid_certificate() {
+        let user_identity = "mitchell@example.io";
+        let server_address = "rustica.example.io:7001";
+        let ca_cn = "Test mTLS CA";
+
+        let (ca_cert_pem, ca_key_pem) = generate_test_ca(ca_cn);
+
+        let environment = Environment {
+            tls_ca: ca_cert_pem.clone(),
+            mtls_cn: ca_cn.to_string(),
+            mtls_key: ca_key_pem,
+            server: server_address.to_string(),
+        };
+
+        let config =
+            Rustica::generate_server_configuration("test-env", user_identity, &environment)
+                .expect("generate_server_configuration failed");
+
+        // Server address and TLS CA pass through unchanged.
+        assert_eq!(config.address, server_address);
+        assert_eq!(config.ca_pem, ca_cert_pem);
+
+        // The private key must be a valid PEM-encoded key pair.
+        assert!(
+            KeyPair::from_pem(&config.mtls_key).is_ok(),
+            "returned mtls_key is not a valid PEM key"
+        );
+
+        // Parse the issued certificate with x509-parser and verify its fields.
+        let (_, pem) =
+            parse_x509_pem(config.mtls_cert.as_bytes()).expect("mtls_cert is not valid PEM");
+        let (_, cert) =
+            parse_x509_certificate(&pem.contents).expect("mtls_cert is not a valid X.509 cert");
+
+        // Subject CN must equal the user identity.
+        let cn = cert
+            .subject()
+            .iter_common_name()
+            .next()
+            .expect("cert has no CN")
+            .as_str()
+            .expect("CN is not a UTF-8 string");
+        assert_eq!(cn, user_identity);
+
+        // The SAN DNS entry must also equal the user identity.
+        let san = cert
+            .subject_alternative_name()
+            .expect("SAN extension parse error")
+            .expect("cert has no SAN extension");
+        let has_dns_san = san
+            .value
+            .general_names
+            .iter()
+            .any(|gn| matches!(gn, GeneralName::DNSName(name) if *name == user_identity));
+        assert!(
+            has_dns_san,
+            "expected SAN DNS name {user_identity} not found"
+        );
+
+        // Validity window should be approximately 90 days
+        let validity = cert.validity();
+        let duration =
+            (validity.not_after - validity.not_before).expect("validity period subtraction failed");
+        let days = duration.whole_days();
+        assert!(
+            (89..=91).contains(&days),
+            "expected ~90 day validity, got {days} days"
+        );
+
+        // Certificate must currently be valid.
+        assert!(
+            validity.is_valid(),
+            "generated certificate is not currently valid"
+        );
     }
 }


### PR DESCRIPTION
This takes some more in-depth changes as I need to rewrite some components to use new versions of libraries that have breaking changes.

First up is `rcgen` going from 10 -> 13. This allows us to finally get rid of `ring` 16 and have united on a single version of `ring` 17.