### PR TITLE
Support updating files in GH

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.44.2"
+version = "0.45.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3990,7 +3990,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "aes",
  "alkali",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3990,7 +3990,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.44.2"
+version = "0.45.0"
 dependencies = [
  "aes",
  "alkali",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.44.2"
+version = "0.45.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.44.1"
+version = "0.44.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.44.2"
+version = "0.45.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/github/repo.rs
+++ b/runtime/plaid-stl/src/github/repo.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     github::{
-        CreateFileRequest, FetchFileCustomMediaType, FetchFileRequest, GithubApiWrapper,
+        CreateOrUpdateFileRequest, FetchFileCustomMediaType, FetchFileRequest, GithubApiWrapper,
         RepositoryCollaborator, RepositoryCustomProperty, SbomResponse,
     },
     PlaidFunctionError,
@@ -409,7 +409,7 @@ pub fn fetch_file(
     organization: &str,
     repository_name: &str,
     file_path: &str,
-    reference: &str,
+    reference: Option<&str>,
 ) -> Result<String, PlaidFunctionError> {
     fetch_file_with_custom_media_type(
         client_id,
@@ -435,7 +435,7 @@ pub fn fetch_file_with_custom_media_type(
     organization: &str,
     repository_name: &str,
     file_path: &str,
-    reference: &str,
+    reference: Option<&str>,
     media_type: FetchFileCustomMediaType,
 ) -> Result<String, PlaidFunctionError> {
     extern "C" {
@@ -447,7 +447,7 @@ pub fn fetch_file_with_custom_media_type(
         organization: organization.to_string(),
         repository_name: repository_name.to_string(),
         file_path: file_path.to_string(),
-        reference: reference.to_string(),
+        reference: reference.map(|r| r.to_string()),
         media_type,
     };
     let wrapper = GithubApiWrapper {
@@ -578,13 +578,97 @@ pub fn create_file(
         new_host_function_with_error_buffer!(github, create_file);
     }
 
-    let request = CreateFileRequest {
+    let request = CreateOrUpdateFileRequest {
         owner: owner.to_string(),
         repo: repo.to_string(),
         path: path.to_string(),
         message: message.to_string(),
         content: content.into(),
         branch: branch.map(|b| b.to_string()),
+        sha: None,
+    };
+
+    let wrapper = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: request,
+    };
+
+    let request = serde_json::to_string(&wrapper).unwrap();
+    const RETURN_BUFFER_SIZE: usize = 1024; // 1 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let res = unsafe {
+        github_create_file(
+            request.as_bytes().as_ptr(),
+            request.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    let response_body =
+        String::from_utf8(return_buffer).map_err(|_| PlaidFunctionError::InternalApiError)?;
+
+    Ok(response_body)
+}
+
+/// Updates an existing file in a repository (update-only).
+/// Updates an **existing** file in the given `owner` and `repo` at the specified `path`.
+/// The `message` will be used as the commit message. The `content` must be provided as raw bytes
+/// (e.g., a UTF-8 string’s `.into()` or a `Vec<u8>`).
+///
+/// **Do not base64-encode the content** — this function will base64-encode it automatically before sending it to the GitHub API.  
+/// If `branch` is omitted, the repository’s default branch is used.
+/// See the [GitHub API docs](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#create-or-update-file-contents)
+/// for protocol details (this function only supports updates; use the separate create API to create new files).
+pub fn update_file(
+    client_id: impl Display,
+    owner: impl Display,
+    repo: impl Display,
+    path: impl Display,
+    message: impl Display,
+    content: impl Into<Vec<u8>>,
+    branch: Option<impl Display>,
+) -> Result<String, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(github, create_file);
+    }
+
+    // Get the SHA of the existing file to update it
+    let file = fetch_file(
+        &client_id,
+        &owner.to_string(),
+        &repo.to_string(),
+        &path.to_string(),
+        branch.as_ref().map(|b| b.to_string()).as_deref(),
+    )?;
+
+    let sha = serde_json::from_str::<serde_json::Value>(&file)
+        .unwrap()
+        .as_object()
+        .and_then(|obj| obj.get("sha"))
+        .and_then(|sha| sha.as_str())
+        .unwrap()
+        .to_string();
+
+    let request = CreateOrUpdateFileRequest {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        path: path.to_string(),
+        message: message.to_string(),
+        content: content.into(),
+        branch: branch.map(|b| b.to_string()),
+        sha: Some(sha),
     };
 
     let wrapper = GithubApiWrapper {

--- a/runtime/plaid-stl/src/github/repo.rs
+++ b/runtime/plaid-stl/src/github/repo.rs
@@ -654,11 +654,11 @@ pub fn update_file(
     )?;
 
     let sha = serde_json::from_str::<serde_json::Value>(&file)
-        .unwrap()
+        .map_err(|_| PlaidFunctionError::InternalApiError)?
         .as_object()
         .and_then(|obj| obj.get("sha"))
         .and_then(|sha| sha.as_str())
-        .unwrap()
+        .ok_or(PlaidFunctionError::InternalApiError)?
         .to_string();
 
     let request = CreateOrUpdateFileRequest {

--- a/runtime/plaid-stl/src/github/types.rs
+++ b/runtime/plaid-stl/src/github/types.rs
@@ -177,7 +177,7 @@ impl FileSearchResultItem {
             &self.repository.owner.login,
             &self.repository.name,
             &self.path,
-            reference,
+            Some(reference),
         )
         .map_err(|_| PlaidFunctionError::InternalApiError)?;
         let content = serde_json::from_str::<GithubFileContent>(&content)
@@ -339,7 +339,7 @@ pub struct FetchFileRequest {
     pub organization: String,
     pub repository_name: String,
     pub file_path: String,
-    pub reference: String,
+    pub reference: Option<String>,
     pub media_type: FetchFileCustomMediaType,
 }
 
@@ -472,14 +472,14 @@ pub struct PullRequestRequestReviewers {
     pub team_reviewers: Vec<String>,
 }
 
-/// Request to create a new file in a repository.
+/// Request to create or update a file in a repository.
 #[derive(Serialize, Deserialize)]
-pub struct CreateFileRequest {
+pub struct CreateOrUpdateFileRequest {
     /// Owner of the repository (e.g., GitHub username or org).
     pub owner: String,
     /// Name of the repository.
     pub repo: String,
-    /// Path to create the file at
+    /// Path to create or update the file at
     pub path: String,
     /// The commit message.
     pub message: String,
@@ -487,6 +487,8 @@ pub struct CreateFileRequest {
     pub content: Vec<u8>,
     /// The branch name. Default: the repository’s default branch.
     pub branch: Option<String>,
+    /// The blob SHA of the file being replaced. Required if updating a file.
+    pub sha: Option<String>,
 }
 
 /// Request to comment on a pull request or issue

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.44.1"
+version = "0.44.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.44.2"
+version = "0.45.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/github/repos.rs
+++ b/runtime/plaid/src/apis/github/repos.rs
@@ -650,7 +650,6 @@ impl Github {
         let path = self.validate_path(&request.params.path)?;
         let file_hash = sha256_hex(&request.params.content);
 
-        info!("Creating file with hash [{file_hash}] at [{path}] in repository [{owner}/{repo}] on behalf of [{module}]");
         let address = format!("/repos/{owner}/{repo}/contents/{path}");
 
         let mut body = json!({
@@ -662,8 +661,12 @@ impl Github {
         }
 
         if let Some(sha) = request.params.sha {
+            // Validate: even if this is not a commit hash but a blob hash, the format is still the same
+            self.validate_commit_hash(&sha)?;
             body["sha"] = json!(sha);
         }
+
+        info!("Creating file with hash [{file_hash}] at [{path}] in repository [{owner}/{repo}] on behalf of [{module}]");
 
         match self
             .make_generic_put_request(&request.client_id, address, Some(&body), module)

--- a/runtime/plaid/src/apis/github/repos.rs
+++ b/runtime/plaid/src/apis/github/repos.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 use http::{HeaderMap, HeaderValue};
 use plaid_stl::github::{
     AddUserToRepoParams, CheckCodeownersParams, CodeownersErrorsResponse, CodeownersStatus,
-    CommentOnPullRequestRequest, CreateFileRequest, FetchCommitParams, FetchFileCustomMediaType,
-    FetchFileRequest, GetBranchProtectionRulesParams, GetBranchProtectionRulesetParams,
-    GetCustomPropertiesValuesParams, GetRepoCollaboratorsParams, GetRepoIdFromRepoNameParams,
-    GetRepoNameFromRepoIdParams, GetRepoSbomParams, GetWeeklyCommitCountParams, GithubApiWrapper,
-    GithubRepository, ListFilesParams, RemoveUserFromRepoParams, RequireSignedCommitsParams,
-    UpdateBranchProtectionRuleParams,
+    CommentOnPullRequestRequest, CreateOrUpdateFileRequest, FetchCommitParams,
+    FetchFileCustomMediaType, FetchFileRequest, GetBranchProtectionRulesParams,
+    GetBranchProtectionRulesetParams, GetCustomPropertiesValuesParams, GetRepoCollaboratorsParams,
+    GetRepoIdFromRepoNameParams, GetRepoNameFromRepoIdParams, GetRepoSbomParams,
+    GetWeeklyCommitCountParams, GithubApiWrapper, GithubRepository, ListFilesParams,
+    RemoveUserFromRepoParams, RequireSignedCommitsParams, UpdateBranchProtectionRuleParams,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -204,20 +204,25 @@ impl Github {
 
         let reference = &request.params.reference;
 
-        // Reference can be commit hash OR a branch name.
-        // To validate that the provided ref is valid, we must check that it is either a
-        // commit hash or branch name using the provided validator functions
-        if self.validate_commit_hash(&reference).is_err()
-            && self.validate_branch_name(&reference).is_err()
-        {
-            return Err(ApiError::BadRequest);
-        }
+        let (ref_log, ref_q_param) = match reference {
+            Some(r) => {
+                // Reference can be commit hash OR a branch name.
+                // To validate that the provided ref is valid, we must check that it is either a
+                // commit hash or branch name using the provided validator functions
+                if self.validate_commit_hash(&r).is_err() && self.validate_branch_name(&r).is_err()
+                {
+                    return Err(ApiError::BadRequest);
+                }
+                (format!(" and reference [{r}]"), format!("?ref={r}"))
+            }
+            None => (String::new(), String::new()),
+        };
 
         let custom_media_type = request.params.media_type;
 
-        info!("Fetching contents of file in repository [{organization}/{repository_name}] at {file_path} and reference {reference} with encoding [{custom_media_type}]");
+        info!("Fetching contents of file in repository [{organization}/{repository_name}] at {file_path}{ref_log} with encoding [{custom_media_type}]");
         let address =
-            format!("/repos/{organization}/{repository_name}/contents/{file_path}?ref={reference}");
+            format!("/repos/{organization}/{repository_name}/contents/{file_path}{ref_q_param}");
 
         // Set the Accept header according to the media type we have
         let header_value = match custom_media_type {
@@ -637,7 +642,7 @@ impl Github {
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let request: GithubApiWrapper<CreateFileRequest> =
+        let request: GithubApiWrapper<CreateOrUpdateFileRequest> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         let owner = self.validate_org(&request.params.owner)?;
@@ -654,6 +659,10 @@ impl Github {
         });
         if let Some(branch) = request.params.branch {
             body["branch"] = json!(branch);
+        }
+
+        if let Some(sha) = request.params.sha {
+            body["sha"] = json!(sha);
         }
 
         match self

--- a/runtime/plaid/src/apis/github/repos.rs
+++ b/runtime/plaid/src/apis/github/repos.rs
@@ -206,8 +206,9 @@ impl Github {
         // If it is not given, we will omit that part of the log and append nothing to the URL.
         let (ref_log, ref_q_param) = match request.params.reference {
             Some(r) => {
-                // According to https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content, reference can be
-                // a commit SHA, a branch name, or a tag name. We will validate that it is either a valid commit hash or a valid branch name.
+                // According to https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content,
+                // `reference` can be a commit SHA, a branch name, or a tag name. We validate that it is either a 40-char SHA-1,
+                // or a branch/tag name that matches our `branch_name` validator (see validators.rs).
                 // This means that we try validating both ways: if both fail, we return an error. If either succeeds, we continue.
                 if self.validate_commit_hash(&r).is_err() && self.validate_branch_name(&r).is_err()
                 {

--- a/runtime/plaid/src/apis/github/repos.rs
+++ b/runtime/plaid/src/apis/github/repos.rs
@@ -202,17 +202,18 @@ impl Github {
             return Err(ApiError::BadRequest);
         }
 
-        let reference = &request.params.reference;
-
-        let (ref_log, ref_q_param) = match reference {
+        // If a reference is given (and passes validation), we will log about it and append it to the request URL as a query parameter.
+        // If it is not given, we will omit that part of the log and append nothing to the URL.
+        let (ref_log, ref_q_param) = match request.params.reference {
             Some(r) => {
-                // Reference can be commit hash OR a branch name.
-                // To validate that the provided ref is valid, we must check that it is either a
-                // commit hash or branch name using the provided validator functions
+                // According to https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content, reference can be
+                // a commit SHA, a branch name, or a tag name. We will validate that it is either a valid commit hash or a valid branch name.
+                // This means that we try validating both ways: if both fail, we return an error. If either succeeds, we continue.
                 if self.validate_commit_hash(&r).is_err() && self.validate_branch_name(&r).is_err()
                 {
                     return Err(ApiError::BadRequest);
                 }
+                //               log                       query param
                 (format!(" and reference [{r}]"), format!("?ref={r}"))
             }
             None => (String::new(), String::new()),
@@ -220,7 +221,7 @@ impl Github {
 
         let custom_media_type = request.params.media_type;
 
-        info!("Fetching contents of file in repository [{organization}/{repository_name}] at {file_path}{ref_log} with encoding [{custom_media_type}]");
+        info!("Fetching contents of file in repository [{organization}/{repository_name}] at [{file_path}]{ref_log} with encoding [{custom_media_type}]");
         let address =
             format!("/repos/{organization}/{repository_name}/contents/{file_path}{ref_q_param}");
 


### PR DESCRIPTION
The [endpoint](https://docs.github.com/en/rest/repos/contents?apiVersion=2026-03-10#create-or-update-file-contents) to create and update a file is the same, but updating also requires passing the SHA of the to-be-updated file.

This PR adds support for that, by adding an `update_file` method that transparently fetches the file, gets its SHA, and passes it to the endpoint via the host.

Along the way, we also make `reference` optional when fetching a file: according to the API docs, not passing a reference means fetching from the default branch, which is what we want. Note - THIS IS A BREAKING CHANGE for modules.