### PR TITLE
Update GH deploy keys API to return ID on creation

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3990,7 +3990,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "aes",
  "alkali",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.44.0"
+version = "0.44.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/github/deploy_keys.rs
+++ b/runtime/plaid-stl/src/github/deploy_keys.rs
@@ -62,9 +62,9 @@ pub fn create_deploy_key(
     title: impl Display,
     key: impl Display,
     read_only: bool,
-) -> Result<(), PlaidFunctionError> {
+) -> Result<u64, PlaidFunctionError> {
     extern "C" {
-        new_host_function!(github, create_deploy_key);
+        new_host_function_with_error_buffer!(github, create_deploy_key);
     }
 
     let params = CreateDeployKeyParams {
@@ -75,14 +75,23 @@ pub fn create_deploy_key(
         read_only,
     };
 
+    const RETURN_BUFFER_SIZE: usize = 64 * 1024; // 64 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
     let wrapped = GithubApiWrapper {
         client_id: client_id.to_string(),
         params,
     };
 
     let params = serde_json::to_string(&wrapped).unwrap();
-    let res =
-        unsafe { github_create_deploy_key(params.as_bytes().as_ptr(), params.as_bytes().len()) };
+    let res = unsafe {
+        github_create_deploy_key(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
 
     // There was an error with the Plaid system. Maybe the API is not
     // configured.
@@ -90,5 +99,11 @@ pub fn create_deploy_key(
         return Err(res.into());
     }
 
-    Ok(())
+    return_buffer.truncate(res as usize);
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    String::from_utf8(return_buffer)
+        .unwrap()
+        .parse::<u64>()
+        .map_err(|_| PlaidFunctionError::InternalApiError)
 }

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.44.0"
+version = "0.44.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/github/deploy_keys.rs
+++ b/runtime/plaid/src/apis/github/deploy_keys.rs
@@ -52,7 +52,7 @@ impl Github {
         &self,
         params: &str,
         module: Arc<PlaidModule>,
-    ) -> Result<u32, ApiError> {
+    ) -> Result<String, ApiError> {
         let request: GithubApiWrapper<CreateDeployKeyParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
         let owner = self.validate_username(&request.params.owner)?;
@@ -81,6 +81,11 @@ impl Github {
             read_only,
         };
 
+        #[derive(serde::Deserialize)]
+        struct Response {
+            id: u64,
+        }
+
         info!("Creating read{perm} deploy key with title [{title}] for repo {owner}/{repo}");
 
         let address = format!("/repos/{owner}/{repo}/keys");
@@ -89,9 +94,11 @@ impl Github {
             .make_generic_post_request(request.client_id, address, Some(&body), module)
             .await
         {
-            Ok((status, Ok(_))) => {
+            Ok((status, Ok(body))) => {
                 if status == 201 {
-                    Ok(0)
+                    let response: Response =
+                        serde_json::from_str(&body).map_err(|_| ApiError::BadRequest)?;
+                    Ok(response.id.to_string())
                 } else {
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
                         status,

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -405,7 +405,7 @@ impl_new_function!(
     DISALLOW_IN_TEST_MODE
 );
 impl_new_function!(github, delete_deploy_key, DISALLOW_IN_TEST_MODE);
-impl_new_function!(github, create_deploy_key, DISALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(github, create_deploy_key, DISALLOW_IN_TEST_MODE);
 impl_new_function!(github, require_signed_commits, DISALLOW_IN_TEST_MODE);
 impl_new_function!(github, add_repo_to_team, DISALLOW_IN_TEST_MODE);
 impl_new_function!(github, remove_repo_from_team, DISALLOW_IN_TEST_MODE);


### PR DESCRIPTION
The `create_...` method now returns the key ID as a `u64`.