### PR TITLE
[GH API] Add enterprise call to manage repo access for org installations

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3990,7 +3990,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "aes",
  "alkali",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.41.0"
+version = "0.41.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/github/enterprise.rs
+++ b/runtime/plaid-stl/src/github/enterprise.rs
@@ -1,0 +1,131 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{github::GithubApiWrapper, PlaidFunctionError};
+
+#[derive(Deserialize, Serialize)]
+pub struct GrantRepoAccessToOrgInstallationParams {
+    pub enterprise: String,
+    pub org: String,
+    pub installation_id: u64,
+    pub repositories: Vec<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct RemoveRepoAccessFromOrgInstallationParams {
+    pub enterprise: String,
+    pub org: String,
+    pub installation_id: u64,
+    pub repositories: Vec<String>,
+}
+
+/// Grants a GitHub organization installation access to one or more repositories
+/// ## Arguments
+///
+/// * `enterprise` - The enterprise name. The name is not case sensitive.
+/// * `org` - The organization name. The name is not case sensitive.
+/// * `installation_id` - The ID of the installation to grant access to.
+/// * `repositories` - The list of repositories to grant access to.
+pub fn grant_repo_access_to_org_installation(
+    client_id: impl Display,
+    enterprise: impl Display,
+    org: impl Display,
+    installation_id: u64,
+    repositories: Vec<String>,
+) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(github, grant_repo_access_to_org_installation);
+    }
+
+    // Parse repo names and remove org if present
+    let prefix = format!("{org}/");
+    let repositories: Vec<String> = repositories
+        .into_iter()
+        .map(|repo| repo.trim_start_matches(&prefix).to_string())
+        .collect();
+
+    let params = GrantRepoAccessToOrgInstallationParams {
+        enterprise: enterprise.to_string(),
+        org: org.to_string(),
+        installation_id,
+        repositories,
+    };
+
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let request = serde_json::to_string(&wrapper).unwrap();
+
+    let res = unsafe {
+        github_grant_repo_access_to_org_installation(
+            request.as_bytes().as_ptr(),
+            request.as_bytes().len(),
+        )
+    };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    Ok(())
+}
+
+/// Removes a GitHub organization installation's access to one or more repositories
+/// ## Arguments
+///
+/// * `enterprise` - The enterprise name. The name is not case sensitive.
+/// * `org` - The organization name. The name is not case sensitive.
+/// * `installation_id` - The ID of the installation to remove access from.
+/// * `repositories` - The list of repositories to remove access from.
+pub fn remove_repo_access_from_org_installation(
+    client_id: impl Display,
+    enterprise: impl Display,
+    org: impl Display,
+    installation_id: u64,
+    repositories: Vec<String>,
+) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(github, remove_repo_access_from_org_installation);
+    }
+
+    // Parse repo names and remove org if present
+    let prefix = format!("{org}/");
+    let repositories: Vec<String> = repositories
+        .into_iter()
+        .map(|repo| repo.trim_start_matches(&prefix).to_string())
+        .collect();
+
+    let params = RemoveRepoAccessFromOrgInstallationParams {
+        enterprise: enterprise.to_string(),
+        org: org.to_string(),
+        installation_id,
+        repositories,
+    };
+
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let request = serde_json::to_string(&wrapper).unwrap();
+
+    let res = unsafe {
+        github_remove_repo_access_from_org_installation(
+            request.as_bytes().as_ptr(),
+            request.as_bytes().len(),
+        )
+    };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    Ok(())
+}

--- a/runtime/plaid-stl/src/github/mod.rs
+++ b/runtime/plaid-stl/src/github/mod.rs
@@ -1,5 +1,6 @@
 mod actions;
 mod copilot;
+mod enterprise;
 mod fpat;
 mod graphql;
 mod members;
@@ -16,6 +17,7 @@ mod types;
 
 pub use actions::*;
 pub use copilot::*;
