### PR TITLE
Add support for multiple connections to the GitHub API

### DIFF
--- a/modules/examples/example_github_graphql/src/lib.rs
+++ b/modules/examples/example_github_graphql/src/lib.rs
@@ -115,7 +115,8 @@ fn main(_: String, source: LogSource) -> Result<Option<String>, Errors> {
         ]
         .into();
 
-        match github::make_graphql_query(GITHUB_GRAPHQL_QUERY, variables) {
+        match github::make_graphql_query("PROVIDE YOUR CLIENT ID", GITHUB_GRAPHQL_QUERY, variables)
+        {
             Ok(result) => {
                 let result: Value = serde_json::from_str(&result).unwrap();
 

--- a/modules/tests/test_gh_id_conversion/src/lib.rs
+++ b/modules/tests/test_gh_id_conversion/src/lib.rs
@@ -15,13 +15,13 @@ const REPO_ID: i64 = 777071534;
 fn main(_log: String, _source: LogSource) -> Result<(), i32> {
     plaid::print_debug_string(&format!("testing gh_id_conversion"));
 
-    let user_id = github::get_user_id_from_username(USERNAME).unwrap();
+    let user_id = github::get_user_id_from_username("noauth", USERNAME).unwrap();
     if user_id != USER_ID {
         plaid::print_debug_string(&format!("Expected user ID [{USER_ID}] but got [{user_id}]"));
         return Err(-1);
     }
 
-    let username = github::get_username_from_user_id(USER_ID).unwrap();
+    let username = github::get_username_from_user_id("noauth", USER_ID).unwrap();
     if username != USERNAME {
         plaid::print_debug_string(&format!(
             "Expected username [{USERNAME}] but got [{username}]"
@@ -29,13 +29,13 @@ fn main(_log: String, _source: LogSource) -> Result<(), i32> {
         return Err(-1);
     }
 
-    let repo_id = github::get_repo_id_from_repo_name(REPO_OWNER, REPO_NAME).unwrap();
+    let repo_id = github::get_repo_id_from_repo_name("noauth", REPO_OWNER, REPO_NAME).unwrap();
     if repo_id != REPO_ID {
         plaid::print_debug_string(&format!("Expected repo ID [{REPO_ID}] but got [{repo_id}]"));
         return Err(-1);
     }
 
-    let repo_name = github::get_repo_name_from_repo_id(REPO_ID.to_string()).unwrap();
+    let repo_name = github::get_repo_name_from_repo_id("noauth", REPO_ID.to_string()).unwrap();
     if repo_name != format!("{REPO_OWNER}/{REPO_NAME}") {
         plaid::print_debug_string(&format!(
             "Expected repo name [{REPO_OWNER}/{REPO_NAME}] but got [{repo_name}]"

--- a/runtime/plaid-stl/src/github/actions.rs
+++ b/runtime/plaid-stl/src/github/actions.rs
@@ -1,12 +1,18 @@
+use std::fmt::Display;
+
 use serde::{Deserialize, Serialize};
 
-use crate::{github::RepositoryDispatchParams, PlaidFunctionError};
+use crate::{
+    github::{GithubApiWrapper, RepositoryDispatchParams},
+    PlaidFunctionError,
+};
 
 /// Trigger a GHA workflow via repository_dispatch.
 /// For more details, see
 /// * https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event
 /// * https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#repository_dispatch
 pub fn trigger_repo_dispatch<T>(
+    client_id: impl Display,
     owner: &str,
     repo: &str,
     event_type: &str,
@@ -26,7 +32,12 @@ where
         client_payload,
     };
 
-    let params = serde_json::to_string(&params).unwrap();
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let params = serde_json::to_string(&wrapped).unwrap();
     let res = unsafe {
         github_trigger_repo_dispatch(params.as_bytes().as_ptr(), params.as_bytes().len())
     };

--- a/runtime/plaid-stl/src/github/copilot.rs
+++ b/runtime/plaid-stl/src/github/copilot.rs
@@ -1,13 +1,23 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     github::{
         CopilotAddUsersResponse, CopilotRemoveUsersResponse, CopilotSeat, CopilotSeatsResult,
+        GithubApiWrapper,
     },
     PlaidFunctionError,
 };
+
+#[derive(Deserialize, Serialize)]
+pub struct ListSeatsInOrgCopilotParams {
+    pub org: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub per_page: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page: Option<u16>,
+}
 
 /// List seats in org's Copilot subscription, paginated
 /// ## Arguments
@@ -16,24 +26,27 @@ use crate::{
 /// * `per_page` - The number of results per page (max 100)
 /// * `page` - The page number of the results to fetch.
 pub fn list_copilot_subscription_seats_by_page(
+    client_id: impl Display,
     org: &str,
-    per_page: Option<u64>,
-    page: Option<u64>,
+    per_page: Option<u8>,
+    page: Option<u16>,
 ) -> Result<Vec<CopilotSeat>, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, list_seats_in_org_copilot);
     }
 
-    let mut params: HashMap<&'static str, String> = HashMap::new();
-    params.insert("org", org.to_string());
-    if let Some(per_page) = per_page {
-        params.insert("per_page", per_page.to_string());
-    }
-    if let Some(page) = page {
-        params.insert("page", page.to_string());
-    }
+    let params = ListSeatsInOrgCopilotParams {
+        org: org.to_string(),
+        per_page,
+        page,
+    };
 
-    let request = serde_json::to_string(&params).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let request = serde_json::to_string(&wrapper).unwrap();
 
     const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
@@ -123,32 +136,40 @@ pub fn list_all_copilot_subscription_seats(
     Ok(seats)
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct AddUsersToOrgCopilotParams {
+    #[serde(skip_serializing)]
+    pub org: String,
+    pub selected_usernames: Vec<String>,
+}
+
 /// Add a user to the org's Copilot subscription
 /// ## Arguments
 ///
 /// * `org` - The org owning the subscription
 /// * `user` - The user to add to Copilot subscription
 pub fn add_user_to_copilot_subscription(
+    client_id: impl Display,
     org: &str,
     user: &str,
 ) -> Result<CopilotAddUsersResponse, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, add_users_to_org_copilot);
     }
-    #[derive(Serialize)]
-    struct Params<'a> {
-        org: &'a str,
-        selected_usernames: Vec<&'a str>,
-    }
-    let params = Params {
-        org,
-        selected_usernames: vec![user],
+    let params = AddUsersToOrgCopilotParams {
+        org: org.to_string(),
+        selected_usernames: vec![user.to_string()],
+    };
+
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
     };
 
     const RETURN_BUFFER_SIZE: usize = 1024; // 1 KiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
-    let params = serde_json::to_string(&params).unwrap();
+    let params = serde_json::to_string(&wrapper).unwrap();
     let res = unsafe {
         github_add_users_to_org_copilot(
             params.as_bytes().as_ptr(),
@@ -176,12 +197,20 @@ pub fn add_user_to_copilot_subscription(
     Ok(response_body)
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct RemoveUsersFromOrgCopilotParams {
+    #[serde(skip_serializing)]
+    pub org: String,
+    pub selected_usernames: Vec<String>,
+}
+
 /// Remove a user from the org's Copilot subscription
 /// ## Arguments
 ///
 /// * `org` - The org owning the subscription
 /// * `user` - The user to remove from Copilot subscription
 pub fn remove_user_from_copilot_subscription(
+    client_id: impl Display,
     org: &str,
     user: &str,
 ) -> Result<CopilotRemoveUsersResponse, PlaidFunctionError> {
@@ -189,20 +218,20 @@ pub fn remove_user_from_copilot_subscription(
         new_host_function_with_error_buffer!(github, remove_users_from_org_copilot);
     }
 
-    #[derive(Serialize)]
-    struct Params<'a> {
-        org: &'a str,
-        selected_usernames: Vec<&'a str>,
-    }
-    let params = Params {
-        org,
-        selected_usernames: vec![user],
+    let params = RemoveUsersFromOrgCopilotParams {
+        org: org.to_string(),
+        selected_usernames: vec![user.to_string()],
+    };
+
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
     };
 
     const RETURN_BUFFER_SIZE: usize = 1024; // 1 KiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
-    let params = serde_json::to_string(&params).unwrap();
+    let params = serde_json::to_string(&wrapper).unwrap();
     let res = unsafe {
         github_remove_users_from_org_copilot(
             params.as_bytes().as_ptr(),
@@ -236,6 +265,7 @@ pub fn remove_user_from_copilot_subscription(
 /// * `org` - The org owning the subscription
 /// * `users` - The list of users to remove from Copilot subscription
 pub fn remove_users_from_copilot_subscription(
+    client_id: impl Display,
     org: &str,
     users: Vec<&str>,
 ) -> Result<CopilotRemoveUsersResponse, PlaidFunctionError> {
@@ -243,20 +273,20 @@ pub fn remove_users_from_copilot_subscription(
         new_host_function_with_error_buffer!(github, remove_users_from_org_copilot);
     }
 
-    #[derive(Serialize)]
-    struct Params<'a> {
-        org: &'a str,
-        selected_usernames: Vec<&'a str>,
-    }
-    let params = Params {
-        org,
-        selected_usernames: users,
+    let params = RemoveUsersFromOrgCopilotParams {
+        org: org.to_string(),
+        selected_usernames: users.into_iter().map(|u| u.to_string()).collect(),
+    };
+
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
     };
 
     const RETURN_BUFFER_SIZE: usize = 1024; // 1 KiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
-    let params = serde_json::to_string(&params).unwrap();
+    let params = serde_json::to_string(&wrapper).unwrap();
     let res = unsafe {
         github_remove_users_from_org_copilot(
             params.as_bytes().as_ptr(),

--- a/runtime/plaid-stl/src/github/copilot.rs
+++ b/runtime/plaid-stl/src/github/copilot.rs
@@ -138,7 +138,6 @@ pub fn list_all_copilot_subscription_seats(
 
 #[derive(Deserialize, Serialize)]
 pub struct AddUsersToOrgCopilotParams {
-    #[serde(skip_serializing)]
     pub org: String,
     pub selected_usernames: Vec<String>,
 }
@@ -199,7 +198,6 @@ pub fn add_user_to_copilot_subscription(
 
 #[derive(Deserialize, Serialize)]
 pub struct RemoveUsersFromOrgCopilotParams {
-    #[serde(skip_serializing)]
     pub org: String,
     pub selected_usernames: Vec<String>,
 }

--- a/runtime/plaid-stl/src/github/fpat.rs
+++ b/runtime/plaid-stl/src/github/fpat.rs
@@ -1,22 +1,39 @@
-use std::{collections::HashMap, fmt::Display};
+use std::fmt::Display;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-use crate::{github::ReviewPatAction, PlaidFunctionError};
+use crate::{
+    github::{GithubApiWrapper, ReviewPatAction},
+    PlaidFunctionError,
+};
+
+#[derive(Deserialize, Serialize)]
+pub struct ListFpatRequestsForOrgParams {
+    pub org: String,
+}
 
 /// Lists approved fine-grained personal access tokens owned by organization members that can access organization resources
 /// ## Arguments
 ///
 /// * `org` - The organization name. The name is not case sensitive.
-pub fn list_fpat_requests_for_org(org: &str) -> Result<String, PlaidFunctionError> {
+pub fn list_fpat_requests_for_org(
+    client_id: impl Display,
+    org: &str,
+) -> Result<String, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, list_fpat_requests_for_org);
     }
 
-    let mut params: HashMap<&'static str, &str> = HashMap::new();
-    params.insert("org", org);
+    let params = ListFpatRequestsForOrgParams {
+        org: org.to_string(),
+    };
 
-    let request = serde_json::to_string(&params).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let request = serde_json::to_string(&wrapper).unwrap();
 
     const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
@@ -42,6 +59,14 @@ pub fn list_fpat_requests_for_org(org: &str) -> Result<String, PlaidFunctionErro
     Ok(String::from_utf8(return_buffer).unwrap())
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct ReviewFpatRequestsForOrgParams {
+    pub org: String,
+    pub pat_request_ids: Vec<u64>,
+    pub action: String,
+    pub reason: String,
+}
+
 /// Approves or denies multiple pending requests to access organization resources via a fine-grained personal access token
 /// ## Arguments
 ///
@@ -50,6 +75,7 @@ pub fn list_fpat_requests_for_org(org: &str) -> Result<String, PlaidFunctionErro
 /// * `action` - Action to apply to the requests.
 /// * `reason` - Reason for approving or denying the requests. Max 1024 characters.
 pub fn review_fpat_requests_for_org(
+    client_id: impl Display,
     org: String,
     pat_request_ids: &[u64],
     action: ReviewPatAction,
@@ -58,15 +84,8 @@ pub fn review_fpat_requests_for_org(
     extern "C" {
         new_host_function!(github, review_fpat_requests_for_org);
     }
-    #[derive(Serialize)]
-    struct Request {
-        org: String,
-        pat_request_ids: Vec<u64>,
-        action: String,
-        reason: String,
-    }
 
-    let request = Request {
+    let request = ReviewFpatRequestsForOrgParams {
         org,
         pat_request_ids: pat_request_ids.to_vec(),
         action: match action {
@@ -76,7 +95,12 @@ pub fn review_fpat_requests_for_org(
         reason,
     };
 
-    let request = serde_json::to_string(&request).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: request,
+    };
+
+    let request = serde_json::to_string(&wrapper).unwrap();
 
     let res = unsafe {
         github_review_fpat_requests_for_org(request.as_bytes().as_ptr(), request.as_bytes().len())
@@ -90,6 +114,16 @@ pub fn review_fpat_requests_for_org(
     }
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct GetReposForFpatParams {
+    pub org: String,
+    pub request_id: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub per_page: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page: Option<u64>,
+}
+
 /// Lists the repositories a fine-grained personal access token request is requesting access to
 /// ## Arguments
 ///
@@ -97,8 +131,9 @@ pub fn review_fpat_requests_for_org(
 /// * `request_id` - Unique identifier of the request for access via fine-grained personal access token.
 /// * `per_page` - The number of results per page (max 100)
 /// * `page` - The page number of the results to fetch.
-pub fn get_repos_for_fpat<T: Display>(
-    org: T,
+pub fn get_repos_for_fpat(
+    client_id: impl Display,
+    org: impl Display,
     request_id: u64,
     per_page: Option<u64>,
     page: Option<u64>,
@@ -106,17 +141,20 @@ pub fn get_repos_for_fpat<T: Display>(
     extern "C" {
         new_host_function_with_error_buffer!(github, get_repos_for_fpat);
     }
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("org", org.to_string());
-    params.insert("request_id", request_id.to_string());
-    if let Some(per_page) = per_page {
-        params.insert("per_page", per_page.to_string());
-    }
-    if let Some(page) = page {
-        params.insert("page", page.to_string());
-    }
 
-    let request = serde_json::to_string(&params).unwrap();
+    let params = GetReposForFpatParams {
+        org: org.to_string(),
+        request_id,
+        per_page,
+        page,
+    };
+
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let request = serde_json::to_string(&wrapper).unwrap();
 
     const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];

--- a/runtime/plaid-stl/src/github/graphql.rs
+++ b/runtime/plaid-stl/src/github/graphql.rs
@@ -1,10 +1,11 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 
 use serde::Serialize;
 
-use crate::PlaidFunctionError;
+use crate::{github::GithubApiWrapper, PlaidFunctionError};
 
 pub fn make_graphql_query(
+    client_id: impl Display,
     query_name: &str,
     variables: HashMap<String, String>,
 ) -> Result<String, PlaidFunctionError> {
@@ -24,7 +25,12 @@ pub fn make_graphql_query(
         variables,
     };
 
-    let query = serde_json::to_string(&request).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: request,
+    };
+
+    let query = serde_json::to_string(&wrapper).unwrap();
 
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
@@ -50,6 +56,7 @@ pub fn make_graphql_query(
 }
 
 pub fn make_advanced_graphql_query(
+    client_id: impl Display,
     query_name: &str,
     variables: HashMap<String, serde_json::Value>,
 ) -> Result<String, PlaidFunctionError> {
@@ -69,7 +76,12 @@ pub fn make_advanced_graphql_query(
         variables,
     };
 
-    let query = serde_json::to_string(&request).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: request,
+    };
+
+    let query = serde_json::to_string(&wrapper).unwrap();
 
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 

--- a/runtime/plaid-stl/src/github/members.rs
+++ b/runtime/plaid-stl/src/github/members.rs
@@ -1,12 +1,15 @@
 use std::fmt::Display;
-use std::collections::HashMap;
 
+use crate::github::GithubApiWrapper;
 use crate::PlaidFunctionError;
 
 /// Get a user's ID from their username
 /// ## Arguments
 /// * `username` - The GitHub username.
-pub fn get_user_id_from_username(username: impl Display) -> Result<String, PlaidFunctionError> {
+pub fn get_user_id_from_username(
+    client_id: impl Display,
+    username: impl Display,
+) -> Result<String, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, get_user_id_from_username);
     }
@@ -14,12 +17,16 @@ pub fn get_user_id_from_username(username: impl Display) -> Result<String, Plaid
     const RETURN_BUFFER_SIZE: usize = 64 * 1024; // 64 KiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
-    let username = username.to_string();
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: username.to_string(),
+    };
+    let params = serde_json::to_string(&wrapped).unwrap();
 
     let res = unsafe {
         github_get_user_id_from_username(
-            username.as_bytes().as_ptr(),
-            username.as_bytes().len(),
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
             return_buffer.as_mut_ptr(),
             RETURN_BUFFER_SIZE,
         )
@@ -40,7 +47,10 @@ pub fn get_user_id_from_username(username: impl Display) -> Result<String, Plaid
 /// Get a username from a user ID
 /// ## Arguments
 /// * `user_id` - The GitHub user ID.
-pub fn get_username_from_user_id(user_id: impl Display) -> Result<String, PlaidFunctionError> {
+pub fn get_username_from_user_id(
+    client_id: impl Display,
+    user_id: impl Display,
+) -> Result<String, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, get_username_from_user_id);
     }
@@ -50,10 +60,16 @@ pub fn get_username_from_user_id(user_id: impl Display) -> Result<String, PlaidF
 
     let user_id = user_id.to_string();
 
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: user_id,
+    };
+    let params = serde_json::to_string(&wrapped).unwrap();
+
     let res = unsafe {
         github_get_username_from_user_id(
-            user_id.as_bytes().as_ptr(),
-            user_id.as_bytes().len(),
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
             return_buffer.as_mut_ptr(),
             RETURN_BUFFER_SIZE,
         )
@@ -71,23 +87,36 @@ pub fn get_username_from_user_id(user_id: impl Display) -> Result<String, PlaidF
     Ok(String::from_utf8(return_buffer).unwrap())
 }
 
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct RemoveOutsideCollaboratorParams {
+    pub user: String,
+    pub org: String,
+}
+
 /// Remove an outside collaborator from an org
 /// ## Arguments
 ///
 /// * `user` - The outside collaborator to remove from the org
 /// * `org` - The GitHub organization to remove the user from
 pub fn remove_outside_collaborator_from_org(
+    client_id: impl Display,
     user: impl Display,
     org: impl Display,
 ) -> Result<i32, PlaidFunctionError> {
     extern "C" {
         new_host_function!(github, remove_outside_collaborator_from_org);
     }
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("user", user.to_string());
-    params.insert("org", org.to_string());
 
-    let request = serde_json::to_string(&params).unwrap();
+    let params = RemoveOutsideCollaboratorParams {
+        user: user.to_string(),
+        org: org.to_string(),
+    };
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let request = serde_json::to_string(&wrapped).unwrap();
 
     let res = unsafe {
         github_remove_outside_collaborator_from_org(

--- a/runtime/plaid-stl/src/github/org.rs
+++ b/runtime/plaid-stl/src/github/org.rs
@@ -1,6 +1,12 @@
-use std::{collections::HashMap, fmt::Display};
+use std::fmt::Display;
 
-use crate::PlaidFunctionError;
+use crate::{github::GithubApiWrapper, PlaidFunctionError};
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct CheckOrgMembershipParams {
+    pub user: String,
+    pub org: String,
+}
 
 /// Check whether a user belongs to an org
 /// ## Arguments
@@ -8,17 +14,22 @@ use crate::PlaidFunctionError;
 /// * `user` - The account to check org membership of
 /// * `org` - The org to check if `user` is part of
 pub fn check_org_membership_of_user(
+    client_id: impl Display,
     user: impl Display,
     org: impl Display,
 ) -> Result<bool, PlaidFunctionError> {
     extern "C" {
         new_host_function!(github, check_org_membership_of_user);
     }
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("user", user.to_string());
-    params.insert("org", org.to_string());
-
-    let request = serde_json::to_string(&params).unwrap();
+    let params = CheckOrgMembershipParams {
+        user: user.to_string(),
+        org: org.to_string(),
+    };
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+    let request = serde_json::to_string(&wrapped).unwrap();
 
     let res = unsafe {
         github_check_org_membership_of_user(request.as_bytes().as_ptr(), request.as_bytes().len())

--- a/runtime/plaid-stl/src/github/protection.rs
+++ b/runtime/plaid-stl/src/github/protection.rs
@@ -1,9 +1,18 @@
-use std::{collections::HashMap, fmt::Display};
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
 
 use crate::{
-    github::{CheckCodeownersParams, CodeownersStatus},
+    github::{CheckCodeownersParams, CodeownersStatus, ConfigureSecretParams, GithubApiWrapper},
     PlaidFunctionError,
 };
+
+#[derive(Serialize, Deserialize)]
+pub struct GetBranchProtectionRulesParams {
+    pub owner: String,
+    pub repo: String,
+    pub branch: String,
+}
 
 /// Get protection rules for a branch
 /// ## Arguments
@@ -12,6 +21,7 @@ use crate::{
 /// * `repo` - The name of the repository without the .git extension. The name is not case sensitive.
 /// * `branch` - The name of the branch. Cannot contain wildcard characters.
 pub fn get_branch_protection_rules(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
     branch: impl Display,
@@ -19,12 +29,18 @@ pub fn get_branch_protection_rules(
     extern "C" {
         new_host_function_with_error_buffer!(github, get_branch_protection_rules);
     }
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("owner", owner.to_string());
-    params.insert("repo", repo.to_string());
-    params.insert("branch", branch.to_string());
+    let params = GetBranchProtectionRulesParams {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        branch: branch.to_string(),
+    };
 
-    let request = serde_json::to_string(&params).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let request = serde_json::to_string(&wrapper).unwrap();
 
     const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
@@ -48,6 +64,13 @@ pub fn get_branch_protection_rules(
     Ok(String::from_utf8(return_buffer).unwrap())
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct GetBranchProtectionRulesetParams {
+    pub owner: String,
+    pub repo: String,
+    pub branch: String,
+}
+
 /// Get protection rules (as in ruleset) for a branch
 /// ## Arguments
 ///
@@ -55,6 +78,7 @@ pub fn get_branch_protection_rules(
 /// * `repo` - The name of the repository without the .git extension. The name is not case sensitive.
 /// * `branch` - The name of the branch. Cannot contain wildcard characters.
 pub fn get_branch_protection_ruleset(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
     branch: impl Display,
@@ -62,12 +86,19 @@ pub fn get_branch_protection_ruleset(
     extern "C" {
         new_host_function_with_error_buffer!(github, get_branch_protection_ruleset);
     }
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("owner", owner.to_string());
-    params.insert("repo", repo.to_string());
-    params.insert("branch", branch.to_string());
 
-    let request = serde_json::to_string(&params).unwrap();
+    let params = GetBranchProtectionRulesetParams {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        branch: branch.to_string(),
+    };
+
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let request = serde_json::to_string(&wrapper).unwrap();
 
     const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
@@ -91,6 +122,14 @@ pub fn get_branch_protection_ruleset(
     Ok(String::from_utf8(return_buffer).unwrap())
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct UpdateBranchProtectionRuleParams {
+    pub owner: String,
+    pub repo: String,
+    pub branch: String,
+    pub body: String,
+}
+
 /// Update branch protection rule for a single branch
 /// ## Arguments
 ///
@@ -99,6 +138,7 @@ pub fn get_branch_protection_ruleset(
 /// * `branch` - The name of the branch. Cannot contain wildcard characters.
 /// * `body` - Body of the PUT request. See https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#update-branch-protection
 pub fn update_branch_protection_rule(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
     branch: impl Display,
@@ -107,13 +147,20 @@ pub fn update_branch_protection_rule(
     extern "C" {
         new_host_function!(github, update_branch_protection_rule);
     }
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("owner", owner.to_string());
-    params.insert("repo", repo.to_string());
-    params.insert("branch", branch.to_string());
-    params.insert("body", body.to_string());
 
-    let request = serde_json::to_string(&params).unwrap();
+    let params = UpdateBranchProtectionRuleParams {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        branch: branch.to_string(),
+        body: body.to_string(),
+    };
+
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let request = serde_json::to_string(&wrapper).unwrap();
 
     let res = unsafe {
         github_update_branch_protection_rule(request.as_bytes().as_ptr(), request.as_bytes().len())
@@ -128,6 +175,13 @@ pub fn update_branch_protection_rule(
     Ok(())
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct CreateEnvironmentForRepoParams {
+    pub owner: String,
+    pub repo: String,
+    pub env_name: String,
+}
+
 /// Create a GitHub deployment environment for a given repository.
 ///
 /// Arguments:
@@ -135,6 +189,7 @@ pub fn update_branch_protection_rule(
 /// * `repo` - The name of the repository
 /// * `env_name` - The name of the environment to be created
 pub fn create_environment_for_repo(
+    client_id: impl Display,
     owner: &str,
     repo: &str,
     env_name: &str,
@@ -143,13 +198,19 @@ pub fn create_environment_for_repo(
         new_host_function!(github, create_environment_for_repo);
     }
 
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("owner", owner.to_string());
-    params.insert("repo", repo.to_string());
-    params.insert("env_name", env_name.to_string());
+    let params = CreateEnvironmentForRepoParams {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        env_name: env_name.to_string(),
+    };
+
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
 
     let request =
-        serde_json::to_string(&params).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+        serde_json::to_string(&wrapper).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
 
     let res = unsafe {
         github_create_environment_for_repo(request.as_bytes().as_ptr(), request.as_bytes().len())
@@ -161,6 +222,14 @@ pub fn create_environment_for_repo(
     }
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct CreateDeploymentBranchProtectionRuleParams {
+    pub owner: String,
+    pub repo: String,
+    pub env_name: String,
+    pub branch: String,
+}
+
 /// Create a deployment branch protection rule for a GitHub environment.
 ///
 /// Arguments:
@@ -169,6 +238,7 @@ pub fn create_environment_for_repo(
 /// * `env_name` - The name of the environment to be created
 /// * `branch` - The branch from which a deployment can be triggered. This will be set in the deployment protection rules
 pub fn create_deployment_branch_protection_rule(
+    client_id: impl Display,
     owner: &str,
     repo: &str,
     env_name: &str,
@@ -178,14 +248,20 @@ pub fn create_deployment_branch_protection_rule(
         new_host_function!(github, create_deployment_branch_protection_rule);
     }
 
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("owner", owner.to_string());
-    params.insert("repo", repo.to_string());
-    params.insert("env_name", env_name.to_string());
-    params.insert("branch", branch.to_string());
+    let params = CreateDeploymentBranchProtectionRuleParams {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        env_name: env_name.to_string(),
+        branch: branch.to_string(),
+    };
+
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
 
     let request =
-        serde_json::to_string(&params).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+        serde_json::to_string(&wrapper).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
 
     let res = unsafe {
         github_create_deployment_branch_protection_rule(
@@ -200,9 +276,18 @@ pub fn create_deployment_branch_protection_rule(
     }
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct RequireSignedCommitsParams {
+    pub owner: String,
+    pub repo: String,
+    pub branch: String,
+    pub activated: bool,
+}
+
 /// Enforce signed commits (if `activated` is true) or turn it off (if `activated` is false) on a given branch of a given repo.
 /// For more details, see https://docs.github.com/en/enterprise-cloud@latest/rest/branches/branch-protection?apiVersion=2022-11-28#create-commit-signature-protection
 pub fn require_signed_commits(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
     branch: impl Display,
@@ -212,20 +297,19 @@ pub fn require_signed_commits(
         new_host_function!(github, require_signed_commits);
     }
 
-    let mut params: HashMap<&'static str, String> = HashMap::new();
-    params.insert("owner", owner.to_string());
-    params.insert("repo", repo.to_string());
-    params.insert("branch", branch.to_string());
-    params.insert(
-        "activated",
-        if activated {
-            "true".to_string()
-        } else {
-            "false".to_string()
-        },
-    );
+    let params = RequireSignedCommitsParams {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        branch: branch.to_string(),
+        activated,
+    };
 
-    let params = serde_json::to_string(&params).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let params = serde_json::to_string(&wrapper).unwrap();
     let res = unsafe {
         github_require_signed_commits(params.as_bytes().as_ptr(), params.as_bytes().len())
     };
@@ -248,6 +332,7 @@ pub fn require_signed_commits(
 /// * `secret_name` - The name of the secret to set
 /// * `secret` - The plaintext secret to be set
 pub fn configure_secret(
+    client_id: impl Display,
     owner: &str,
     repo: &str,
     env_name: Option<&str>,
@@ -258,17 +343,21 @@ pub fn configure_secret(
         new_host_function!(github, configure_secret);
     }
 
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("owner", owner.to_string());
-    params.insert("repo", repo.to_string());
-    if let Some(env_name) = env_name {
-        params.insert("env_name", env_name.to_string());
-    }
-    params.insert("secret_name", secret_name.to_string());
-    params.insert("secret", secret.to_string());
+    let params = ConfigureSecretParams {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        env_name: env_name.map(|s| s.to_string()),
+        secret_name: secret_name.to_string(),
+        secret: secret.to_string(),
+    };
+
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
 
     let request =
-        serde_json::to_string(&params).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+        serde_json::to_string(&wrapped).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
 
     let res =
         unsafe { github_configure_secret(request.as_bytes().as_ptr(), request.as_bytes().len()) };
@@ -282,6 +371,7 @@ pub fn configure_secret(
 /// Check a repo's CODEOWNERS file
 /// For more details, see https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-codeowners-errors
 pub fn check_codeowners_file(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
 ) -> Result<CodeownersStatus, PlaidFunctionError> {
@@ -296,8 +386,12 @@ pub fn check_codeowners_file(
         owner: owner.to_string(),
         repo: repo.to_string(),
     };
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
 
-    let params = serde_json::to_string(&params).unwrap();
+    let params = serde_json::to_string(&wrapper).unwrap();
     let res = unsafe {
         github_check_codeowners_file(
             params.as_bytes().as_ptr(),

--- a/runtime/plaid-stl/src/github/pull_request.rs
+++ b/runtime/plaid-stl/src/github/pull_request.rs
@@ -3,11 +3,20 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    github::{CommentOnPullRequestRequest, PullRequestRequestReviewers},
+    github::{CommentOnPullRequestRequest, GithubApiWrapper, PullRequestRequestReviewers},
     PlaidFunctionError,
 };
 
+#[derive(Serialize, Deserialize)]
+pub struct ListFilesParams {
+    pub owner: String,
+    pub repo: String,
+    pub pull_request: String,
+    pub page: String,
+}
+
 pub fn list_files(
+    client_id: impl Display,
     organization: &str,
     repository_name: &str,
     pull_request: &str,
@@ -18,22 +27,18 @@ pub fn list_files(
     }
     const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
 
-    #[derive(Serialize)]
-    struct Request<'a> {
-        organization: &'a str,
-        repository_name: &'a str,
-        pull_request: &'a str,
-        page: &'a str,
-    }
-
-    let request = Request {
-        organization,
-        repository_name,
-        pull_request,
-        page,
+    let request = ListFilesParams {
+        owner: organization.to_string(),
+        repo: repository_name.to_string(),
+        pull_request: pull_request.to_string(),
+        page: page.to_string(),
+    };
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: request,
     };
 
-    let request = serde_json::to_string(&request).unwrap();
+    let request = serde_json::to_string(&wrapped).unwrap();
 
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
@@ -59,6 +64,7 @@ pub fn list_files(
 }
 
 pub fn comment_on_pull_request(
+    client_id: impl Display,
     username: impl Display,
     repository_name: impl Display,
     pull_request: impl Display,
@@ -75,7 +81,12 @@ pub fn comment_on_pull_request(
         comment: comment.to_string(),
     };
 
-    let request = serde_json::to_string(&request).unwrap();
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: request,
+    };
+
+    let request = serde_json::to_string(&wrapped).unwrap();
 
     let res = unsafe {
         github_comment_on_pull_request(request.as_bytes().as_ptr(), request.as_bytes().len())
@@ -91,6 +102,7 @@ pub fn comment_on_pull_request(
 /// Request a reviewer on a PR
 /// For more details, see https://docs.github.com/en/rest/pulls/review-requests?apiVersion=2022-11-28#request-reviewers-for-a-pull-request
 pub fn pull_request_request_reviewers(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
     pull_request: u64,
@@ -109,7 +121,12 @@ pub fn pull_request_request_reviewers(
         team_reviewers: team_reviewers.iter().map(|s| s.to_string()).collect(),
     };
 
-    let params = serde_json::to_string(&params).unwrap();
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let params = serde_json::to_string(&wrapped).unwrap();
     let res = unsafe {
         github_pull_request_request_reviewers(params.as_bytes().as_ptr(), params.as_bytes().len())
     };
@@ -128,7 +145,7 @@ pub fn pull_request_request_reviewers(
 /// Represents the top-level parameters needed to query pull requests
 /// for a given repository, including the repository owner, name, and
 /// optional filter options.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct GetPullRequestRequest {
     /// Owner of the repository (e.g., GitHub username or org).
     pub owner: String,
@@ -146,7 +163,7 @@ pub struct GetPullRequestRequest {
 ///
 /// Each field is optional; if none are provided, the request will
 /// return all pull requests for the repository.
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 pub struct GetPullRequestOptions {
     /// Filter pull requests by state (`open`, `closed`, or `all`).
     ///
@@ -241,7 +258,7 @@ impl GetPullRequestOptionsBuilder {
 }
 
 /// Possible states of a pull request.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub enum PullRequestState {
     /// Only open pull requests.
     Open,
@@ -368,6 +385,7 @@ pub struct CreatePullRequestRequest {
 /// - `Ok(Vec<PullRequest>)` with all matching pull requests, or
 /// - `Err(PlaidFunctionError)` if the request fails.
 pub fn get_pull_requests(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
     options: Option<GetPullRequestOptions>,
@@ -389,7 +407,11 @@ pub fn get_pull_requests(
     let mut prs = Vec::<PullRequest>::new();
 
     loop {
-        let request = serde_json::to_string(&request_base).unwrap();
+        let wrapped = GithubApiWrapper {
+            client_id: client_id.to_string(),
+            params: request_base.clone(),
+        };
+        let request = serde_json::to_string(&wrapped).unwrap();
 
         let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
         let res = unsafe {
@@ -452,6 +474,7 @@ pub fn get_pull_requests(
 /// - `Err(PlaidFunctionError)` if the request fails (e.g., invalid branches,
 ///   missing permissions, or Plaid system misconfiguration).
 pub fn create_pull_request(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
     title: impl Display,
@@ -474,7 +497,12 @@ pub fn create_pull_request(
         draft,
     };
 
-    let request = serde_json::to_string(&request).unwrap();
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: request,
+    };
+
+    let request = serde_json::to_string(&wrapped).unwrap();
 
     const RETURN_BUFFER_SIZE: usize = 1024 * 1024 * 5; // 5 MiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
@@ -530,6 +558,7 @@ pub struct AddLabelsRequest {
 /// - `Ok(())` if the labels were successfully added, or
 /// - `Err(PlaidFunctionError)` if the request fails.
 pub fn add_labels(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
     number: u32,
@@ -546,7 +575,12 @@ pub fn add_labels(
         labels: labels.into_iter().map(|s| s.to_string()).collect(),
     };
 
-    let params = serde_json::to_string(&params).unwrap();
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let params = serde_json::to_string(&wrapped).unwrap();
     let res = unsafe { github_add_labels(params.as_bytes().as_ptr(), params.as_bytes().len()) };
 
     // There was an error with the Plaid system. Maybe the API is not

--- a/runtime/plaid-stl/src/github/reference.rs
+++ b/runtime/plaid-stl/src/github/reference.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use crate::{
-    github::{GetOrCreateBranchReferenceParams, GitApiRef, GitRef},
+    github::{GetOrCreateBranchReferenceParams, GitApiRef, GitRef, GithubApiWrapper},
     PlaidFunctionError,
 };
 
@@ -27,6 +27,7 @@ use crate::{
 /// - `Ok(None)` if the reference does not exist.
 /// - `Err(PlaidFunctionError)` if the request fails.
 pub fn get_reference(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
     reference: GitRef,
@@ -42,7 +43,12 @@ pub fn get_reference(
         sha: None,
     };
 
-    let request = serde_json::to_string(&request).unwrap();
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: request,
+    };
+
+    let request = serde_json::to_string(&wrapped).unwrap();
     const RETURN_BUFFER_SIZE: usize = 1024 * 10; // 10 KiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
@@ -100,6 +106,7 @@ pub fn get_reference(
 /// - `Ok(())` if the reference was created successfully.
 /// - `Err(PlaidFunctionError)` if the request fails.
 pub fn create_reference(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
     reference: GitRef,
@@ -116,7 +123,12 @@ pub fn create_reference(
         sha: Some(sha.to_string()),
     };
 
-    let params = serde_json::to_string(&request).unwrap();
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: request,
+    };
+
+    let params = serde_json::to_string(&wrapped).unwrap();
     let res =
         unsafe { github_create_reference(params.as_bytes().as_ptr(), params.as_bytes().len()) };
 

--- a/runtime/plaid-stl/src/github/repo.rs
+++ b/runtime/plaid-stl/src/github/repo.rs
@@ -1,18 +1,24 @@
-use std::{collections::HashMap, fmt::Display};
+use std::fmt::Display;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     github::{
         CreateFileRequest, DeleteDeployKeyParams, FetchFileCustomMediaType, FetchFileRequest,
-        RepositoryCollaborator, RepositoryCustomProperty, SbomResponse,
+        GithubApiWrapper, RepositoryCollaborator, RepositoryCustomProperty, SbomResponse,
     },
     PlaidFunctionError,
 };
 
+#[derive(Deserialize, Serialize)]
+pub struct RemoveUserFromRepoParams {
+    pub user: String,
+    pub repo: String,
+}
+
 // TODO: Do not use this function, it is deprecated and will be removed soon
-pub fn remove_user_from_repo(repo: &str, user: &str) -> Result<(), i32> {
-    remove_user_from_repo_detailed(repo, user).map_err(|_| -4)
+pub fn remove_user_from_repo(client_id: impl Display, repo: &str, user: &str) -> Result<(), i32> {
+    remove_user_from_repo_detailed(client_id, repo, user).map_err(|_| -4)
 }
 
 /// Remove a user from a repo
@@ -20,16 +26,26 @@ pub fn remove_user_from_repo(repo: &str, user: &str) -> Result<(), i32> {
 ///
 /// * `repo` - The repo to remove the user from
 /// * `user` - The user to remove from `repo`
-pub fn remove_user_from_repo_detailed(repo: &str, user: &str) -> Result<(), PlaidFunctionError> {
+pub fn remove_user_from_repo_detailed(
+    client_id: impl Display,
+    repo: &str,
+    user: &str,
+) -> Result<(), PlaidFunctionError> {
     extern "C" {
         new_host_function!(github, remove_user_from_repo);
     }
 
-    let mut params: HashMap<&'static str, &str> = HashMap::new();
-    params.insert("user", user);
-    params.insert("repo", repo);
+    let params = RemoveUserFromRepoParams {
+        user: user.to_string(),
+        repo: repo.to_string(),
+    };
 
-    let params = serde_json::to_string(&params).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let params = serde_json::to_string(&wrapper).unwrap();
     let res = unsafe {
         github_remove_user_from_repo(params.as_bytes().as_ptr(), params.as_bytes().len())
     };
@@ -43,9 +59,21 @@ pub fn remove_user_from_repo_detailed(repo: &str, user: &str) -> Result<(), Plai
     Ok(())
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct AddUserToRepoParams {
+    pub user: String,
+    pub repo: String,
+    pub permission: Option<String>,
+}
+
 /// TODO: Do not use this function, it is deprecated and will be removed soon
-pub fn add_user_to_repo(repo: &str, user: &str, permission: Option<&str>) -> Result<(), i32> {
-    add_user_to_repo_detailed(repo, user, permission).map_err(|_| -4)
+pub fn add_user_to_repo(
+    client_id: impl Display,
+    repo: &str,
+    user: &str,
+    permission: Option<&str>,
+) -> Result<(), i32> {
+    add_user_to_repo_detailed(client_id, repo, user, permission).map_err(|_| -4)
 }
 
 /// Add a user to a repo
@@ -54,6 +82,7 @@ pub fn add_user_to_repo(repo: &str, user: &str, permission: Option<&str>) -> Res
 /// * `repo` - The repo to add the user to
 /// * `user` - The user to add to `repo`
 pub fn add_user_to_repo_detailed(
+    client_id: impl Display,
     repo: &str,
     user: &str,
     permission: Option<&str>,
@@ -62,14 +91,18 @@ pub fn add_user_to_repo_detailed(
         new_host_function!(github, add_user_to_repo);
     }
 
-    let mut params: HashMap<&'static str, &str> = HashMap::new();
-    params.insert("user", user);
-    params.insert("repo", repo);
-    if let Some(permission) = permission {
-        params.insert("permission", permission);
-    }
+    let params = AddUserToRepoParams {
+        user: user.to_string(),
+        repo: repo.to_string(),
+        permission: permission.map(|p| p.to_string()),
+    };
 
-    let params = serde_json::to_string(&params).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let params = serde_json::to_string(&wrapper).unwrap();
     let res =
         unsafe { github_add_user_to_repo(params.as_bytes().as_ptr(), params.as_bytes().len()) };
 
@@ -82,6 +115,15 @@ pub fn add_user_to_repo_detailed(
     Ok(())
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct GetRepoCollaboratorsParams {
+    pub owner: String,
+    pub repo: String,
+    pub per_page: Option<u8>,
+    pub page: Option<u16>,
+    pub affiliation: Option<String>,
+}
+
 /// DEPRECATED - DO NOT USE. Instead, use get_all_repository_collaborators
 /// Get first 30 collaborators on a repository
 /// ## Arguments
@@ -89,17 +131,27 @@ pub fn add_user_to_repo_detailed(
 /// * `owner` - The account owner of the repository. The name is not case sensitive.
 /// * `repo` - The name of the repository without the .git extension. The name is not case sensitive.
 pub fn get_repository_collaborators(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
 ) -> Result<String, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, get_repository_collaborators);
     }
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("owner", owner.to_string());
-    params.insert("repo", repo.to_string());
+    let params = GetRepoCollaboratorsParams {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        per_page: None,
+        page: None,
+        affiliation: None,
+    };
 
-    let request = serde_json::to_string(&params).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let request = serde_json::to_string(&wrapper).unwrap();
 
     const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
@@ -129,34 +181,31 @@ pub fn get_repository_collaborators(
 /// * `owner` - The account owner of the repository. The name is not case sensitive.
 /// * `repo` - The name of the repository without the .git extension. The name is not case sensitive.
 pub fn get_all_repository_collaborators(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
 ) -> Result<Vec<RepositoryCollaborator>, PlaidFunctionError> {
-    get_all_repository_collaborators_detailed(owner, repo, None)
+    get_all_repository_collaborators_detailed(client_id, owner, repo, None)
 }
 
 /// Get all collaborators on a repository with direct access.
 pub fn get_all_repository_collaborators_direct_access(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
 ) -> Result<Vec<RepositoryCollaborator>, PlaidFunctionError> {
-    get_all_repository_collaborators_detailed(owner, repo, Some("direct"))
+    get_all_repository_collaborators_detailed(client_id, owner, repo, Some("direct"))
 }
 
 /// Get all collaborators on a repository with affiliation filter.
 pub fn get_all_repository_collaborators_detailed(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
     affiliation: Option<&str>,
 ) -> Result<Vec<RepositoryCollaborator>, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, get_repository_collaborators);
-    }
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("owner", owner.to_string());
-    params.insert("repo", repo.to_string());
-    if let Some(affiliation) = affiliation {
-        params.insert("affiliation", affiliation.to_string());
     }
 
     let mut collaborators = Vec::<RepositoryCollaborator>::new();
@@ -166,10 +215,21 @@ pub fn get_all_repository_collaborators_detailed(
 
     loop {
         page += 1;
-        params.insert("page", page.to_string());
-        // params.insert("per_page", "30".to_owned()"); // Default: 30 items per page
 
-        let request = serde_json::to_string(&params).unwrap();
+        let params = GetRepoCollaboratorsParams {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            per_page: None,
+            page: Some(page),
+            affiliation: affiliation.map(|a| a.to_string()),
+        };
+
+        let wrapper = GithubApiWrapper {
+            client_id: client_id.to_string(),
+            params,
+        };
+
+        let request = serde_json::to_string(&wrapper).unwrap();
 
         let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
@@ -202,23 +262,35 @@ pub fn get_all_repository_collaborators_detailed(
     Ok(collaborators)
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct GetCustomPropertiesValuesParams {
+    pub owner: String,
+    pub repo: String,
+}
+
 /// Get custom properties for a repository
 /// ## Arguments
 ///
 /// * `owner` - The account owner of the repository. The name is not case sensitive.
 /// * `repo` - The name of the repository without the .git extension. The name is not case sensitive.
 pub fn get_custom_properties_values(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
 ) -> Result<Vec<RepositoryCustomProperty>, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, get_custom_properties_values);
     }
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("owner", owner.to_string());
-    params.insert("repo", repo.to_string());
 
-    let request = serde_json::to_string(&params).unwrap();
+    let params = GetCustomPropertiesValuesParams {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+    };
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+    let request = serde_json::to_string(&wrapper).unwrap();
 
     const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
@@ -247,19 +319,32 @@ pub fn get_custom_properties_values(
     Ok(response_body)
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct GetRepoSbomParams {
+    pub owner: String,
+    pub repo: String,
+}
+
 /// Get the software bill of materials (SBOM) for a repository in SPDX JSON format.
 pub fn get_repo_sbom(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
 ) -> Result<SbomResponse, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, get_repo_sbom);
     }
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("owner", owner.to_string());
-    params.insert("repo", repo.to_string());
 
-    let request = serde_json::to_string(&params).unwrap();
+    let params = GetRepoSbomParams {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+    };
+
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+    let request = serde_json::to_string(&wrapper).unwrap();
 
     const RETURN_BUFFER_SIZE: usize = 5 * 1024 * 1024; // 5 MiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
@@ -292,12 +377,14 @@ pub fn get_repo_sbom(
 /// * `file_path`: Path of the file or directory to read
 /// * `reference`: The name of the commit/branch/tag
 pub fn fetch_file(
+    client_id: impl Display,
     organization: &str,
     repository_name: &str,
     file_path: &str,
     reference: &str,
 ) -> Result<String, PlaidFunctionError> {
     fetch_file_with_custom_media_type(
+        client_id,
         organization,
         repository_name,
         file_path,
@@ -315,6 +402,7 @@ pub fn fetch_file(
 /// * `reference`: The name of the commit/branch/tag
 /// * `media_type`: The media type to fetch
 pub fn fetch_file_with_custom_media_type(
+    client_id: impl Display,
     organization: &str,
     repository_name: &str,
     file_path: &str,
@@ -333,7 +421,11 @@ pub fn fetch_file_with_custom_media_type(
         reference: reference.to_string(),
         media_type,
     };
-    let request = serde_json::to_string(&request).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: request,
+    };
+    let request = serde_json::to_string(&wrapper).unwrap();
 
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
@@ -358,28 +450,40 @@ pub fn fetch_file_with_custom_media_type(
     Ok(String::from_utf8(return_buffer).unwrap())
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct FetchCommitParams {
+    pub user: String,
+    pub repo: String,
+    pub commit: String,
+}
+
 /// Returns the contents of a single commit reference
 /// ## Arguments
 ///
 /// * `user` - The account owner of the repository. The name is not case sensitive.
 /// * `repo` - The name of the repository without the .git extension. The name is not case sensitive.
 /// * `commit` - The commit reference. Can be a commit SHA, branch name (heads/BRANCH_NAME), or tag name (tags/TAG_NAME)
-pub fn fetch_commit(user: &str, repo: &str, commit: &str) -> Result<String, PlaidFunctionError> {
+pub fn fetch_commit(
+    client_id: impl Display,
+    user: &str,
+    repo: &str,
+    commit: &str,
+) -> Result<String, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, fetch_commit);
     }
     const RETURN_BUFFER_SIZE: usize = 5 * 1024 * 1024; // 5 MiB
 
-    #[derive(Serialize)]
-    struct Request<'a> {
-        user: &'a str,
-        repo: &'a str,
-        commit: &'a str,
-    }
-
-    let request = Request { user, repo, commit };
-
-    let request = serde_json::to_string(&request).unwrap();
+    let params = FetchCommitParams {
+        user: user.to_string(),
+        repo: repo.to_string(),
+        commit: commit.to_string(),
+    };
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+    let request = serde_json::to_string(&wrapper).unwrap();
 
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
@@ -407,6 +511,7 @@ pub fn fetch_commit(user: &str, repo: &str, commit: &str) -> Result<String, Plai
 /// Delete a deploy key with given ID from a given repository.
 /// For more details, see https://docs.github.com/en/rest/deploy-keys/deploy-keys?apiVersion=2022-11-28#delete-a-deploy-key
 pub fn delete_deploy_key(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
     key_id: u64,
@@ -421,7 +526,12 @@ pub fn delete_deploy_key(
         key_id,
     };
 
-    let params = serde_json::to_string(&params).unwrap();
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let params = serde_json::to_string(&wrapped).unwrap();
     let res =
         unsafe { github_delete_deploy_key(params.as_bytes().as_ptr(), params.as_bytes().len()) };
 
@@ -461,6 +571,7 @@ pub fn delete_deploy_key(
 /// - `Err(PlaidFunctionError)` if the request fails (e.g., file already exists,
 ///   branch protection, missing configuration).
 pub fn create_file(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
     path: impl Display,
@@ -481,7 +592,12 @@ pub fn create_file(
         branch: branch.map(|b| b.to_string()),
     };
 
-    let request = serde_json::to_string(&request).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: request,
+    };
+
+    let request = serde_json::to_string(&wrapper).unwrap();
     const RETURN_BUFFER_SIZE: usize = 1024; // 1 KiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
@@ -510,11 +626,18 @@ pub fn create_file(
     Ok(response_body)
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct GetRepoIdFromRepoNameParams {
+    pub owner: String,
+    pub repo: String,
+}
+
 /// Get a repo ID from its name
 /// ## Arguments
 /// * `owner` - The owner of the repo.
 /// * `repo` - The name of the repo without the owner.
 pub fn get_repo_id_from_repo_name(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
 ) -> Result<i64, PlaidFunctionError> {
@@ -525,12 +648,17 @@ pub fn get_repo_id_from_repo_name(
     const RETURN_BUFFER_SIZE: usize = 32;
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
-    let mut params: HashMap<&'static str, &str> = HashMap::new();
-    let owner = owner.to_string();
-    let repo = repo.to_string();
-    params.insert("owner", &owner);
-    params.insert("repo", &repo);
-    let params = serde_json::to_string(&params).unwrap();
+    let params = GetRepoIdFromRepoNameParams {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+    };
+
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let params = serde_json::to_string(&wrapper).unwrap();
 
     let res = unsafe {
         github_get_repo_id_from_repo_name(
@@ -555,10 +683,18 @@ pub fn get_repo_id_from_repo_name(
     Ok(response)
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct GetRepoNameFromRepoIdParams {
+    pub repo_id: String,
+}
+
 /// Get a repo_name from a repo ID
 /// ## Arguments
 /// * `repo_id` - The GitHub repo ID.
-pub fn get_repo_name_from_repo_id(repo_id: impl Display) -> Result<String, PlaidFunctionError> {
+pub fn get_repo_name_from_repo_id(
+    client_id: impl Display,
+    repo_id: impl Display,
+) -> Result<String, PlaidFunctionError> {
     extern "C" {
         new_host_function_with_error_buffer!(github, get_repo_name_from_repo_id);
     }
@@ -566,12 +702,21 @@ pub fn get_repo_name_from_repo_id(repo_id: impl Display) -> Result<String, Plaid
     const RETURN_BUFFER_SIZE: usize = 64 * 1024; // 64 KiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
-    let repo_id = repo_id.to_string();
+    let params = GetRepoNameFromRepoIdParams {
+        repo_id: repo_id.to_string(),
+    };
+
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let params = serde_json::to_string(&wrapper).unwrap();
 
     let res = unsafe {
         github_get_repo_name_from_repo_id(
-            repo_id.as_bytes().as_ptr(),
-            repo_id.as_bytes().len(),
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
             return_buffer.as_mut_ptr(),
             RETURN_BUFFER_SIZE,
         )

--- a/runtime/plaid-stl/src/github/repo.rs
+++ b/runtime/plaid-stl/src/github/repo.rs
@@ -16,7 +16,9 @@ pub struct RemoveUserFromRepoParams {
     pub repo: String,
 }
 
-// TODO: Do not use this function, it is deprecated and will be removed soon
+#[deprecated(
+    note = "This function is deprecated and will be removed soon. Please use remove_user_from_repo_detailed instead."
+)]
 pub fn remove_user_from_repo(client_id: impl Display, repo: &str, user: &str) -> Result<(), i32> {
     remove_user_from_repo_detailed(client_id, repo, user).map_err(|_| -4)
 }
@@ -66,7 +68,9 @@ pub struct AddUserToRepoParams {
     pub permission: Option<String>,
 }
 
-/// TODO: Do not use this function, it is deprecated and will be removed soon
+#[deprecated(
+    note = "This function is deprecated and will be removed soon. Please use add_user_to_repo_detailed instead."
+)]
 pub fn add_user_to_repo(
     client_id: impl Display,
     repo: &str,
@@ -130,6 +134,9 @@ pub struct GetRepoCollaboratorsParams {
 ///
 /// * `owner` - The account owner of the repository. The name is not case sensitive.
 /// * `repo` - The name of the repository without the .git extension. The name is not case sensitive.
+#[deprecated(
+    note = "This function is deprecated and will be removed soon. Please use get_all_repository_collaborators instead."
+)]
 pub fn get_repository_collaborators(
     client_id: impl Display,
     owner: impl Display,

--- a/runtime/plaid-stl/src/github/search.rs
+++ b/runtime/plaid-stl/src/github/search.rs
@@ -67,6 +67,7 @@ pub fn search_code(
             // * Those that have to be (or are better) evaluated module-side. These are not passed to the API and
             // are processed later here.
             repo: search_criteria.and_then(|c| {
+                c.only_from_org.as_ref()?;
                 if let Some(RepoFilter::OnlyFromRepos { repos }) = &c.repo_filter {
                     if repos.len() == 1 {
                         return Some(repos[0].clone());

--- a/runtime/plaid-stl/src/github/search.rs
+++ b/runtime/plaid-stl/src/github/search.rs
@@ -1,9 +1,25 @@
-use std::{collections::HashMap, fmt::Display};
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
 
 use crate::{
-    github::{CodeSearchCriteria, FileSearchResult, FileSearchResultItem, RepoFilter},
+    github::{
+        CodeSearchCriteria, FileSearchResult, FileSearchResultItem, GithubApiWrapper, RepoFilter,
+    },
     PlaidFunctionError,
 };
+
+#[derive(Serialize, Deserialize)]
+pub struct SearchCodeParams {
+    pub file_content: Option<String>,
+    pub filename: Option<String>,
+    pub extension: Option<String>,
+    pub path: Option<String>,
+    pub org: Option<String>,
+    pub repo: Option<String>,
+    pub per_page: Option<u8>,
+    pub page: Option<u16>,
+}
 
 /// Search for code in GitHub.
 /// If additional selection criteria are given, these are used to decide whether
@@ -15,6 +31,7 @@ use crate::{
 /// - `path`: The path under which files are searched, e.g., "src"
 /// - `search_criteria`: An optional `CodeSearchCriteria` object with additional search criteria
 pub fn search_code(
+    client_id: impl Display,
     filename: Option<impl Display>,
     extension: Option<impl Display>,
     path: Option<impl Display>,
@@ -25,56 +42,48 @@ pub fn search_code(
         new_host_function_with_error_buffer!(github, search_code);
     }
 
-    let mut params: HashMap<&str, String> = HashMap::new();
-    if let Some(filename) = filename {
-        params.insert("filename", filename.to_string());
-    }
-    if let Some(extension) = extension {
-        params.insert("extension", extension.to_string());
-    }
-    if let Some(path) = path {
-        params.insert("path", path.to_string());
-    }
-    if let Some(content) = file_content {
-        params.insert("file_content", content.to_string());
-    }
-
-    // If we are given selection criteria, then we divide them between
-    //
-    // * Those that can be baked directly into the GitHub search query, thus making the overall search more
-    // efficient (because less results are returned). These are passed to the API.
-    //
-    // * Those that have to be (or are better) evaluated module-side. These are not passed to the API and
-    // are processed later here.
-
-    if let Some(criteria) = search_criteria {
-        if let Some(org) = &criteria.only_from_org {
-            // Search only inside an organization
-            params.insert("org", org.clone());
-
-            if let Some(RepoFilter::OnlyFromRepos { repos }) = &criteria.repo_filter {
-                if repos.len() == 1 {
-                    // Special case: search only in a repository
-                    params.insert("repo", repos[0].clone());
-                }
-            }
-        }
-    }
-
     let mut search_results = Vec::<FileSearchResultItem>::new();
     let mut page = 0;
 
-    // Use a larger page size to make less requests and reduce chances of hitting the rate limit
+    // Use a larger page size to make fewer requests and reduce chances of hitting the rate limit
     let per_page = 100;
-    params.insert("per_page", per_page.to_string());
 
     const RETURN_BUFFER_SIZE: usize = 1 * 1024 * 1024; // 1 MiB
 
     loop {
         page += 1;
-        params.insert("page", page.to_string());
 
-        let request = serde_json::to_string(&params).unwrap(); // safe unwrap
+        let params = SearchCodeParams {
+            filename: filename.as_ref().map(|f| f.to_string()),
+            extension: extension.as_ref().map(|e| e.to_string()),
+            path: path.as_ref().map(|p| p.to_string()),
+            file_content: file_content.as_ref().map(|c| c.to_string()),
+            org: search_criteria.and_then(|c| c.only_from_org.clone()),
+            // If we are given selection criteria, then we divide them between
+            //
+            // * Those that can be baked directly into the GitHub search query, thus making the overall search more
+            // efficient (because less results are returned). These are passed to the API.
+            //
+            // * Those that have to be (or are better) evaluated module-side. These are not passed to the API and
+            // are processed later here.
+            repo: search_criteria.and_then(|c| {
+                if let Some(RepoFilter::OnlyFromRepos { repos }) = &c.repo_filter {
+                    if repos.len() == 1 {
+                        return Some(repos[0].clone());
+                    }
+                }
+                None
+            }),
+            per_page: Some(per_page),
+            page: Some(page),
+        };
+
+        let wrapper = GithubApiWrapper {
+            client_id: client_id.to_string(),
+            params,
+        };
+
+        let request = serde_json::to_string(&wrapper).unwrap(); // safe unwrap
 
         let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
@@ -110,7 +119,7 @@ pub fn search_code(
 
         // If we did not fill this page, we know there won't be a next one.
         // So we can stop here and save one API call.
-        if received_page_size < per_page {
+        if received_page_size < per_page as usize {
             break;
         }
     }

--- a/runtime/plaid-stl/src/github/secrets.rs
+++ b/runtime/plaid-stl/src/github/secrets.rs
@@ -3,12 +3,13 @@ use std::fmt::Display;
 use serde::Deserialize;
 
 use crate::{
-    github::{AddOrRemoveRepoToOrgSecretParams, ListOrgSecretsForRepoParams},
+    github::{AddOrRemoveRepoToOrgSecretParams, GithubApiWrapper, ListOrgSecretsForRepoParams},
     PlaidFunctionError,
 };
 
 /// Add a repo to the list of repos that have access to an organization secret
 pub fn add_repo_to_org_secret(
+    client_id: impl Display,
     org: impl Display,
     repository: impl Display,
     secret_name: impl Display,
@@ -22,7 +23,13 @@ pub fn add_repo_to_org_secret(
         repository: repository.to_string(),
         secret_name: secret_name.to_string(),
     };
-    let params = serde_json::to_string(&params).unwrap();
+
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let params = serde_json::to_string(&wrapped).unwrap();
     let res = unsafe {
         github_add_repo_to_org_secret(params.as_bytes().as_ptr(), params.as_bytes().len())
     };
@@ -38,6 +45,7 @@ pub fn add_repo_to_org_secret(
 
 /// Remove a repo from the list of repos that have access to an organization secret
 pub fn remove_repo_from_org_secret(
+    client_id: impl Display,
     org: impl Display,
     repository: impl Display,
     secret_name: impl Display,
@@ -51,7 +59,12 @@ pub fn remove_repo_from_org_secret(
         repository: repository.to_string(),
         secret_name: secret_name.to_string(),
     };
-    let params = serde_json::to_string(&params).unwrap();
+
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+    let params = serde_json::to_string(&wrapped).unwrap();
     let res = unsafe {
         github_remove_repo_from_org_secret(params.as_bytes().as_ptr(), params.as_bytes().len())
     };
@@ -67,6 +80,7 @@ pub fn remove_repo_from_org_secret(
 
 /// List the organization secrets that a repository has access to
 pub fn list_org_secrets_for_repo(
+    client_id: impl Display,
     org: impl Display,
     repository: impl Display,
 ) -> Result<Vec<String>, PlaidFunctionError> {
@@ -99,7 +113,12 @@ pub fn list_org_secrets_for_repo(
             per_page: None,
             page: Some(page),
         };
-        let params = serde_json::to_string(&params).unwrap();
+
+        let wrapped = GithubApiWrapper {
+            client_id: client_id.to_string(),
+            params,
+        };
+        let params = serde_json::to_string(&wrapped).unwrap();
         let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
         let res = unsafe {
             github_list_org_secrets_for_repo(

--- a/runtime/plaid-stl/src/github/stats.rs
+++ b/runtime/plaid-stl/src/github/stats.rs
@@ -1,10 +1,22 @@
-use std::{collections::HashMap, fmt::Display};
+use std::fmt::Display;
 
-use crate::{github::WeeklyCommits, PlaidFunctionError};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    github::{GithubApiWrapper, WeeklyCommits},
+    PlaidFunctionError,
+};
+
+#[derive(Serialize, Deserialize)]
+pub struct GetWeeklyCommitCountParams {
+    pub owner: String,
+    pub repo: String,
+}
 
 /// Get the weekly commit count on a given repo.
 /// For more details, see https://docs.github.com/en/rest/metrics/statistics?apiVersion=2022-11-28#get-the-weekly-commit-count
 pub fn get_weekly_commit_count(
+    client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
 ) -> Result<WeeklyCommits, PlaidFunctionError> {
@@ -15,10 +27,16 @@ pub fn get_weekly_commit_count(
     const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
-    let mut params: HashMap<&'static str, String> = HashMap::new();
-    params.insert("owner", owner.to_string());
-    params.insert("repo", repo.to_string());
-    let params = serde_json::to_string(&params).unwrap();
+    let params = GetWeeklyCommitCountParams {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+    };
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let params = serde_json::to_string(&wrapper).unwrap();
 
     let res = unsafe {
         github_get_weekly_commit_count(

--- a/runtime/plaid-stl/src/github/team.rs
+++ b/runtime/plaid-stl/src/github/team.rs
@@ -1,10 +1,29 @@
-use std::{collections::HashMap, fmt::Display};
+use std::fmt::Display;
 
-use crate::{github::GitHubRepoTeam, PlaidFunctionError};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    github::{GitHubRepoTeam, GithubApiWrapper},
+    PlaidFunctionError,
+};
+
+#[derive(Serialize, Deserialize)]
+pub struct AddUserToTeamParams {
+    pub org: String,
+    pub team_slug: String,
+    pub user: String,
+    pub role: String,
+}
 
 // TODO: Do not use this function, it is deprecated and will be removed soon
-pub fn add_user_to_team(team: &str, user: &str, org: &str, role: &str) -> Result<(), i32> {
-    add_user_to_team_detailed(team, user, org, role).map_err(|_| -4)
+pub fn add_user_to_team(
+    client_id: impl Display,
+    team: &str,
+    user: &str,
+    org: &str,
+    role: &str,
+) -> Result<(), i32> {
+    add_user_to_team_detailed(client_id, team, user, org, role).map_err(|_| -4)
 }
 
 /// Add a user to a team
@@ -15,6 +34,7 @@ pub fn add_user_to_team(team: &str, user: &str, org: &str, role: &str) -> Result
 /// * `org` - Github organization that `team` exists in
 /// * `role` - Role to grant `user` on `team`
 pub fn add_user_to_team_detailed(
+    client_id: impl Display,
     team: &str,
     user: &str,
     org: &str,
@@ -24,13 +44,19 @@ pub fn add_user_to_team_detailed(
         new_host_function!(github, add_user_to_team);
     }
 
-    let mut params: HashMap<&'static str, &str> = HashMap::new();
-    params.insert("user", user);
-    params.insert("team_slug", team);
-    params.insert("org", org);
-    params.insert("role", role);
+    let params = AddUserToTeamParams {
+        org: org.to_string(),
+        team_slug: team.to_string(),
+        user: user.to_string(),
+        role: role.to_string(),
+    };
 
-    let params = serde_json::to_string(&params).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let params = serde_json::to_string(&wrapper).unwrap();
     let res =
         unsafe { github_add_user_to_team(params.as_bytes().as_ptr(), params.as_bytes().len()) };
 
@@ -43,9 +69,21 @@ pub fn add_user_to_team_detailed(
     Ok(())
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct RemoveUserFromTeamParams {
+    pub org: String,
+    pub team_slug: String,
+    pub user: String,
+}
+
 // TODO: Do not use this function, it is deprecated and will be removed soon
-pub fn remove_user_from_team(team: &str, user: &str, org: &str) -> Result<(), i32> {
-    remove_user_from_team_detailed(team, user, org).map_err(|_| -4)
+pub fn remove_user_from_team(
+    client_id: impl Display,
+    team: &str,
+    user: &str,
+    org: &str,
+) -> Result<(), i32> {
+    remove_user_from_team_detailed(client_id, team, user, org).map_err(|_| -4)
 }
 
 /// Remove a user from a team
@@ -55,6 +93,7 @@ pub fn remove_user_from_team(team: &str, user: &str, org: &str) -> Result<(), i3
 /// * `user` - The user to remove from `team`
 /// * `org` - Github organization that `team` exists in
 pub fn remove_user_from_team_detailed(
+    client_id: impl Display,
     team: &str,
     user: &str,
     org: &str,
@@ -63,12 +102,18 @@ pub fn remove_user_from_team_detailed(
         new_host_function!(github, remove_user_from_team);
     }
 
-    let mut params: HashMap<&'static str, &str> = HashMap::new();
-    params.insert("user", user);
-    params.insert("team_slug", team);
-    params.insert("org", org);
+    let params = RemoveUserFromTeamParams {
+        org: org.to_string(),
+        team_slug: team.to_string(),
+        user: user.to_string(),
+    };
 
-    let params = serde_json::to_string(&params).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let params = serde_json::to_string(&wrapper).unwrap();
     let res = unsafe {
         github_remove_user_from_team(params.as_bytes().as_ptr(), params.as_bytes().len())
     };
@@ -82,9 +127,18 @@ pub fn remove_user_from_team_detailed(
     Ok(())
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct AddRepoToTeamParams {
+    pub org: String,
+    pub team_slug: String,
+    pub repo: String,
+    pub permission: String,
+}
+
 /// Add a repo to a GH team, with a given permission.
 /// For more details, see https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#add-or-update-team-repository-permissions
 pub fn add_repo_to_team(
+    client_id: impl Display,
     org: impl Display,
     repo: impl Display,
     team_slug: impl Display,
@@ -94,13 +148,19 @@ pub fn add_repo_to_team(
         new_host_function!(github, add_repo_to_team);
     }
 
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("org", org.to_string());
-    params.insert("team_slug", team_slug.to_string());
-    params.insert("repo", repo.to_string());
-    params.insert("permission", permission.to_string());
+    let params = AddRepoToTeamParams {
+        org: org.to_string(),
+        team_slug: team_slug.to_string(),
+        repo: repo.to_string(),
+        permission: permission.to_string(),
+    };
 
-    let params = serde_json::to_string(&params).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let params = serde_json::to_string(&wrapper).unwrap();
     let res =
         unsafe { github_add_repo_to_team(params.as_bytes().as_ptr(), params.as_bytes().len()) };
 
@@ -113,9 +173,17 @@ pub fn add_repo_to_team(
     Ok(())
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct RemoveRepoFromTeamParams {
+    pub org: String,
+    pub team_slug: String,
+    pub repo: String,
+}
+
 /// Remove a repo from a GH team.
 /// For more details, see https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#remove-a-repository-from-a-team
 pub fn remove_repo_from_team(
+    client_id: impl Display,
     org: impl Display,
     repo: impl Display,
     team_slug: impl Display,
@@ -124,12 +192,18 @@ pub fn remove_repo_from_team(
         new_host_function!(github, remove_repo_from_team);
     }
 
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("org", org.to_string());
-    params.insert("team_slug", team_slug.to_string());
-    params.insert("repo", repo.to_string());
+    let params = RemoveRepoFromTeamParams {
+        org: org.to_string(),
+        team_slug: team_slug.to_string(),
+        repo: repo.to_string(),
+    };
 
-    let params = serde_json::to_string(&params).unwrap();
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let params = serde_json::to_string(&wrapper).unwrap();
     let res = unsafe {
         github_remove_repo_from_team(params.as_bytes().as_ptr(), params.as_bytes().len())
     };
@@ -143,8 +217,17 @@ pub fn remove_repo_from_team(
     Ok(())
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct GetRepoTeamsParams {
+    pub org: String,
+    pub repo: String,
+    pub per_page: Option<u8>,
+    pub page: Option<u16>,
+}
+
 /// Get the teams that have access to a repository.
 pub fn get_repo_teams(
+    client_id: impl Display,
     org: impl Display,
     repo: impl Display,
 ) -> Result<Vec<GitHubRepoTeam>, PlaidFunctionError> {
@@ -152,19 +235,26 @@ pub fn get_repo_teams(
         new_host_function_with_error_buffer!(github, get_repo_teams);
     }
 
-    let mut params: HashMap<&str, String> = HashMap::new();
-    params.insert("org", org.to_string());
-    params.insert("repo", repo.to_string());
-
     const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
 
     let mut teams = Vec::<GitHubRepoTeam>::new();
     let mut page = 0;
     loop {
         page += 1;
-        params.insert("page", page.to_string());
 
-        let request = serde_json::to_string(&params).unwrap();
+        let params = GetRepoTeamsParams {
+            org: org.to_string(),
+            repo: repo.to_string(),
+            per_page: None,
+            page: Some(page),
+        };
+
+        let wrapper = GithubApiWrapper {
+            client_id: client_id.to_string(),
+            params,
+        };
+
+        let request = serde_json::to_string(&wrapper).unwrap();
 
         let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 

--- a/runtime/plaid-stl/src/github/team.rs
+++ b/runtime/plaid-stl/src/github/team.rs
@@ -15,7 +15,9 @@ pub struct AddUserToTeamParams {
     pub role: String,
 }
 
-// TODO: Do not use this function, it is deprecated and will be removed soon
+#[deprecated(
+    note = "This function is deprecated and will be removed soon. Please use add_user_to_team_detailed instead."
+)]
 pub fn add_user_to_team(
     client_id: impl Display,
     team: &str,
@@ -76,7 +78,9 @@ pub struct RemoveUserFromTeamParams {
     pub user: String,
 }
 
-// TODO: Do not use this function, it is deprecated and will be removed soon
+#[deprecated(
+    note = "This function is deprecated and will be removed soon. Please use remove_user_from_team_detailed instead."
+)]
 pub fn remove_user_from_team(
     client_id: impl Display,
     team: &str,

--- a/runtime/plaid-stl/src/github/types.rs
+++ b/runtime/plaid-stl/src/github/types.rs
@@ -158,7 +158,10 @@ pub struct GithubFileContent {
 
 impl FileSearchResultItem {
     /// Retrieve the content of the search result
-    pub fn retrieve_raw_content(&self) -> Result<String, PlaidFunctionError> {
+    pub fn retrieve_raw_content(
+        &self,
+        client_id: impl Display,
+    ) -> Result<String, PlaidFunctionError> {
         let reference_regex = regex::Regex::new(r"^.*?ref=([a-f0-9]{40})$").unwrap(); // TODO improve
         let reference = reference_regex
             .captures(&self.url)
@@ -167,6 +170,7 @@ impl FileSearchResultItem {
             .ok_or(PlaidFunctionError::InternalApiError)?
             .as_str();
         let content = super::fetch_file(
+            client_id,
             &self.repository.owner.login,
             &self.repository.name,
             &self.path,
@@ -360,6 +364,21 @@ impl Display for FetchFileCustomMediaType {
 /*******************************************************************************************
    MISCELLANEA
 *******************************************************************************************/
+
+#[derive(Serialize, Deserialize)]
+pub struct GithubApiWrapper<T> {
+    pub client_id: String,
+    pub params: T,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ConfigureSecretParams {
+    pub owner: String,
+    pub repo: String,
+    pub env_name: Option<String>,
+    pub secret_name: String,
+    pub secret: String,
+}
 
 /// A GitHub user.
 /// Note - We only deserialize the fields we care about.

--- a/runtime/plaid/resources/config/apis.toml
+++ b/runtime/plaid/resources/config/apis.toml
@@ -139,7 +139,7 @@ root_certificate = """
 # "User-Agent" = "Plaid/0.10"
 
 [apis."github"]
-[apis."github".authentication]
+[apis."github".authentication.noauth]
 # Nothing here means no authentication
 [apis."github".graphql_queries]
 
@@ -366,4 +366,3 @@ rules_and_actions = { "some_rule.wasm"  = ["Encrypt", "Decrypt"] }
 # [apis.gcp.bigquery.schemas."<some-dataset>"."table1"]
 # column1 = "string"
 # colum2 = "float"
-

--- a/runtime/plaid/src/apis/github/actions.rs
+++ b/runtime/plaid/src/apis/github/actions.rs
@@ -5,7 +5,7 @@ use crate::{
     apis::{github::GitHubError, ApiError},
     loader::PlaidModule,
 };
-use plaid_stl::github::RepositoryDispatchParams;
+use plaid_stl::github::{GithubApiWrapper, RepositoryDispatchParams};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -29,12 +29,14 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: RepositoryDispatchParams<Value> =
+        let request: GithubApiWrapper<RepositoryDispatchParams<Value>> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_username(&request.owner)?;
-        let repo = self.validate_repository_name(&request.repo)?;
-        let event_type = self.validate_event_type(&request.event_type)?;
+        let params = request.params;
+
+        let owner = self.validate_username(&params.owner)?;
+        let repo = self.validate_repository_name(&params.repo)?;
+        let event_type = self.validate_event_type(&params.event_type)?;
         // Since client_payload can be an arbitrary JSON, we "validate" it alredy when deserializing it to a Value.
         // However, we have no control over the content.
 
@@ -44,10 +46,13 @@ impl Github {
 
         let body = RepositoryDispatchPayload {
             event_type,
-            client_payload: &request.client_payload,
+            client_payload: &params.client_payload,
         };
 
-        match self.make_generic_post_request(address, &body, module).await {
+        match self
+            .make_generic_post_request(request.client_id, address, &body, module)
+            .await
+        {
             Ok((status, Ok(_))) => {
                 if status == 204 {
                     Ok(0)

--- a/runtime/plaid/src/apis/github/code.rs
+++ b/runtime/plaid/src/apis/github/code.rs
@@ -32,6 +32,11 @@ impl Github {
 
         let file_content = request.params.file_content.clone().unwrap_or_default();
 
+        if file_content.contains([':', '"', '\'', '(', ')', '&', '|', '\n', '\r', '\t']) {
+            // These characters have special meaning in GitHub's search syntax and could be used for injection attacks, so we reject them outright.
+            return Err(ApiError::BadRequest);
+        }
+
         let filename = match request.params.filename {
             None => String::new(),
             Some(filename) => format!("filename:{}", self.validate_filename(&filename)?),

--- a/runtime/plaid/src/apis/github/code.rs
+++ b/runtime/plaid/src/apis/github/code.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
+
+use plaid_stl::github::{GithubApiWrapper, SearchCodeParams};
 
 use super::Github;
 use crate::{
@@ -14,7 +16,7 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<SearchCodeParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         /*
@@ -28,34 +30,31 @@ impl Github {
         We simply validate individual parameters if present.
         */
 
-        let file_content = match request.get("file_content") {
+        let file_content = request.params.file_content.clone().unwrap_or_default();
+
+        let filename = match request.params.filename {
             None => String::new(),
-            Some(content) => content.to_string(),
+            Some(filename) => format!("filename:{}", self.validate_filename(&filename)?),
         };
 
-        let filename = match request.get("filename") {
+        let extension = match request.params.extension {
             None => String::new(),
-            Some(filename) => format!("filename:{}", self.validate_filename(filename)?),
+            Some(extension) => format!("extension:{}", self.validate_extension(&extension)?),
         };
 
-        let extension = match request.get("extension") {
+        let path = match request.params.path {
             None => String::new(),
-            Some(extension) => format!("extension:{}", self.validate_extension(extension)?),
-        };
-
-        let path = match request.get("path") {
-            None => String::new(),
-            Some(path) => format!("path:{}", self.validate_path(path)?),
+            Some(path) => format!("path:{}", self.validate_path(&path)?),
         };
 
         // See if we were told to search only in a specific organization or repository
-        let org = match request.get("org") {
+        let org = match request.params.org {
             None => None,
-            Some(org) => Some(self.validate_org(org)?),
+            Some(org) => Some(self.validate_org(&org)?.to_string()),
         };
-        let repo = match request.get("repo") {
+        let repo = match request.params.repo {
             None => None,
-            Some(repo) => Some(self.validate_repository_name(repo)?),
+            Some(repo) => Some(self.validate_repository_name(&repo)?.to_string()),
         };
 
         // Assemble org and repo depending on what we received.
@@ -67,21 +66,13 @@ impl Github {
             (_, Some(repo)) => format!("repo:{repo}"),
         };
 
-        let per_page: u8 = request
-            .get("per_page")
-            .unwrap_or(&"100")
-            .parse::<u8>()
-            .map_err(|_| ApiError::BadRequest)?;
+        let per_page: u8 = request.params.per_page.unwrap_or(100);
         if per_page > 100 {
             // GitHub supports up to 100 results per page
             return Err(ApiError::BadRequest);
         }
 
-        let page: u16 = request
-            .get("page")
-            .unwrap_or(&"1")
-            .parse::<u16>()
-            .map_err(|_| ApiError::BadRequest)?;
+        let page: u16 = request.params.page.unwrap_or(1);
 
         // Construct the query with the piece we have. Multiple spaces, if present, do not cause problems.
         let query = format!("{file_content} {filename} {extension} {path} {org_and_repo}");
@@ -95,7 +86,10 @@ impl Github {
         // https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#rate-limit
         let address = format!("/search/code?q={query}&per_page={per_page}&page={page}");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)

--- a/runtime/plaid/src/apis/github/copilot.rs
+++ b/runtime/plaid/src/apis/github/copilot.rs
@@ -3,9 +3,12 @@ use crate::{
     apis::{github::GitHubError, ApiError},
     loader::PlaidModule,
 };
-use serde::{Deserialize, Serialize};
+use plaid_stl::github::{
+    AddUsersToOrgCopilotParams, GithubApiWrapper, ListSeatsInOrgCopilotParams,
+    RemoveUsersFromOrgCopilotParams,
+};
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 impl Github {
     /// List all seats in the Copilot subscription for an organization
@@ -15,27 +18,22 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<ListSeatsInOrgCopilotParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let organization = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
-        let per_page: u8 = request
-            .get("per_page")
-            .unwrap_or(&"50")
-            .parse::<u8>()
-            .map_err(|_| ApiError::BadRequest)?;
-        let page: u16 = request
-            .get("page")
-            .unwrap_or(&"1")
-            .parse::<u16>()
-            .map_err(|_| ApiError::BadRequest)?;
+        let organization = self.validate_org(&request.params.org)?;
+        let per_page: u8 = request.params.per_page.unwrap_or(50);
+        let page: u16 = request.params.page.unwrap_or(1);
 
         info!("List seats in Copilot subscription for org {organization}");
 
         let address =
             format!("/orgs/{organization}/copilot/billing/seats?page={page}&per_page={per_page}");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)
@@ -57,28 +55,23 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        #[derive(Deserialize, Serialize)]
-        struct Request {
-            #[serde(skip_serializing)]
-            org: String,
-            selected_usernames: Vec<String>,
-        }
-        let request: Request = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        let request: GithubApiWrapper<AddUsersToOrgCopilotParams> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let organization = self.validate_org(&request.org)?;
-        for username in &request.selected_usernames {
+        let organization = self.validate_org(&request.params.org)?;
+        for username in &request.params.selected_usernames {
             self.validate_username(&username)?;
         }
 
         info!(
             "Adding users {:?} to Copilot subscription for org {organization} as module {module}",
-            request.selected_usernames
+            request.params.selected_usernames
         );
 
         let address = format!("/orgs/{organization}/copilot/billing/selected_users");
 
         match self
-            .make_generic_post_request(address, &request, module)
+            .make_generic_post_request(&request.client_id, address, &request, module)
             .await
         {
             Ok((status, Ok(body))) => {
@@ -102,28 +95,23 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        #[derive(Deserialize, Serialize)]
-        struct Request {
-            #[serde(skip_serializing)]
-            org: String,
-            selected_usernames: Vec<String>,
-        }
-        let request: Request = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        let request: GithubApiWrapper<RemoveUsersFromOrgCopilotParams> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let organization = self.validate_org(&request.org)?;
-        for username in request.selected_usernames.iter() {
+        let organization = self.validate_org(&request.params.org)?;
+        for username in request.params.selected_usernames.iter() {
             self.validate_username(&username)?;
         }
 
         info!(
-            "Remove users {:?} from Copilot subscription for org {organization}",
-            request.selected_usernames
+            "Remove users {:?} from Copilot subscription for org {organization} as module {module}",
+            request.params.selected_usernames
         );
 
         let address = format!("/orgs/{organization}/copilot/billing/selected_users");
 
         match self
-            .make_generic_delete_request(address, Some(&request), module)
+            .make_generic_delete_request(&request.client_id, address, Some(&request), module)
             .await
         {
             Ok((status, Ok(body))) => {

--- a/runtime/plaid/src/apis/github/copilot.rs
+++ b/runtime/plaid/src/apis/github/copilot.rs
@@ -7,6 +7,7 @@ use plaid_stl::github::{
     AddUsersToOrgCopilotParams, GithubApiWrapper, ListSeatsInOrgCopilotParams,
     RemoveUsersFromOrgCopilotParams,
 };
+use serde::Serialize;
 
 use std::sync::Arc;
 
@@ -70,8 +71,17 @@ impl Github {
 
         let address = format!("/orgs/{organization}/copilot/billing/selected_users");
 
+        #[derive(Serialize)]
+        struct RequestBody {
+            selected_usernames: Vec<String>,
+        }
+
+        let body = RequestBody {
+            selected_usernames: request.params.selected_usernames.clone(),
+        };
+
         match self
-            .make_generic_post_request(&request.client_id, address, &request.params, module)
+            .make_generic_post_request(&request.client_id, address, &body, module)
             .await
         {
             Ok((status, Ok(body))) => {
@@ -110,8 +120,17 @@ impl Github {
 
         let address = format!("/orgs/{organization}/copilot/billing/selected_users");
 
+        #[derive(Serialize)]
+        struct RequestBody {
+            selected_usernames: Vec<String>,
+        }
+
+        let body = RequestBody {
+            selected_usernames: request.params.selected_usernames.clone(),
+        };
+
         match self
-            .make_generic_delete_request(&request.client_id, address, Some(&request.params), module)
+            .make_generic_delete_request(&request.client_id, address, Some(&body), module)
             .await
         {
             Ok((status, Ok(body))) => {

--- a/runtime/plaid/src/apis/github/copilot.rs
+++ b/runtime/plaid/src/apis/github/copilot.rs
@@ -71,7 +71,7 @@ impl Github {
         let address = format!("/orgs/{organization}/copilot/billing/selected_users");
 
         match self
-            .make_generic_post_request(&request.client_id, address, &request, module)
+            .make_generic_post_request(&request.client_id, address, &request.params, module)
             .await
         {
             Ok((status, Ok(body))) => {
@@ -111,7 +111,7 @@ impl Github {
         let address = format!("/orgs/{organization}/copilot/billing/selected_users");
 
         match self
-            .make_generic_delete_request(&request.client_id, address, Some(&request), module)
+            .make_generic_delete_request(&request.client_id, address, Some(&request.params), module)
             .await
         {
             Ok((status, Ok(body))) => {

--- a/runtime/plaid/src/apis/github/deploy_keys.rs
+++ b/runtime/plaid/src/apis/github/deploy_keys.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use plaid_stl::github::DeleteDeployKeyParams;
+use plaid_stl::github::{DeleteDeployKeyParams, GithubApiWrapper};
 
 use crate::{
     apis::{github::GitHubError, ApiError},
@@ -17,18 +17,18 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: DeleteDeployKeyParams =
+        let request: GithubApiWrapper<DeleteDeployKeyParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
-        let owner = self.validate_username(&request.owner)?;
-        let repo = self.validate_repository_name(&request.repo)?;
-        let key_id = request.key_id; // this is implicitly validated because it's a u64
+        let owner = self.validate_username(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
+        let key_id = request.params.key_id; // this is implicitly validated because it's a u64
 
         info!("Removing deploy key with ID {key_id} from repo {owner}/{repo}");
 
         let address = format!("/repos/{owner}/{repo}/keys/{key_id}");
 
         match self
-            .make_generic_delete_request(address, None::<&String>, module)
+            .make_generic_delete_request(request.client_id, address, None::<&String>, module)
             .await
         {
             Ok((status, Ok(_))) => {

--- a/runtime/plaid/src/apis/github/environments.rs
+++ b/runtime/plaid/src/apis/github/environments.rs
@@ -1,5 +1,8 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
+use plaid_stl::github::{
+    CreateDeploymentBranchProtectionRuleParams, CreateEnvironmentForRepoParams, GithubApiWrapper,
+};
 use serde::Serialize;
 
 use crate::{
@@ -61,14 +64,12 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<CreateEnvironmentForRepoParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_username(request.get("owner").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
-        let env_name =
-            self.validate_environment_name(request.get("env_name").ok_or(ApiError::BadRequest)?)?;
+        let owner = self.validate_username(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
+        let env_name = self.validate_environment_name(&request.params.env_name)?;
 
         info!(
             "Creating and configuring environment [{env_name}] in repo [{owner}/{repo}] on behalf of [{module}]"
@@ -87,7 +88,7 @@ impl Github {
         };
 
         match self
-            .make_generic_put_request(address, Some(&body), module)
+            .make_generic_put_request(&request.client_id, address, Some(&body), module)
             .await
         {
             Ok((status, _)) => {
@@ -110,16 +111,13 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<CreateDeploymentBranchProtectionRuleParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_username(request.get("owner").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
-        let env_name =
-            self.validate_environment_name(request.get("env_name").ok_or(ApiError::BadRequest)?)?;
-        let branch: &str =
-            self.validate_branch_name(request.get("branch").ok_or(ApiError::BadRequest)?)?;
+        let owner = self.validate_username(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
+        let env_name = self.validate_environment_name(&request.params.env_name)?;
+        let branch = self.validate_branch_name(&request.params.branch)?;
 
         info!(
             "Creating deployment branch protection rule for branch [{branch}] and environment [{env_name}] in repo [{owner}/{repo}] on behalf of [{module}]"
@@ -134,7 +132,7 @@ impl Github {
         };
 
         match self
-            .make_generic_post_request(address, Some(&body), module)
+            .make_generic_post_request(request.client_id, address, Some(&body), module)
             .await
         {
             Ok((status, _)) => {

--- a/runtime/plaid/src/apis/github/graphql.rs
+++ b/runtime/plaid/src/apis/github/graphql.rs
@@ -1,5 +1,6 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, fmt::Display, sync::Arc};
 
+use plaid_stl::github::GithubApiWrapper;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -51,22 +52,30 @@ impl Github {
     /// Execute a GraphQL query by calling the GitHub API.
     async fn make_gql_request<T: Serialize>(
         &self,
+        client_id: impl Display,
         query: T,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request = self.client._post(GITHUB_GQL_API, Some(&query)).await;
+        let client = self.clients.get(&client_id.to_string()).ok_or_else(|| {
+            ApiError::GitHubError(GitHubError::InvalidInput(format!(
+                "Client ID not found: {}",
+                client_id
+            )))
+        })?;
+
+        let request = client._post(GITHUB_GQL_API, Some(&query)).await;
 
         match request {
             Ok(r) => {
                 if r.status() == 200 {
-                    let body = self.client.body_to_string(r).await.map_err(|e| {
+                    let body = client.body_to_string(r).await.map_err(|e| {
                         ApiError::GitHubError(GitHubError::GraphQLRequestError(e.to_string()))
                     })?;
 
                     Ok(body)
                 } else {
                     let status = r.status();
-                    let body = self.client.body_to_string(r).await.map_err(|e| {
+                    let body = client.body_to_string(r).await.map_err(|e| {
                         ApiError::GitHubError(GitHubError::GraphQLRequestError(e.to_string()))
                     })?;
 
@@ -86,23 +95,25 @@ impl Github {
         request: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: Request = serde_json::from_str(request).map_err(|_| ApiError::BadRequest)?;
+        let request: GithubApiWrapper<Request> =
+            serde_json::from_str(request).map_err(|_| ApiError::BadRequest)?;
 
-        let query = match self.config.graphql_queries.get(&request.query_name) {
+        let query = match self.config.graphql_queries.get(&request.params.query_name) {
             Some(query) => query.to_owned(),
             None => {
                 return Err(ApiError::GitHubError(GitHubError::GraphQLQueryUnknown(
-                    request.query_name,
+                    request.params.query_name,
                 )))
             }
         };
 
         let query = GraphQLQuery {
             query,
-            variables: request.variables,
+            variables: request.params.variables,
         };
 
-        self.make_gql_request(query, module).await
+        self.make_gql_request(&request.client_id, query, module)
+            .await
     }
 
     /// Execute an advanced GraphQL query specified by `request`, on behalf of `module`.
@@ -111,23 +122,24 @@ impl Github {
         request: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: AdvancedRequest =
+        let request: GithubApiWrapper<AdvancedRequest> =
             serde_json::from_str(request).map_err(|_| ApiError::BadRequest)?;
 
-        let query = match self.config.graphql_queries.get(&request.query_name) {
+        let query = match self.config.graphql_queries.get(&request.params.query_name) {
             Some(query) => query.to_owned(),
             None => {
                 return Err(ApiError::GitHubError(GitHubError::GraphQLQueryUnknown(
-                    request.query_name,
+                    request.params.query_name,
                 )))
             }
         };
 
         let query = AdvancedGraphQLQuery {
             query: query,
-            variables: request.variables,
+            variables: request.params.variables,
         };
 
-        self.make_gql_request(query, module).await
+        self.make_gql_request(&request.client_id, query, module)
+            .await
     }
 }

--- a/runtime/plaid/src/apis/github/members.rs
+++ b/runtime/plaid/src/apis/github/members.rs
@@ -85,11 +85,11 @@ impl Github {
     /// See https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-a-user
     pub async fn get_user_id_from_username(
         &self,
-        username: &str,
+        params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         let request: GithubApiWrapper<String> =
-            serde_json::from_str(username).map_err(|_| ApiError::BadRequest)?;
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
         let username = self.validate_username(&request.params)?;
 
         info!("Getting user ID for username [{username}] on behalf of [{module}]");
@@ -119,11 +119,11 @@ impl Github {
     /// See https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-a-user-using-their-id
     pub async fn get_username_from_user_id(
         &self,
-        user_id: &str,
+        params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
         let request: GithubApiWrapper<String> =
-            serde_json::from_str(user_id).map_err(|_| ApiError::BadRequest)?;
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
         let user_id = self.validate_user_id(&request.params)?;
 
         info!("Getting username for user ID [{user_id}] on behalf of [{module}]");

--- a/runtime/plaid/src/apis/github/members.rs
+++ b/runtime/plaid/src/apis/github/members.rs
@@ -1,11 +1,13 @@
-use plaid_stl::github::GitHubUser;
+use plaid_stl::github::{
+    CheckOrgMembershipParams, GitHubUser, GithubApiWrapper, RemoveOutsideCollaboratorParams,
+};
 
 use super::Github;
 use crate::{
     apis::{github::GitHubError, ApiError},
     loader::PlaidModule,
 };
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 impl Github {
     /// Check if a user belongs to an org
@@ -15,17 +17,20 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<bool, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<CheckOrgMembershipParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         // Parse out all the parameters from our parameter string
-        let org = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
-        let user = self.validate_username(request.get("user").ok_or(ApiError::BadRequest)?)?;
+        let org = self.validate_org(&request.params.org)?;
+        let user = self.validate_username(&request.params.user)?;
 
         info!("Checking if user [{user}] is part the [{org}] org on behalf of {module}");
         let address = format!("/orgs/{org}/members/{user}");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(_))) => {
                 if status == 204 {
                     Ok(true)
@@ -49,17 +54,17 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<RemoveOutsideCollaboratorParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let org = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
-        let user = self.validate_username(request.get("user").ok_or(ApiError::BadRequest)?)?;
+        let org = self.validate_org(&request.params.org)?;
+        let user = self.validate_username(&request.params.user)?;
 
         info!("Removing outside collaborator [{user}] from org [{org}] on behalf of {module}");
         let address = format!("/orgs/{org}/outside_collaborators/{user}");
 
         match self
-            .make_generic_delete_request::<&str>(address, None, module)
+            .make_generic_delete_request::<&str>(&request.client_id, address, None, module)
             .await
         {
             Ok((status, Ok(_))) => {
@@ -83,12 +88,17 @@ impl Github {
         username: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let username = self.validate_username(username)?;
+        let request: GithubApiWrapper<String> =
+            serde_json::from_str(username).map_err(|_| ApiError::BadRequest)?;
+        let username = self.validate_username(&request.params)?;
 
         info!("Getting user ID for username [{username}] on behalf of [{module}]");
         let address = format!("/users/{username}");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     let user_info: GitHubUser = serde_json::from_str(&body)
@@ -112,12 +122,17 @@ impl Github {
         user_id: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let user_id = self.validate_user_id(user_id)?;
+        let request: GithubApiWrapper<String> =
+            serde_json::from_str(user_id).map_err(|_| ApiError::BadRequest)?;
+        let user_id = self.validate_user_id(&request.params)?;
 
         info!("Getting username for user ID [{user_id}] on behalf of [{module}]");
         let address = format!("/user/{user_id}");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     let user_info: GitHubUser = serde_json::from_str(&body)

--- a/runtime/plaid/src/apis/github/mod.rs
+++ b/runtime/plaid/src/apis/github/mod.rs
@@ -19,13 +19,13 @@ use octocrab::{NoAuth, Octocrab};
 
 use serde::{Deserialize, Serialize};
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, fmt::Display, sync::Arc};
 
 use crate::loader::PlaidModule;
 
 use super::ApiError;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 #[serde(untagged)]
 pub enum Authentication {
     /// If you provide a token then we will initialize the client using that
@@ -54,7 +54,9 @@ pub struct GithubConfig {
     /// The authentication method used when configuring the GitHub API module. More
     /// methods may be added here in the future but one variant of the enum must be defined.
     /// See the Authentication enum structure above for more details.
-    authentication: Authentication,
+    /// This is a map from a string identifier to the authentication method, since Plaid supports
+    /// multiple GitHub connections in the same runtime.
+    authentication: HashMap<String, Authentication>,
     /// This is a map of GraphQL queries you are allowing rules to execute. These are
     /// manually specified to reduce the risk of abuse by rules as they are very powerful
     /// and hard to reason about in a generic way, especially at runtime.
@@ -65,8 +67,8 @@ pub struct GithubConfig {
 pub struct Github {
     /// Configuration for Plaid's GitHub API
     config: GithubConfig,
-    /// Client to make requests with
-    client: Octocrab,
+    /// Clients to make requests with, keyed by their identifier
+    clients: HashMap<String, Octocrab>,
     /// Validators used to check parameters passed by modules
     validators: HashMap<&'static str, regex::Regex>,
 }
@@ -86,7 +88,7 @@ pub enum GitHubError {
 
 impl Github {
     pub fn new(config: GithubConfig) -> Result<Self, ApiError> {
-        let client = build_github_client(&config.authentication)?;
+        let clients = build_github_clients(&config.authentication)?;
 
         // Create all the validators and compile all the regexes. If the module contains
         // any invalid regexes it will panic.
@@ -94,7 +96,7 @@ impl Github {
 
         Ok(Self {
             config,
-            client,
+            clients,
             validators,
         })
     }
@@ -105,10 +107,12 @@ impl Github {
     /// (at least currently).
     async fn make_generic_get_request(
         &self,
+        client_id: impl Display,
         uri: String,
         module: Arc<PlaidModule>,
     ) -> Result<(u16, Result<String, ApiError>), ApiError> {
-        self.make_get_request_with_headers(uri, None, module).await
+        self.make_get_request_with_headers(client_id, uri, None, module)
+            .await
     }
 
     /// Make a GET request with custom headers to the GitHub API using the GitHub app library.
@@ -117,6 +121,7 @@ impl Github {
     /// we assume that all necessary validation has already been performed by the calling function.
     async fn make_get_request_with_headers(
         &self,
+        client_id: impl Display,
         uri: String,
         headers: Option<HeaderMap>,
         module: Arc<PlaidModule>,
@@ -134,12 +139,19 @@ impl Github {
             }
         );
 
-        let request = self.client._get_with_headers(uri, headers).await;
+        let client = self.clients.get(&client_id.to_string()).ok_or_else(|| {
+            ApiError::GitHubError(GitHubError::InvalidInput(format!(
+                "Client ID not found: {}",
+                client_id
+            )))
+        })?;
+
+        let request = client._get_with_headers(uri, headers).await;
 
         match request {
             Ok(r) => {
                 let status = r.status().as_u16();
-                let body = self.client.body_to_string(r).await.map_err(|e| {
+                let body = client.body_to_string(r).await.map_err(|e| {
                     ApiError::GitHubError(GitHubError::GraphQLRequestError(e.to_string()))
                 });
                 Ok((status, body))
@@ -154,18 +166,26 @@ impl Github {
     /// (at least currently).
     async fn make_generic_post_request<T: Serialize>(
         &self,
+        client_id: impl Display,
         uri: String,
         body: T,
         module: Arc<PlaidModule>,
     ) -> Result<(u16, Result<String, ApiError>), ApiError> {
         info!("Making a post request to {uri} on behalf of {module}");
 
-        let request = self.client._post(uri, Some(&body)).await;
+        let client = self.clients.get(&client_id.to_string()).ok_or_else(|| {
+            ApiError::GitHubError(GitHubError::InvalidInput(format!(
+                "Client ID not found: {}",
+                client_id
+            )))
+        })?;
+
+        let request = client._post(uri, Some(&body)).await;
 
         match request {
             Ok(r) => {
                 let status = r.status().as_u16();
-                let body = self.client.body_to_string(r).await.map_err(|e| {
+                let body = client.body_to_string(r).await.map_err(|e| {
                     ApiError::GitHubError(GitHubError::GraphQLRequestError(e.to_string()))
                 });
                 Ok((status, body))
@@ -180,18 +200,26 @@ impl Github {
     /// (at least currently).
     async fn make_generic_put_request<T: Serialize>(
         &self,
+        client_id: impl Display,
         uri: String,
         body: Option<&T>,
         module: Arc<PlaidModule>,
     ) -> Result<(u16, Result<String, ApiError>), ApiError> {
         info!("Making a put request to {uri} on behalf of {module}");
 
-        let request = self.client._put(uri, body).await;
+        let client = self.clients.get(&client_id.to_string()).ok_or_else(|| {
+            ApiError::GitHubError(GitHubError::InvalidInput(format!(
+                "Client ID not found: {}",
+                client_id
+            )))
+        })?;
+
+        let request = client._put(uri, body).await;
 
         match request {
             Ok(r) => {
                 let status = r.status().as_u16();
-                let body = self.client.body_to_string(r).await.map_err(|e| {
+                let body = client.body_to_string(r).await.map_err(|e| {
                     ApiError::GitHubError(GitHubError::GraphQLRequestError(e.to_string()))
                 });
                 Ok((status, body))
@@ -206,18 +234,26 @@ impl Github {
     /// (at least currently).
     async fn make_generic_delete_request<T: Serialize>(
         &self,
+        client_id: impl Display,
         uri: String,
         body: Option<&T>,
         module: Arc<PlaidModule>,
     ) -> Result<(u16, Result<String, ApiError>), ApiError> {
         info!("Making a delete request to {uri} on behalf of {module}");
 
-        let request = self.client._delete(uri, body).await;
+        let client = self.clients.get(&client_id.to_string()).ok_or_else(|| {
+            ApiError::GitHubError(GitHubError::InvalidInput(format!(
+                "Client ID not found: {}",
+                client_id
+            )))
+        })?;
+
+        let request = client._delete(uri, body).await;
 
         match request {
             Ok(r) => {
                 let status = r.status().as_u16();
-                let body = self.client.body_to_string(r).await.map_err(|e| {
+                let body = client.body_to_string(r).await.map_err(|e| {
                     ApiError::GitHubError(GitHubError::GraphQLRequestError(e.to_string()))
                 });
                 Ok((status, body))
@@ -228,46 +264,45 @@ impl Github {
 }
 
 /// Builds an instance of a Github API client
-pub fn build_github_client(authentication: &Authentication) -> Result<Octocrab, ApiError> {
-    let client_builder = match authentication {
-        Authentication::NoAuth {} => {
-            info!("Configuring GitHub client without authentication");
-            Octocrab::builder().with_auth(NoAuth {})
-        }
-        Authentication::Token { token } => {
-            info!("Configuring GitHub client with GitHub PAT");
-            Octocrab::builder().personal_token(token.clone())
-        }
-        Authentication::App {
-            app_id,
-            private_key,
-            ..
-        } => {
-            info!("Configuring GitHub client with GitHub App");
-            let encoding_key = EncodingKey::from_rsa_pem(private_key.as_bytes())
-                .map_err(|_| ApiError::GitHubError(GitHubError::InvalidInput(format!("Failed to create encoding key from private key for GitHub API"))))?;
+pub fn build_github_clients(
+    authentication: &HashMap<String, Authentication>,
+) -> Result<HashMap<String, Octocrab>, ApiError> {
+    authentication
+        .iter()
+        .map(|(key, auth)| {
+            let client = match auth {
+                Authentication::NoAuth {} => {
+                    info!("Configuring GitHub client without authentication for [{key}]");
+                    Octocrab::builder().with_auth(NoAuth {})
+                }
+                Authentication::Token { token } => {
+                    info!("Configuring GitHub client with GitHub PAT for [{key}]");
+                    Octocrab::builder().personal_token(token.clone())
+                }
+                Authentication::App {
+                    app_id,
+                    private_key,
+                    ..
+                } => {
+                    info!("Configuring GitHub client with GitHub App for [{key}]");
+                    let encoding_key =
+                        EncodingKey::from_rsa_pem(private_key.as_bytes()).map_err(|_| {
+                            ApiError::GitHubError(GitHubError::InvalidInput(format!(
+                        "Failed to create encoding key from private key for GitHub API for [{key}]"
+                    )))
+                        })?;
 
-            Octocrab::builder().app((*app_id).into(), encoding_key)
-        }
-    }
-    .add_header(
-        USER_AGENT,
-        format!("Rust/Plaid{}", env!("CARGO_PKG_VERSION")),
-    );
+                    Octocrab::builder().app((*app_id).into(), encoding_key)
+                }
+            }
+            .add_header(
+                USER_AGENT,
+                format!("Rust/Plaid{}", env!("CARGO_PKG_VERSION")),
+            )
+            .build()
+            .map_err(|e| ApiError::GitHubError(GitHubError::ClientError(e)))?;
 
-    let mut client = client_builder
-        .build()
-        .map_err(|e| ApiError::GitHubError(GitHubError::ClientError(e)))?;
-
-    if let Authentication::App {
-        installation_id, ..
-    } = authentication
-    {
-        match client.installation((*installation_id).into()) {
-            Ok(installation_client) => client = installation_client,
-            Err(e) => return Err(ApiError::GitHubError(GitHubError::ClientError(e))),
-        }
-    }
-
-    Ok(client)
+            Ok((key.clone(), client))
+        })
+        .collect()
 }

--- a/runtime/plaid/src/apis/github/mod.rs
+++ b/runtime/plaid/src/apis/github/mod.rs
@@ -267,10 +267,16 @@ impl Github {
 pub fn build_github_clients(
     authentication: &HashMap<String, Authentication>,
 ) -> Result<HashMap<String, Octocrab>, ApiError> {
+    if authentication.is_empty() {
+        return Err(ApiError::GitHubError(GitHubError::InvalidInput(
+            "At least one GitHub client must be configured".to_string(),
+        )));
+    }
+
     authentication
         .iter()
         .map(|(key, auth)| {
-            let client = match auth {
+            let mut client = match auth {
                 Authentication::NoAuth {} => {
                     info!("Configuring GitHub client without authentication for [{key}]");
                     Octocrab::builder().with_auth(NoAuth {})
@@ -291,7 +297,6 @@ pub fn build_github_clients(
                         "Failed to create encoding key from private key for GitHub API for [{key}]"
                     )))
                         })?;
-
                     Octocrab::builder().app((*app_id).into(), encoding_key)
                 }
             }
@@ -301,6 +306,16 @@ pub fn build_github_clients(
             )
             .build()
             .map_err(|e| ApiError::GitHubError(GitHubError::ClientError(e)))?;
+
+            if let Authentication::App {
+                installation_id, ..
+            } = auth
+            {
+                match client.installation((*installation_id).into()) {
+                    Ok(installation_client) => client = installation_client,
+                    Err(e) => return Err(ApiError::GitHubError(GitHubError::ClientError(e))),
+                }
+            }
 
             Ok((key.clone(), client))
         })

--- a/runtime/plaid/src/apis/github/pats.rs
+++ b/runtime/plaid/src/apis/github/pats.rs
@@ -1,6 +1,9 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
+use plaid_stl::github::{
+    GetReposForFpatParams, GithubApiWrapper, ListFpatRequestsForOrgParams,
+    ReviewFpatRequestsForOrgParams,
+};
 
 use crate::{
     apis::{github::GitHubError, ApiError},
@@ -16,15 +19,18 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<ListFpatRequestsForOrgParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let org = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
+        let org = self.validate_org(&request.params.org)?;
 
         info!("Fetching FPAT Requests For {org} on behalf of {module}");
         let address = format!("/orgs/{org}/personal-access-token-requests");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)
@@ -45,20 +51,22 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<GetReposForFpatParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let org = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
-        let request_id =
-            self.validate_pint(request.get("request_id").ok_or(ApiError::BadRequest)?)?;
-        let per_page = self.validate_pint(request.get("per_page").unwrap_or(&"30"))?;
-        let page = self.validate_pint(request.get("page").unwrap_or(&"1"))?;
+        let org = self.validate_org(&request.params.org)?;
+        let request_id = request.params.request_id;
+        let per_page = request.params.per_page.unwrap_or(30);
+        let page = request.params.page.unwrap_or(1);
 
         info!("Fetching Repos For FPAT {request_id} in {org} on behalf of {module}");
         let address =
             format!("/orgs/{org}/personal-access-token-requests/{request_id}/repositories?per_page={per_page}&page={page}");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)
@@ -79,34 +87,27 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        #[derive(Deserialize, Serialize)]
-        struct Request {
-            #[serde(skip_serializing)]
-            org: String,
-            pat_request_ids: Vec<u64>,
-            action: String,
-            reason: String,
-        }
-        let request: Request = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
-        let org = self.validate_org(&request.org)?;
+        let request: GithubApiWrapper<ReviewFpatRequestsForOrgParams> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        let org = self.validate_org(&request.params.org)?;
 
-        match request.action.as_str() {
+        match request.params.action.as_str() {
             "approve" => {
                 info!(
                     "Approving FPATs {:?} Requests For {org} on behalf of {module} because: {}",
-                    request.pat_request_ids, request.reason,
+                    request.params.pat_request_ids, request.params.reason,
                 );
             }
             "deny" => {
                 info!(
                     "Denying FPATs {:?} Requests For {org} on behalf of {module} because: {}",
-                    request.pat_request_ids, request.reason,
+                    request.params.pat_request_ids, request.params.reason,
                 );
             }
             _ => {
                 warn!(
                     "{module} tried to respond to PAT requests with an invalid action: {}",
-                    request.action
+                    request.params.action
                 );
                 return Err(ApiError::BadRequest);
             }
@@ -114,7 +115,7 @@ impl Github {
         let address = format!("/orgs/{org}/personal-access-token-requests");
 
         match self
-            .make_generic_post_request(address, &request, module.clone())
+            .make_generic_post_request(&request.client_id, address, &request, module.clone())
             .await
         {
             Ok((status, Ok(body))) => {

--- a/runtime/plaid/src/apis/github/pats.rs
+++ b/runtime/plaid/src/apis/github/pats.rs
@@ -4,6 +4,7 @@ use plaid_stl::github::{
     GetReposForFpatParams, GithubApiWrapper, ListFpatRequestsForOrgParams,
     ReviewFpatRequestsForOrgParams,
 };
+use serde::Serialize;
 
 use crate::{
     apis::{github::GitHubError, ApiError},
@@ -114,8 +115,21 @@ impl Github {
         }
         let address = format!("/orgs/{org}/personal-access-token-requests");
 
+        #[derive(Serialize)]
+        struct RequestBody {
+            pat_request_ids: Vec<u64>,
+            action: String,
+            reason: String,
+        }
+
+        let body = RequestBody {
+            pat_request_ids: request.params.pat_request_ids,
+            action: request.params.action,
+            reason: request.params.reason,
+        };
+
         match self
-            .make_generic_post_request(&request.client_id, address, &request, module.clone())
+            .make_generic_post_request(&request.client_id, address, &body, module.clone())
             .await
         {
             Ok((status, Ok(body))) => {

--- a/runtime/plaid/src/apis/github/pull_requests.rs
+++ b/runtime/plaid/src/apis/github/pull_requests.rs
@@ -1,6 +1,6 @@
 use plaid_stl::github::{
     AddLabelsRequest, CreatePullRequestRequest, GetPullRequestOptions, GetPullRequestRequest,
-    PullRequestRequestReviewers,
+    GithubApiWrapper, PullRequestRequestReviewers,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -25,39 +25,42 @@ impl Github {
             reviewers: Vec<String>,
             team_reviewers: Vec<String>,
         }
-        let request: PullRequestRequestReviewers =
+        let request: GithubApiWrapper<PullRequestRequestReviewers> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         // Parse out all the parameters from our parameter string
-        let owner = self.validate_org(&request.owner)?;
-        let repo = self.validate_repository_name(&request.repo)?;
-        let pull_number = request.pull_number;
+        let owner = self.validate_org(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
+        let pull_number = request.params.pull_number;
 
-        for reviewer in &request.reviewers {
+        for reviewer in &request.params.reviewers {
             self.validate_username(&reviewer)?;
         }
 
-        for team in &request.team_reviewers {
+        for team in &request.params.team_reviewers {
             self.validate_team_slug(&team)?;
         }
 
-        info!("Requesting reviews from users: [{}] and teams: [{}] on [{owner}/{repo}/{pull_number}] org on behalf of {module}", request.reviewers.join(", "), request.team_reviewers.join(", "));
+        info!("Requesting reviews from users: [{}] and teams: [{}] on [{owner}/{repo}/{pull_number}] org on behalf of {module}", request.params.reviewers.join(", "), request.params.team_reviewers.join(", "));
 
         let address = format!("/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers");
 
         let body = RequestReviewers {
-            reviewers: request.reviewers.clone(),
-            team_reviewers: request.team_reviewers.clone(),
+            reviewers: request.params.reviewers.clone(),
+            team_reviewers: request.params.team_reviewers.clone(),
         };
 
-        match self.make_generic_post_request(address, body, module).await {
+        match self
+            .make_generic_post_request(&request.client_id, address, body, module)
+            .await
+        {
             Ok((status, Ok(_))) => {
                 if status == 201 {
                     Ok(true)
                 } else if status == 404 {
                     Ok(false)
                 } else if status == 422 {
-                    warn!("Some of the reviewers or teams are not collaborators on this repository. Context: [{owner}/{repo}/{pull_number}]. Users: [{}] and teams: [{}]", request.reviewers.join(", "), request.team_reviewers.join(", "));
+                    warn!("Some of the reviewers or teams are not collaborators on this repository. Context: [{owner}/{repo}/{pull_number}]. Users: [{}] and teams: [{}]", request.params.reviewers.join(", "), request.params.team_reviewers.join(", "));
                     Ok(false)
                 } else {
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
@@ -76,22 +79,22 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: CreatePullRequestRequest =
+        let request: GithubApiWrapper<CreatePullRequestRequest> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_org(&request.owner)?;
-        let repo = self.validate_repository_name(&request.repo)?;
+        let owner = self.validate_org(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
 
         // Build the request body, omitting optional fields if they are not set.
         let mut request_body = json!({
-            "title": request.title,
-            "head": request.head,
-            "base": request.base,
-            "draft": request.draft,
+            "title": request.params.title,
+            "head": request.params.head,
+            "base": request.params.base,
+            "draft": request.params.draft,
         });
 
         // Add the body if it exists
-        if let Some(body) = request.body {
+        if let Some(body) = request.params.body {
             request_body["body"] = json!(body);
         }
 
@@ -100,7 +103,7 @@ impl Github {
         info!("Creating pull request in [{owner}/{repo}] org on behalf of {module}");
 
         match self
-            .make_generic_post_request(address, request_body, module)
+            .make_generic_post_request(&request.client_id, address, request_body, module)
             .await
         {
             Ok((status, Ok(body))) => {
@@ -123,24 +126,28 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: GetPullRequestRequest =
+        let request: GithubApiWrapper<GetPullRequestRequest> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_org(&request.owner)?;
-        let repo = self.validate_repository_name(&request.repo)?;
+        let owner = self.validate_org(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
 
-        if request.per_page > 100 {
+        if request.params.per_page > 100 {
             return Err(ApiError::BadRequest);
         }
 
         let options = request
+            .params
             .options
             .map_or(Default::default(), query_string_from_options);
 
         info!("Listing pull requests in [{owner}/{repo}] org on behalf of {module}",);
         let address = format!("/repos/{owner}/{repo}/pulls?{options}");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)
@@ -161,21 +168,27 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request =
-            serde_json::from_str::<AddLabelsRequest>(params).map_err(|_| ApiError::BadRequest)?;
+        let request: GithubApiWrapper<AddLabelsRequest> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_org(&request.owner)?;
-        let repo = self.validate_repository_name(&request.repo)?;
+        let owner = self.validate_org(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
 
         info!(
             "Adding labels to issue/PR #{} in [{owner}/{repo}] org on behalf of {module}",
-            request.number
+            request.params.number
         );
 
-        let address = format!("/repos/{owner}/{repo}/issues/{}/labels", request.number);
-        let body = json!({"labels": request.labels});
+        let address = format!(
+            "/repos/{owner}/{repo}/issues/{}/labels",
+            request.params.number
+        );
+        let body = json!({"labels": request.params.labels});
 
-        match self.make_generic_post_request(address, body, module).await {
+        match self
+            .make_generic_post_request(&request.client_id, address, body, module)
+            .await
+        {
             Ok((status, Ok(_))) => {
                 if status == 200 {
                     Ok(0)

--- a/runtime/plaid/src/apis/github/refs.rs
+++ b/runtime/plaid/src/apis/github/refs.rs
@@ -5,7 +5,7 @@ use crate::{
     apis::{github::GitHubError, ApiError},
     loader::PlaidModule,
 };
-use plaid_stl::github::{GetOrCreateBranchReferenceParams, GitRef};
+use plaid_stl::github::{GetOrCreateBranchReferenceParams, GitRef, GithubApiWrapper};
 
 impl Github {
     /// Returns a single reference from the Git database.
@@ -14,25 +14,28 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: GetOrCreateBranchReferenceParams =
+        let request: GithubApiWrapper<GetOrCreateBranchReferenceParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_username(&request.owner)?;
-        let repo = self.validate_repository_name(&request.repo)?;
+        let owner = self.validate_username(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
 
         // Validate the reference. In practice, tags and branches follow the same naming conventions
         // so we'll use the same validator.
-        match &request.reference {
+        match &request.params.reference {
             GitRef::Branch(name) | GitRef::Tag(name) => self.validate_branch_name(name)?,
         };
 
         info!(
             "Fetching reference [{}] for repository [{owner}/{repo}] on behalf of [{module}]",
-            request.reference
+            request.params.reference
         );
-        let address = format!("/repos/{owner}/{repo}/git/ref/{}", request.reference);
+        let address = format!("/repos/{owner}/{repo}/git/ref/{}", request.params.reference);
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)
@@ -55,18 +58,18 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: GetOrCreateBranchReferenceParams =
+        let request: GithubApiWrapper<GetOrCreateBranchReferenceParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let Some(sha) = request.sha else {
+        let Some(sha) = request.params.sha else {
             return Err(ApiError::BadRequest);
         };
 
-        let owner = self.validate_username(&request.owner)?;
-        let repo = self.validate_repository_name(&request.repo)?;
+        let owner = self.validate_username(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
         let sha = self.validate_commit_hash(&sha)?;
 
-        let reference = format!("refs/{}", request.reference);
+        let reference = format!("refs/{}", request.params.reference);
 
         info!(
             "Creating reference [{reference}] for repository [{owner}/{repo}] on behalf of [{module}]",
@@ -79,7 +82,10 @@ impl Github {
             "sha": sha,
         });
 
-        match self.make_generic_post_request(address, body, module).await {
+        match self
+            .make_generic_post_request(&request.client_id, address, body, module)
+            .await
+        {
             Ok((status, Ok(_))) => {
                 if status == 201 {
                     Ok(0)

--- a/runtime/plaid/src/apis/github/repos.rs
+++ b/runtime/plaid/src/apis/github/repos.rs
@@ -1,9 +1,14 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use http::{HeaderMap, HeaderValue};
 use plaid_stl::github::{
-    CheckCodeownersParams, CodeownersErrorsResponse, CodeownersStatus, CommentOnPullRequestRequest,
-    CreateFileRequest, FetchFileCustomMediaType, FetchFileRequest, GithubRepository,
+    AddUserToRepoParams, CheckCodeownersParams, CodeownersErrorsResponse, CodeownersStatus,
+    CommentOnPullRequestRequest, CreateFileRequest, FetchCommitParams, FetchFileCustomMediaType,
+    FetchFileRequest, GetBranchProtectionRulesParams, GetBranchProtectionRulesetParams,
+    GetCustomPropertiesValuesParams, GetRepoCollaboratorsParams, GetRepoIdFromRepoNameParams,
+    GetRepoNameFromRepoIdParams, GetRepoSbomParams, GetWeeklyCommitCountParams, GithubApiWrapper,
+    GithubRepository, ListFilesParams, RemoveUserFromRepoParams, RequireSignedCommitsParams,
+    UpdateBranchProtectionRuleParams,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -24,20 +29,19 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<RemoveUserFromRepoParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         // GitHub says this is only valid on Organization repositories. Not sure if it's ignored
         // on others? This may not work on standard accounts. Also, pull is the lowest permission level
-        let user = self.validate_username(request.get("user").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
+        let user = self.validate_username(&request.params.user)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
 
         let address = format!("/repos/{repo}/collaborators/{user}");
         info!("Removing user [{user}] from [{repo}] on behalf of {module}");
 
         match self
-            .make_generic_delete_request::<&str>(address, None, module)
+            .make_generic_delete_request::<&str>(&request.client_id, address, None, module)
             .await
         {
             Ok((status, _)) => {
@@ -60,15 +64,14 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<AddUserToRepoParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         // GitHub says this is only valid on Organization repositories. Not sure if it's ignored
         // on others? This may not work on standard accounts. Also, pull is the lowest permission level
-        let user = self.validate_username(request.get("user").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
-        let permission = request.get("permission").unwrap_or(&"pull");
+        let user = self.validate_username(&request.params.user)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
+        let permission = request.params.permission.as_deref().unwrap_or("pull");
 
         info!(
             "Adding user [{user}] to [{repo}] with permission [{permission}] on behalf of {module}"
@@ -85,7 +88,7 @@ impl Github {
         };
 
         match self
-            .make_generic_put_request(address, Some(&permission), module)
+            .make_generic_put_request(&request.client_id, address, Some(&permission), module)
             .await
         {
             Ok((status, _)) => {
@@ -110,19 +113,20 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<FetchCommitParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let user = self.validate_username(request.get("user").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
-        let commit =
-            self.validate_commit_hash(request.get("commit").ok_or(ApiError::BadRequest)?)?;
+        let user = self.validate_username(&request.params.user)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
+        let commit = self.validate_commit_hash(&request.params.commit)?;
 
         info!("Fetching commit [{commit}] from [{repo}] by [{user}] on behalf of {module}");
         let address = format!("/repos/{user}/{repo}/commits/{commit}");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)
@@ -144,24 +148,23 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<ListFilesParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let organization =
-            self.validate_org(request.get("organization").ok_or(ApiError::BadRequest)?)?;
-        let repository_name = self.validate_repository_name(
-            request.get("repository_name").ok_or(ApiError::BadRequest)?,
-        )?;
-        let pull_request =
-            self.validate_pint(request.get("pull_request").ok_or(ApiError::BadRequest)?)?;
-        let page = self.validate_pint(request.get("page").ok_or(ApiError::BadRequest)?)?;
+        let organization = self.validate_org(&request.params.owner)?;
+        let repository_name = self.validate_repository_name(&request.params.repo)?;
+        let pull_request = self.validate_pint(&request.params.pull_request)?;
+        let page = self.validate_pint(&request.params.page)?;
 
         info!("Fetching files for Pull Request Nr {pull_request} from [{organization}/{repository_name}] on behalf of {module}");
         let address = format!(
             "/repos/{organization}/{repository_name}/pulls/{pull_request}/files?page={page}"
         );
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)
@@ -183,12 +186,12 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: FetchFileRequest =
+        let request: GithubApiWrapper<FetchFileRequest> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let organization = self.validate_org(&request.organization)?;
-        let repository_name = self.validate_repository_name(&request.repository_name)?;
-        let file_path = &request.file_path;
+        let organization = self.validate_org(&request.params.organization)?;
+        let repository_name = self.validate_repository_name(&request.params.repository_name)?;
+        let file_path = &request.params.file_path;
 
         // If this call return Ok(_), it means the provided file path contains ".." which we do
         // not want to allow
@@ -199,7 +202,7 @@ impl Github {
             return Err(ApiError::BadRequest);
         }
 
-        let reference = request.reference;
+        let reference = &request.params.reference;
 
         // Reference can be commit hash OR a branch name.
         // To validate that the provided ref is valid, we must check that it is either a
@@ -210,7 +213,7 @@ impl Github {
             return Err(ApiError::BadRequest);
         }
 
-        let custom_media_type = request.media_type;
+        let custom_media_type = request.params.media_type;
 
         info!("Fetching contents of file in repository [{organization}/{repository_name}] at {file_path} and reference {reference} with encoding [{custom_media_type}]");
         let address =
@@ -228,7 +231,7 @@ impl Github {
         );
 
         match self
-            .make_get_request_with_headers(address, Some(headers), module)
+            .make_get_request_with_headers(&request.client_id, address, Some(headers), module)
             .await
         {
             Ok((status, Ok(body))) => {
@@ -252,19 +255,21 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<GetBranchProtectionRulesParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_username(request.get("owner").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
-        let branch =
-            self.validate_branch_name(request.get("branch").ok_or(ApiError::BadRequest)?)?;
+        let owner = self.validate_username(&request.params.owner)?;
+
+        let repo = self.validate_repository_name(&request.params.repo)?;
+        let branch = self.validate_branch_name(&request.params.branch)?;
 
         info!("Fetching branch protection rules for branch [{branch}] in repo [{repo}] on behalf of {module}");
         let address = format!("/repos/{owner}/{repo}/branches/{branch}/protection");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)
@@ -286,19 +291,20 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<GetBranchProtectionRulesetParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_username(request.get("owner").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
-        let branch =
-            self.validate_branch_name(request.get("branch").ok_or(ApiError::BadRequest)?)?;
+        let owner = self.validate_username(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
+        let branch = self.validate_branch_name(&request.params.branch)?;
 
         info!("Fetching branch protection rules (as in rulesets) for branch [{branch}] in repo [{repo}] on behalf of {module}");
         let address = format!("/repos/{owner}/{repo}/rules/branches/{branch}");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)
@@ -322,26 +328,17 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<GetRepoCollaboratorsParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_username(request.get("owner").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
-        let per_page: u8 = request
-            .get("per_page")
-            .unwrap_or(&"30")
-            .parse::<u8>()
-            .map_err(|_| ApiError::BadRequest)?;
-        let page: u16 = request
-            .get("page")
-            .unwrap_or(&"1")
-            .parse::<u16>()
-            .map_err(|_| ApiError::BadRequest)?;
-        let affiliation = request.get("affiliation").unwrap_or(&"all");
+        let owner = self.validate_username(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
+        let per_page: u8 = request.params.per_page.unwrap_or(30);
+        let page: u16 = request.params.page.unwrap_or(1);
+        let affiliation = request.params.affiliation.as_deref().unwrap_or("all");
         // See https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2026-03-10#list-repository-collaborators
         // for more details on the possible values for affiliation
-        if !["outside", "direct", "all"].contains(affiliation) {
+        if !["outside", "direct", "all"].contains(&affiliation) {
             return Err(ApiError::BadRequest);
         }
 
@@ -354,7 +351,10 @@ impl Github {
         let address =
             format!("/repos/{owner}/{repo}/collaborators?per_page={per_page}&affiliation={affiliation}&page={page}");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)
@@ -376,15 +376,13 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: HashMap<String, String> =
+        let request: GithubApiWrapper<UpdateBranchProtectionRuleParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_username(request.get("owner").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
-        let branch =
-            self.validate_branch_name(request.get("branch").ok_or(ApiError::BadRequest)?)?;
-        let body = request.get("body").ok_or(ApiError::BadRequest)?;
+        let owner = self.validate_username(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
+        let branch = self.validate_branch_name(&request.params.branch)?;
+        let body = &request.params.body;
         // We deserialize to a Value. This has two effects: (1) it checks that we received valid JSON,
         // and (2) it prepares the body that will be sent later with the request.
         let body =
@@ -394,7 +392,7 @@ impl Github {
         let address = format!("/repos/{owner}/{repo}/branches/{branch}/protection");
 
         match self
-            .make_generic_put_request(address, Some(&body), module)
+            .make_generic_put_request(&request.client_id, address, Some(&body), module)
             .await
         {
             Ok((status, _)) => {
@@ -417,24 +415,13 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<RequireSignedCommitsParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_username(request.get("owner").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
-        let branch =
-            self.validate_branch_name(request.get("branch").ok_or(ApiError::BadRequest)?)?;
-        let activated = match request
-            .get("activated")
-            .ok_or(ApiError::BadRequest)?
-            .to_string()
-            .as_str()
-        {
-            "true" => true,
-            "false" => false,
-            _ => return Err(ApiError::BadRequest),
-        };
+        let owner = self.validate_username(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
+        let branch = self.validate_branch_name(&request.params.branch)?;
+        let activated = request.params.activated;
 
         let address =
             format!("/repos/{owner}/{repo}/branches/{branch}/protection/required_signatures");
@@ -444,7 +431,7 @@ impl Github {
             info!("Enabling signed commits requirement for branch [{branch}] in repo [{owner}/{repo}] on behalf of {module}");
 
             match self
-                .make_generic_post_request(address, None::<String>, module)
+                .make_generic_post_request(&request.client_id, address, None::<String>, module)
                 .await
             {
                 Ok((status, _)) => {
@@ -462,7 +449,7 @@ impl Github {
             info!("Disabling signed commits requirement for branch [{branch}] in repo [{owner}/{repo}] on behalf of {module}");
 
             match self
-                .make_generic_delete_request(address, None::<&String>, module)
+                .make_generic_delete_request(&request.client_id, address, None::<&String>, module)
                 .await
             {
                 Ok((status, _)) => {
@@ -486,17 +473,19 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<GetWeeklyCommitCountParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_username(request.get("owner").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
+        let owner = self.validate_username(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
 
         info!("Fetching weekly commit count for repo [{owner}/{repo}] on behalf of {module}");
         let address = format!("/repos/{owner}/{repo}/stats/participation");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)
@@ -518,13 +507,13 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: CommentOnPullRequestRequest =
+        let request: GithubApiWrapper<CommentOnPullRequestRequest> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let username = self.validate_username(&request.owner)?;
-        let repository_name = self.validate_repository_name(&request.repository)?;
-        let pull_request = self.validate_pint(&request.number)?;
-        let comment = &request.comment;
+        let username = self.validate_username(&request.params.owner)?;
+        let repository_name = self.validate_repository_name(&request.params.repository)?;
+        let pull_request = self.validate_pint(&request.params.number)?;
+        let comment = &request.params.comment;
 
         info!("Commenting on Pull Request [{pull_request}] in repo [{repository_name}] on behalf of {module}");
         let address = format!("/repos/{username}/{repository_name}/issues/{pull_request}/comments");
@@ -535,7 +524,7 @@ impl Github {
         }
 
         match self
-            .make_generic_post_request(address, Body { body: comment }, module)
+            .make_generic_post_request(&request.client_id, address, Body { body: comment }, module)
             .await
         {
             Ok((status, _)) => {
@@ -558,17 +547,19 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<GetCustomPropertiesValuesParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_username(request.get("owner").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
+        let owner = self.validate_username(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
 
         info!("Getting custom properties of repo [{repo}] on behalf of {module}");
         let address = format!("/repos/{owner}/{repo}/properties/values");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)
@@ -590,16 +581,19 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: CheckCodeownersParams =
+        let request: GithubApiWrapper<CheckCodeownersParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_username(&request.owner)?;
-        let repo = self.validate_repository_name(&request.repo)?;
+        let owner = self.validate_username(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
 
         info!("Checking CODEOWNERS for repo [{owner}/{repo}] on behalf of [{module}]");
         let address = format!("/repos/{owner}/{repo}/codeowners/errors");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     // Deserialize the body and see if we had errors
@@ -643,27 +637,27 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: CreateFileRequest =
+        let request: GithubApiWrapper<CreateFileRequest> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_org(&request.owner)?;
-        let repo = self.validate_repository_name(&request.repo)?;
-        let path = self.validate_path(&request.path)?;
-        let file_hash = sha256_hex(&request.content);
+        let owner = self.validate_org(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
+        let path = self.validate_path(&request.params.path)?;
+        let file_hash = sha256_hex(&request.params.content);
 
         info!("Creating file with hash [{file_hash}] at [{path}] in repository [{owner}/{repo}] on behalf of [{module}]");
         let address = format!("/repos/{owner}/{repo}/contents/{path}");
 
         let mut body = json!({
-            "message": request.message,
-            "content": base64::encode(&request.content),
+            "message": request.params.message,
+            "content": base64::encode(&request.params.content),
         });
-        if let Some(branch) = request.branch {
+        if let Some(branch) = request.params.branch {
             body["branch"] = json!(branch);
         }
 
         match self
-            .make_generic_put_request(address, Some(&body), module)
+            .make_generic_put_request(&request.client_id, address, Some(&body), module)
             .await
         {
             Ok((status, Ok(_))) => {
@@ -687,17 +681,19 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<GetRepoSbomParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_username(request.get("owner").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
+        let owner = self.validate_username(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
 
         info!("Fetching SBOM for repo [{owner}/{repo}] on behalf of [{module}]");
         let address = format!("/repos/{owner}/{repo}/dependency-graph/sbom");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)
@@ -719,20 +715,20 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<GetRepoIdFromRepoNameParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_username(request.get("owner").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
+        let owner = self.validate_username(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
 
-        self.get_repo_id_from_repo_name_internal(&owner, &repo, module)
+        self.get_repo_id_from_repo_name_internal(&request.client_id, &owner, &repo, module)
             .await
     }
 
     /// Internal function to get a repo ID from its name, so that it can be called from different places in the runtime
     pub async fn get_repo_id_from_repo_name_internal(
         &self,
+        client_id: &str,
         owner: &str,
         repo: &str,
         module: Arc<PlaidModule>,
@@ -740,7 +736,10 @@ impl Github {
         info!("Getting repo ID for repo [{owner}/{repo}] on behalf of [{module}]");
         let address = format!("/repos/{owner}/{repo}");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     let repo_info: GithubRepository = serde_json::from_str(&body)
@@ -762,15 +761,21 @@ impl Github {
     /// Related to https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository
     pub async fn get_repo_name_from_repo_id(
         &self,
-        repo_id: &str,
+        params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let repo_id = self.validate_repo_id(repo_id)?;
+        let request: GithubApiWrapper<GetRepoNameFromRepoIdParams> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let repo_id = self.validate_repo_id(&request.params.repo_id)?;
 
         info!("Getting repo name for repo ID [{repo_id}] on behalf of [{module}]");
         let address = format!("/repositories/{repo_id}");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     let repo_info: GithubRepository = serde_json::from_str(&body)

--- a/runtime/plaid/src/apis/github/secrets.rs
+++ b/runtime/plaid/src/apis/github/secrets.rs
@@ -5,10 +5,13 @@ use crate::{
 };
 
 use alkali::asymmetric::seal;
-use plaid_stl::github::{AddOrRemoveRepoToOrgSecretParams, ListOrgSecretsForRepoParams};
+use plaid_stl::github::{
+    AddOrRemoveRepoToOrgSecretParams, ConfigureSecretParams, GithubApiWrapper,
+    ListOrgSecretsForRepoParams,
+};
 use serde::Serialize;
 use serde_json::Value;
-use std::{collections::HashMap, fmt::Display, sync::Arc};
+use std::{fmt::Display, sync::Arc};
 
 /// GitHub's maximum secret size limit in bytes (48KiB)
 const GITHUB_SECRET_MAX_BYTES: usize = 48 * 1024; // 49,152 bytes
@@ -38,11 +41,12 @@ impl Github {
     /// given the API address to fetch the public key from (which differs based on the type of secret)
     async fn get_pub_key_for_secret_encryption(
         &self,
+        client_id: impl Display,
         address: impl Display,
         module: Arc<PlaidModule>,
     ) -> Result<(String, String), ApiError> {
         let (status, body) = self
-            .make_generic_get_request(address.to_string(), module.clone())
+            .make_generic_get_request(client_id, address.to_string(), module.clone())
             .await?;
         if status != 200 {
             return Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
@@ -78,20 +82,18 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<ConfigureSecretParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let owner = self.validate_username(request.get("owner").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
+        let owner = self.validate_username(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
         // Validate an env name if present
-        let env_name = match request.get("env_name") {
+        let env_name = match &request.params.env_name {
             Some(name) => Some(self.validate_environment_name(name)?),
             None => None,
         };
-        let secret_name =
-            self.validate_secret_name(request.get("secret_name").ok_or(ApiError::BadRequest)?)?;
-        let secret = request.get("secret").ok_or(ApiError::BadRequest)?;
+        let secret_name = self.validate_secret_name(&request.params.secret_name)?;
+        let secret = &request.params.secret;
 
         // Validate secret length against GitHub's 48KiB limit
         if secret.len() > GITHUB_SECRET_MAX_BYTES {
@@ -119,7 +121,7 @@ impl Github {
             }
         };
         let (pub_key, key_id) = self
-            .get_pub_key_for_secret_encryption(address, module.clone())
+            .get_pub_key_for_secret_encryption(&request.client_id, address, module.clone())
             .await?;
 
         // 2. Encrypt the secret under the pub key
@@ -159,7 +161,7 @@ impl Github {
         };
 
         match self
-            .make_generic_put_request(address, Some(&body), module)
+            .make_generic_put_request(&request.client_id, address, Some(&body), module)
             .await
         {
             Ok((status, _)) => {
@@ -179,6 +181,7 @@ impl Github {
 
     async fn execute_org_secret_action(
         &self,
+        client_id: impl Display,
         request: &AddOrRemoveRepoToOrgSecretParams,
         action: RepoToOrgSecretAction,
         module: Arc<PlaidModule>,
@@ -188,7 +191,12 @@ impl Github {
         let repository = self.validate_repository_name(&request.repository)?;
 
         let repo_id = self
-            .get_repo_id_from_repo_name_internal(&org, &repository, module.clone())
+            .get_repo_id_from_repo_name_internal(
+                &client_id.to_string(),
+                &org,
+                &repository,
+                module.clone(),
+            )
             .await?;
 
         let address = format!("/orgs/{org}/actions/secrets/{secret_name}/repositories/{repo_id}");
@@ -199,7 +207,7 @@ impl Github {
         // So we use a macro to avoid duplicating code and to keep the match DRY.
         macro_rules! org_secret_action {
             ($method:ident, $action:expr) => {
-                match self.$method(address, None::<&String>, module.clone()).await {
+                match self.$method(client_id, address, None::<&String>, module.clone()).await {
                     Ok((status, _)) if status == 204 => {
                         info!("[{module}] {action} organization secret [{secret_name}] on [{repository}]");
                         Ok(0)
@@ -227,11 +235,16 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: AddOrRemoveRepoToOrgSecretParams =
+        let request: GithubApiWrapper<AddOrRemoveRepoToOrgSecretParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        self.execute_org_secret_action(&request, RepoToOrgSecretAction::Add, module)
-            .await
+        self.execute_org_secret_action(
+            request.client_id,
+            &request.params,
+            RepoToOrgSecretAction::Add,
+            module,
+        )
+        .await
     }
 
     /// Remove a repository from the list of repositories that have access to an organization secret
@@ -241,11 +254,16 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: AddOrRemoveRepoToOrgSecretParams =
+        let request: GithubApiWrapper<AddOrRemoveRepoToOrgSecretParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        self.execute_org_secret_action(&request, RepoToOrgSecretAction::Remove, module)
-            .await
+        self.execute_org_secret_action(
+            request.client_id,
+            &request.params,
+            RepoToOrgSecretAction::Remove,
+            module,
+        )
+        .await
     }
 
     /// List the organization secrets that a repository has access to
@@ -255,22 +273,25 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: ListOrgSecretsForRepoParams =
+        let request: GithubApiWrapper<ListOrgSecretsForRepoParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let org = self.validate_org(&request.org)?;
-        let repository = self.validate_repository_name(&request.repository)?;
+        let org = self.validate_org(&request.params.org)?;
+        let repository = self.validate_repository_name(&request.params.repository)?;
 
         // Note: we do not validate these values because they come in encoded as u32, and that's all we need.
         // Therefore, the validation is in the fact that they were able to be deserialized.
-        let per_page = request.per_page.unwrap_or(30);
-        let page = request.page.unwrap_or(1);
+        let per_page = request.params.per_page.unwrap_or(30);
+        let page = request.params.page.unwrap_or(1);
 
         info!("Listing organization secrets that can be accessed by repository [{repository}] on behalf of [{module}]");
 
         let url = format!("/repos/{org}/{repository}/actions/organization-secrets?per_page={per_page}&page={page}");
 
-        match self.make_generic_get_request(url, module).await {
+        match self
+            .make_generic_get_request(request.client_id, url, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)

--- a/runtime/plaid/src/apis/github/teams.rs
+++ b/runtime/plaid/src/apis/github/teams.rs
@@ -1,5 +1,9 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
+use plaid_stl::github::{
+    AddRepoToTeamParams, AddUserToTeamParams, GetRepoTeamsParams, GithubApiWrapper,
+    RemoveRepoFromTeamParams, RemoveUserFromTeamParams,
+};
 use serde::Serialize;
 
 use super::Github;
@@ -66,20 +70,19 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<RemoveUserFromTeamParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         // Parse out all the parameters from our parameter string
-        let org = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
-        let team_slug =
-            self.validate_team_slug(request.get("team_slug").ok_or(ApiError::BadRequest)?)?;
-        let user = self.validate_username(request.get("user").ok_or(ApiError::BadRequest)?)?;
+        let org = self.validate_org(&request.params.org)?;
+        let team_slug = self.validate_team_slug(&request.params.team_slug)?;
+        let user = self.validate_username(&request.params.user)?;
 
         info!("Removing user [{user}] from [{team_slug}] in [{org}] on behalf of {module}");
         let address = format!("/orgs/{org}/teams/{team_slug}/memberships/{user}");
 
         match self
-            .make_generic_delete_request::<&str>(address, None, module)
+            .make_generic_delete_request::<&str>(&request.client_id, address, None, module)
             .await
         {
             Ok((status, _)) => {
@@ -101,16 +104,15 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<AddUserToTeamParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         // Parse out all the parameters from our parameter string
-        let org = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
-        let team_slug =
-            self.validate_team_slug(request.get("team_slug").ok_or(ApiError::BadRequest)?)?;
-        let user = self.validate_username(request.get("user").ok_or(ApiError::BadRequest)?)?;
+        let org = self.validate_org(&request.params.org)?;
+        let team_slug = self.validate_team_slug(&request.params.team_slug)?;
+        let user = self.validate_username(&request.params.user)?;
 
-        let role = request.get("role").ok_or(ApiError::BadRequest)?;
+        let role = &request.params.role;
 
         info!("Adding user [{user}] to [{team_slug}] in [{org}] as [{role}] on behalf of {module}");
         #[derive(Serialize)]
@@ -125,7 +127,7 @@ impl Github {
         let address = format!("/orgs/{org}/teams/{team_slug}/memberships/{user}");
 
         match self
-            .make_generic_put_request(address, Some(&role), module)
+            .make_generic_put_request(&request.client_id, address, Some(&role), module)
             .await
         {
             Ok((status, _)) => {
@@ -147,19 +149,15 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<AddRepoToTeamParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         // Parse out all the parameters
-        let org = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
-        let team_slug =
-            self.validate_team_slug(request.get("team_slug").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
-        let permission = request
-            .get("permission")
-            .and_then(|p| Permission::from_str(*p).ok())
-            .ok_or(ApiError::BadRequest)?;
+        let org = self.validate_org(&request.params.org)?;
+        let team_slug = self.validate_team_slug(&request.params.team_slug)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
+        let permission =
+            Permission::from_str(&request.params.permission).map_err(|_| ApiError::BadRequest)?;
 
         info!("Adding team [{team_slug}] to repo [{repo}] with permission [{permission}] on behalf of [{module}]");
         let address = format!("/orgs/{org}/teams/{team_slug}/repos/{org}/{repo}");
@@ -167,7 +165,12 @@ impl Github {
         let permission_payload = PermissionPayload::from(&permission);
 
         match self
-            .make_generic_put_request(address, Some(&permission_payload), module)
+            .make_generic_put_request(
+                &request.client_id,
+                address,
+                Some(&permission_payload),
+                module,
+            )
             .await
         {
             Ok((status, _)) => {
@@ -189,21 +192,19 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<RemoveRepoFromTeamParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         // Parse out all the parameters
-        let org = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
-        let team_slug =
-            self.validate_team_slug(request.get("team_slug").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
+        let org = self.validate_org(&request.params.org)?;
+        let team_slug = self.validate_team_slug(&request.params.team_slug)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
 
         info!("Removing team [{team_slug}] from repo [{repo}] on behalf of [{module}]");
         let address = format!("/orgs/{org}/teams/{team_slug}/repos/{org}/{repo}");
 
         match self
-            .make_generic_delete_request::<&str>(address, None, module)
+            .make_generic_delete_request::<&str>(&request.client_id, address, None, module)
             .await
         {
             Ok((status, _)) => {
@@ -225,29 +226,23 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: HashMap<&str, &str> =
+        let request: GithubApiWrapper<GetRepoTeamsParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         // Parse out all the parameters
-        let org = self.validate_org(request.get("org").ok_or(ApiError::BadRequest)?)?;
-        let repo =
-            self.validate_repository_name(request.get("repo").ok_or(ApiError::BadRequest)?)?;
+        let org = self.validate_org(&request.params.org)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
 
-        let per_page: u8 = request
-            .get("per_page")
-            .unwrap_or(&"30")
-            .parse::<u8>()
-            .map_err(|_| ApiError::BadRequest)?;
-        let page: u16 = request
-            .get("page")
-            .unwrap_or(&"1")
-            .parse::<u16>()
-            .map_err(|_| ApiError::BadRequest)?;
+        let per_page: u8 = request.params.per_page.unwrap_or(30);
+        let page: u16 = request.params.page.unwrap_or(1);
 
         info!("Getting teams with access to repo [{repo}] on behalf of [{module}]");
         let address = format!("/repos/{org}/{repo}/teams?per_page={per_page}&page={page}");
 
-        match self.make_generic_get_request(address, module).await {
+        match self
+            .make_generic_get_request(&request.client_id, address, module)
+            .await
+        {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)

--- a/runtime/plaid/src/apis/github/validators.rs
+++ b/runtime/plaid/src/apis/github/validators.rs
@@ -80,6 +80,8 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
     // Matches if .. is present in a file path
     define_regex_validator!(validators, "contains_parent_directory_component", r"\.\.");
 
+    define_regex_validator!(validators, "client_id", r"^[\w\-]+$");
+
     validators
 }
 

--- a/runtime/plaid/src/apis/github/validators.rs
+++ b/runtime/plaid/src/apis/github/validators.rs
@@ -80,8 +80,6 @@ pub fn create_validators() -> HashMap<&'static str, regex::Regex> {
     // Matches if .. is present in a file path
     define_regex_validator!(validators, "contains_parent_directory_component", r"\.\.");
 
-    define_regex_validator!(validators, "client_id", r"^[\w\-]+$");
-
     validators
 }
 

--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -1,4 +1,4 @@
-use crate::apis::github::{build_github_client, Authentication};
+use crate::apis::github::{build_github_clients, Authentication};
 use crate::apis::ApiError;
 use crate::executor::Message;
 use crate::parse_duration;
@@ -9,6 +9,7 @@ use plaid_stl::messages::{Generator, LogSource, LogbacksAllowed};
 use serde::Deserialize;
 use serde_json::Value;
 use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::time::Duration;
 use time::OffsetDateTime;
@@ -173,7 +174,13 @@ pub struct Github {
 
 impl Github {
     pub fn new(config: GithubConfig, logger: Sender<Message>) -> Result<Self, ApiError> {
-        let client = build_github_client(&config.authentication)?;
+        let default_client_auth: HashMap<String, Authentication> = [(
+            "gh_data_generator".to_string(),
+            config.authentication.clone(),
+        )]
+        .into();
+        let clients = build_github_clients(&default_client_auth)?;
+        let client = clients.into_iter().next().unwrap().1; // we know there is at least one client because we just built it with one entry
         let lru_cache_size = match config.lru_cache_size {
             0 => {
                 warn!("GitHub API: The LRU cache size must be greater than 0. Using default value of {}.", default_lru_cache_size());


### PR DESCRIPTION
This PR adds support for multiple clients that are used to talk to the GitHub API.

Similarly to what already happens for the Slack API, this gives Plaid the ability to "drive" different GH apps, use different tokens, etc. This way, each operation can be executed with a specific client, which has specific and minimum permissions.

## Breaking changes
These changes are breaking and require all rules that use the GH API to be updated.

In particular:
* The configuration needs to be updated to have a map between client ID and authorization method
* All call sites need to be updated to pass the ID of the client they want to use to make the call