+pub use enterprise::*;
 pub use fpat::*;
 pub use graphql::*;
 pub use members::*;

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.41.0"
+version = "0.41.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/github/enterprise.rs
+++ b/runtime/plaid/src/apis/github/enterprise.rs
@@ -1,0 +1,106 @@
+use std::sync::Arc;
+
+use plaid_stl::github::{
+    GithubApiWrapper, GrantRepoAccessToOrgInstallationParams,
+    RemoveRepoAccessFromOrgInstallationParams,
+};
+use serde_json::json;
+
+use crate::{
+    apis::{github::GitHubError, ApiError},
+    loader::PlaidModule,
+};
+
+use super::Github;
+
+impl Github {
+    /// Grant a GitHub organization installation access to a repository
+    /// See https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/organization-installations?apiVersion=2026-03-10#grant-repository-access-to-an-organization-installation for more detail
+    pub async fn grant_repo_access_to_org_installation(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<u32, ApiError> {
+        let request: GithubApiWrapper<GrantRepoAccessToOrgInstallationParams> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        // We use the same validator for enterprise and org
+        let enterprise = self.validate_org(&request.params.enterprise)?;
+        let org = self.validate_org(&request.params.org)?;
+        let installation_id = request.params.installation_id;
+
+        // We do not validate the repositories because those are in the body and we rely on the API to validate them.
+
+        info!(
+            "Granting repository access to organization installation [{installation_id}] for enterprise [{enterprise}] and organization [{org}] on behalf of [{module}]. Involved repos: {:?}",
+            request.params.repositories
+        );
+
+        let address = format!("/enterprises/{enterprise}/apps/organizations/{org}/installations/{installation_id}/repositories/add");
+
+        let body = json!({
+            "repositories": request.params.repositories,
+        });
+
+        match self
+            .make_generic_patch_request(&request.client_id, address, Some(&body), module)
+            .await
+        {
+            Ok((status, _)) => {
+                if status == 200 {
+                    Ok(0)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Removes a GitHub organization installation's access to a repository
+    /// See https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/organization-installations?apiVersion=2026-03-10#remove-repository-access-from-an-organization-installation for more detail
+    pub async fn remove_repo_access_from_org_installation(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<u32, ApiError> {
+        let request: GithubApiWrapper<RemoveRepoAccessFromOrgInstallationParams> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        // We use the same validator for enterprise and org
+        let enterprise = self.validate_org(&request.params.enterprise)?;
+        let org = self.validate_org(&request.params.org)?;
+        let installation_id = request.params.installation_id;
+
+        // We do not validate the repositories because those are in the body and we rely on the API to validate them.
+
+        info!(
+            "Removing repository access from organization installation [{installation_id}] for enterprise [{enterprise}] and organization [{org}] on behalf of [{module}]. Involved repos: {:?}",
+            request.params.repositories
+        );
+
+        let address = format!("/enterprises/{enterprise}/apps/organizations/{org}/installations/{installation_id}/repositories/remove");
+
+        let body = json!({
+            "repositories": request.params.repositories,
+        });
+
+        match self
+            .make_generic_patch_request(&request.client_id, address, Some(&body), module)
+            .await
+        {
+            Ok((status, _)) => {
+                if status == 200 {
+                    Ok(0)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/runtime/plaid/src/apis/github/enterprise.rs
+++ b/runtime/plaid/src/apis/github/enterprise.rs
@@ -14,7 +14,7 @@ use crate::{
 use super::Github;
 
 impl Github {
-    /// Grant a GitHub organization installation access to a repository
+    /// Grant a GitHub organization installation access to one or more repositories
     /// See https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/organization-installations?apiVersion=2026-03-10#grant-repository-access-to-an-organization-installation for more detail
     pub async fn grant_repo_access_to_org_installation(
         &self,
@@ -61,7 +61,7 @@ impl Github {
         }
     }
 
-    /// Removes a GitHub organization installation's access to a repository
+    /// Removes a GitHub organization installation's access to one or more repositories
     /// See https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/organization-installations?apiVersion=2026-03-10#remove-repository-access-from-an-organization-installation for more detail
     pub async fn remove_repo_access_from_org_installation(
         &self,

--- a/runtime/plaid/src/apis/github/enterprise.rs
+++ b/runtime/plaid/src/apis/github/enterprise.rs
@@ -29,7 +29,9 @@ impl Github {
         let org = self.validate_org(&request.params.org)?;
         let installation_id = request.params.installation_id;
 
-        // We do not validate the repositories because those are in the body and we rely on the API to validate them.
+        for repo in &request.params.repositories {
+            self.validate_repository_name(repo)?;
+        }
 
         info!(
             "Granting repository access to organization installation [{installation_id}] for enterprise [{enterprise}] and organization [{org}] on behalf of [{module}]. Involved repos: {:?}",
@@ -74,7 +76,9 @@ impl Github {
         let org = self.validate_org(&request.params.org)?;
         let installation_id = request.params.installation_id;
 
-        // We do not validate the repositories because those are in the body and we rely on the API to validate them.
+        for repo in &request.params.repositories {
+            self.validate_repository_name(repo)?;
+        }
 
         info!(
             "Removing repository access from organization installation [{installation_id}] for enterprise [{enterprise}] and organization [{org}] on behalf of [{module}]. Involved repos: {:?}",

--- a/runtime/plaid/src/apis/github/mod.rs
+++ b/runtime/plaid/src/apis/github/mod.rs
@@ -2,6 +2,7 @@ mod actions;
 mod code;
 mod copilot;
 mod deploy_keys;
+mod enterprise;
 mod environments;
 mod graphql;
 mod members;
@@ -215,6 +216,40 @@ impl Github {
         })?;
 
         let request = client._put(uri, body).await;
+
+        match request {
+            Ok(r) => {
+                let status = r.status().as_u16();
+                let body = client.body_to_string(r).await.map_err(|e| {
+                    ApiError::GitHubError(GitHubError::GraphQLRequestError(e.to_string()))
+                });
+                Ok((status, body))
+            }
+            Err(e) => Err(ApiError::GitHubError(GitHubError::ClientError(e))),
+        }
+    }
+
+    /// Make a generic patch request to the GitHub API using the GitHub app library. This exists
+    /// to help facilitate the conversion from a token usage to GitHub app. It also means that
+    /// extra parsing can be avoided since we need to re-serialize anyway to pass back to the rules
+    /// (at least currently).
+    async fn make_generic_patch_request<T: Serialize>(
+        &self,
+        client_id: impl Display,
+        uri: String,
+        body: Option<&T>,
+        module: Arc<PlaidModule>,
+    ) -> Result<(u16, Result<String, ApiError>), ApiError> {
+        info!("Making a patch request to {uri} on behalf of {module}");
+
+        let client = self.clients.get(&client_id.to_string()).ok_or_else(|| {
+            ApiError::GitHubError(GitHubError::InvalidInput(format!(
+                "Client ID not found: {}",
+                client_id
+            )))
+        })?;
+
+        let request = client._patch(uri, body).await;
 
         match request {
             Ok(r) => {

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -449,6 +449,16 @@ impl_new_function_with_error_buffer!(github, get_repo_name_from_repo_id, ALLOW_I
 impl_new_function!(github, add_repo_to_org_secret, DISALLOW_IN_TEST_MODE);
 impl_new_function!(github, remove_repo_from_org_secret, DISALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, list_org_secrets_for_repo, ALLOW_IN_TEST_MODE);
+impl_new_function!(
+    github,
+    grant_repo_access_to_org_installation,
+    DISALLOW_IN_TEST_MODE
+);
+impl_new_function!(
+    github,
+    remove_repo_access_from_org_installation,
+    DISALLOW_IN_TEST_MODE
+);
 
 // GitHub Functions only available with GitHub App authentication
 impl_new_function!(github, review_fpat_requests_for_org, DISALLOW_IN_TEST_MODE);
@@ -784,6 +794,8 @@ define_api_functions! {
         "github_add_repo_to_org_secret"                    => github_add_repo_to_org_secret,
         "github_remove_repo_from_org_secret"               => github_remove_repo_from_org_secret,
         "github_list_org_secrets_for_repo"                 => github_list_org_secrets_for_repo,
+        "github_grant_repo_access_to_org_installation"    => github_grant_repo_access_to_org_installation,
+        "github_remove_repo_access_from_org_installation" => github_remove_repo_access_from_org_installation,
 
         // Slack Calls
         "slack_post_to_named_webhook"     => slack_post_to_named_webhook,


### PR DESCRIPTION
This PR exposes two new API calls to rules:
* `grant_repo_access_to_org_installation`
* `remove_repo_access_from_org_installation`

With proper, enterprise-level access, these can be used to programmatically manage which repositories a GH app has access to.

It also adds `make_generic_patch_request` because this API required a `PATCH` call.