### PR TITLE
slack: schedule messages instead of dropping them on rate limit

### DIFF
--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "46.1.0"
+version = "46.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/slack/mod.rs
+++ b/runtime/plaid-stl/src/slack/mod.rs
@@ -1117,10 +1117,12 @@ struct ScheduledMessageBody {
 }
 
 /// Schedule a Block Kit message for future delivery (chat.scheduleMessage).
-/// Used to deliver a message that would otherwise be dropped when a channel is
-/// rate limited (see [`SlackDeliveryResponse::rate_limited`]). The runtime just
-/// relays the call — the caller owns the retry/window policy and inspects
-/// [`ScheduleMessageResponse::window_full`] to pick another `post_at`.
+/// The runtime just relays the call — the caller supplies the delivery time and
+/// owns any retry/window policy, inspecting [`ScheduleMessageResponse::window_full`]
+/// to pick another `post_at` if a window is full. One use is delivering a
+/// message that would otherwise be dropped when a channel is rate limited
+/// (see [`SlackDeliveryResponse::rate_limited`]), but scheduling is general —
+/// any caller that wants a message delivered at a specific time can use it.
 /// - `post_at`: Unix timestamp (seconds) to deliver at; must be in the future.
 pub fn schedule_message(
     bot: &str,

--- a/runtime/plaid-stl/src/slack/mod.rs
+++ b/runtime/plaid-stl/src/slack/mod.rs
@@ -928,3 +928,437 @@ pub fn remove_from_channel(bot: &str, channel: &str, user: &str) -> Result<(), P
 
     Ok(())
 }
+
+#[derive(Serialize)]
+struct SlackMessageWithOptions {
+    channel: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    blocks: Option<serde_json::Value>,
+    attachments: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unfurl_links: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unfurl_media: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<serde_json::Value>,
+}
+
+/// Optional settings for [`post_message_with_options`].
+#[derive(Default)]
+pub struct PostMessageOptions {
+    /// Whether Slack should unfurl links in the message.
+    pub unfurl_links: Option<bool>,
+    /// Whether Slack should unfurl media in the message.
+    pub unfurl_media: Option<bool>,
+    /// Message metadata JSON: `{"event_type": "...", "event_payload": {...}}`.
+    /// Metadata is invisible to users but is returned by conversations.history,
+    /// letting rules correlate posted messages back to the event that generated
+    /// them (e.g. to recover the `ts` of a message delivered via scheduling).
+    pub metadata: Option<String>,
+}
+
+/// Response from a `post_message` call. On success the message posted
+/// immediately and `ts` is set. If the caller opted in to rate-limit handling
+/// and the channel was rate limited, `ok` is false and `error` is
+/// `"ratelimited"` — the caller should then schedule the message itself via
+/// [`schedule_message`].
+#[derive(Serialize, Deserialize)]
+pub struct SlackDeliveryResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub channel: Option<String>,
+    /// Set when the message posted immediately.
+    #[serde(default)]
+    pub ts: Option<String>,
+    /// Slack error code when `ok` is false (e.g. `"ratelimited"`).
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+impl SlackDeliveryResponse {
+    /// Whether the post was rejected because the channel is rate limited, i.e.
+    /// the caller should schedule the message for later delivery instead.
+    pub fn rate_limited(&self) -> bool {
+        !self.ok && self.error.as_deref() == Some("ratelimited")
+    }
+}
+
+/// Post a Slack message with Block Kit blocks, attachments and optional
+/// settings (unfurl behavior, message metadata). Returns a
+/// [`SlackDeliveryResponse`]; callers that set `schedule_on_ratelimit` should
+/// check [`SlackDeliveryResponse::rate_limited`] and, when true, deliver the
+/// message themselves via [`schedule_message`] — the runtime does not schedule
+/// automatically, it only reports the rate limit.
+/// - `bot`: configured bot name
+/// - `channel`: channel ID to post to
+/// - `blocks`: Block Kit JSON array (may be empty)
+/// - `attachments`: attachments JSON array
+/// - `options`: see [`PostMessageOptions`]
+pub fn post_message_with_options(
+    bot: &str,
+    channel: &str,
+    blocks: &str,
+    attachments: &str,
+    options: PostMessageOptions,
+) -> Result<SlackDeliveryResponse, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(slack, post_message);
+    }
+
+    let metadata = match options.metadata {
+        Some(m) => Some(
+            serde_json::from_str(&m).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?,
+        ),
+        None => None,
+    };
+
+    let message = SlackMessageWithOptions {
+        channel: channel.to_owned(),
+        blocks: optional_blocks(blocks)?,
+        attachments: serde_json::from_str(attachments)
+            .map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?,
+        unfurl_links: options.unfurl_links,
+        unfurl_media: options.unfurl_media,
+        metadata,
+    };
+
+    const RETURN_BUFFER_SIZE: usize = 32 * 1024; // 32 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    // Opt in to the runtime's scheduleMessage fallback on rate limit. Only this
+    // helper sets the flag, so existing post helpers keep the historical 429
+    // behavior and never see a scheduled-delivery response.
+    #[derive(Serialize)]
+    struct PostMessageScheduled {
+        bot: String,
+        body: String,
+        schedule_on_ratelimit: bool,
+    }
+
+    let params = serde_json::to_string(&PostMessageScheduled {
+        bot: bot.to_string(),
+        body: serde_json::to_string(&message).unwrap(),
+        schedule_on_ratelimit: true,
+    })
+    .unwrap();
+
+    let res = unsafe {
+        slack_post_message(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    let res = String::from_utf8(return_buffer).unwrap();
+
+    serde_json::from_str(&res).map_err(|_| PlaidFunctionError::Unknown)
+}
+
+/// Data sent to the runtime to schedule a message (chat.scheduleMessage). The
+/// `body` is the fully rendered Slack payload including `post_at`.
+#[derive(Serialize, Deserialize)]
+pub struct ScheduleMessage {
+    pub bot: String,
+    pub body: String,
+}
+
+/// Response from chat.scheduleMessage.
+#[derive(Serialize, Deserialize)]
+pub struct ScheduleMessageResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub channel: Option<String>,
+    /// Set on success; identifies the scheduled message for later deletion.
+    #[serde(default)]
+    pub scheduled_message_id: Option<String>,
+    /// Unix timestamp the message is scheduled to post at.
+    #[serde(default)]
+    pub post_at: Option<u64>,
+    /// Slack error code when `ok` is false.
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+impl ScheduleMessageResponse {
+    /// Whether scheduling was rejected because this 5-minute window already
+    /// holds the maximum scheduled messages for the channel
+    /// (`restricted_too_many`), or the target time slipped into the past
+    /// (`time_in_past`). Either way the caller should retry with a later
+    /// `post_at`.
+    pub fn window_full(&self) -> bool {
+        !self.ok
+            && matches!(
+                self.error.as_deref(),
+                Some("restricted_too_many") | Some("time_in_past")
+            )
+    }
+}
+
+#[derive(Serialize)]
+struct ScheduledMessageBody {
+    channel: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    blocks: Option<serde_json::Value>,
+    attachments: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unfurl_links: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unfurl_media: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<serde_json::Value>,
+    post_at: u64,
+}
+
+/// Schedule a Block Kit message for future delivery (chat.scheduleMessage).
+/// Used to deliver a message that would otherwise be dropped when a channel is
+/// rate limited (see [`SlackDeliveryResponse::rate_limited`]). The runtime just
+/// relays the call — the caller owns the retry/window policy and inspects
+/// [`ScheduleMessageResponse::window_full`] to pick another `post_at`.
+/// - `post_at`: Unix timestamp (seconds) to deliver at; must be in the future.
+pub fn schedule_message(
+    bot: &str,
+    channel: &str,
+    blocks: &str,
+    attachments: &str,
+    post_at: u64,
+    options: PostMessageOptions,
+) -> Result<ScheduleMessageResponse, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(slack, schedule_message);
+    }
+
+    let metadata = match options.metadata {
+        Some(m) => Some(
+            serde_json::from_str(&m).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?,
+        ),
+        None => None,
+    };
+
+    let message = ScheduledMessageBody {
+        channel: channel.to_owned(),
+        blocks: optional_blocks(blocks)?,
+        attachments: serde_json::from_str(attachments)
+            .map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?,
+        unfurl_links: options.unfurl_links,
+        unfurl_media: options.unfurl_media,
+        metadata,
+        post_at,
+    };
+
+    const RETURN_BUFFER_SIZE: usize = 32 * 1024; // 32 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let params = serde_json::to_string(&ScheduleMessage {
+        bot: bot.to_string(),
+        body: serde_json::to_string(&message).unwrap(),
+    })
+    .unwrap();
+
+    let res = unsafe {
+        slack_schedule_message(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    let res = String::from_utf8(return_buffer).unwrap();
+
+    serde_json::from_str(&res).map_err(|_| PlaidFunctionError::Unknown)
+}
+
+/// Data to be sent to the runtime for deleting a scheduled message
+#[derive(Serialize, Deserialize)]
+pub struct DeleteScheduledMessage {
+    /// Bot to use for deleting the scheduled message
+    pub bot: String,
+    /// ID of the channel the message is scheduled to post to
+    pub channel: String,
+    /// ID returned by chat.scheduleMessage
+    pub scheduled_message_id: String,
+}
+
+impl DeleteScheduledMessage {
+    /// Serialize the body for the Slack API request
+    pub fn body(&self) -> Result<String, String> {
+        #[derive(Serialize)]
+        struct DeleteScheduledMessageBody<'a> {
+            channel: &'a str,
+            scheduled_message_id: &'a str,
+        }
+
+        let body = DeleteScheduledMessageBody {
+            channel: &self.channel,
+            scheduled_message_id: &self.scheduled_message_id,
+        };
+
+        serde_json::to_string(&body).map_err(|e| format!("Failed to serialize body: {}", e))
+    }
+}
+
+/// Response from chat.deleteScheduledMessage. When `ok` is false, `error`
+/// carries the Slack error code; `invalid_scheduled_message_id` means the
+/// message already posted (or never existed) and can no longer be deleted.
+#[derive(Serialize, Deserialize)]
+pub struct DeleteScheduledMessageResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+impl DeleteScheduledMessageResponse {
+    /// Whether the delete failed because the message already posted
+    /// (or the ID was never valid).
+    pub fn already_posted(&self) -> bool {
+        !self.ok && self.error.as_deref() == Some("invalid_scheduled_message_id")
+    }
+}
+
+/// Delete a scheduled message before it posts (chat.deleteScheduledMessage).
+/// - `bot`: configured bot name
+/// - `channel`: ID of the channel the message is scheduled to post to
+/// - `scheduled_message_id`: ID returned when the message was scheduled
+///
+/// Returns `ok: false` with the Slack error code rather than an `Err` for
+/// API-level failures so callers can handle `invalid_scheduled_message_id`
+/// (the message already posted) distinctly.
+pub fn delete_scheduled_message(
+    bot: &str,
+    channel: &str,
+    scheduled_message_id: &str,
+) -> Result<DeleteScheduledMessageResponse, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(slack, delete_scheduled_message);
+    }
+    const RETURN_BUFFER_SIZE: usize = 32 * 1024; // 32 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let params = serde_json::to_string(&DeleteScheduledMessage {
+        bot: bot.to_string(),
+        channel: channel.to_string(),
+        scheduled_message_id: scheduled_message_id.to_string(),
+    })
+    .unwrap();
+
+    let res = unsafe {
+        slack_delete_scheduled_message(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    let res = String::from_utf8(return_buffer).unwrap();
+
+    serde_json::from_str(&res).map_err(|_| PlaidFunctionError::Unknown)
+}
+
+/// Data to be sent to the runtime for fetching channel history
+#[derive(Serialize, Deserialize)]
+pub struct ConversationsHistory {
+    /// Bot to use for fetching history
+    pub bot: String,
+    /// ID of the channel to fetch history for
+    pub channel: String,
+    /// Maximum number of messages to return
+    #[serde(default)]
+    pub limit: Option<u32>,
+    /// Only include messages after this Slack timestamp
+    #[serde(default)]
+    pub oldest: Option<String>,
+}
+
+/// Message metadata as returned by conversations.history
+#[derive(Serialize, Deserialize)]
+pub struct MessageMetadata {
+    pub event_type: String,
+    #[serde(default)]
+    pub event_payload: serde_json::Value,
+}
+
+/// A single message in a conversations.history response. Only the fields
+/// needed for correlating messages are deserialized.
+#[derive(Serialize, Deserialize)]
+pub struct HistoryMessage {
+    pub ts: String,
+    #[serde(default)]
+    pub metadata: Option<MessageMetadata>,
+}
+
+/// Response from conversations.history
+#[derive(Serialize, Deserialize)]
+pub struct ConversationsHistoryResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub messages: Vec<HistoryMessage>,
+}
+
+/// Fetch recent message history for a channel (conversations.history),
+/// including message metadata. Requires the bot to have the
+/// `channels:history` scope (or `groups:history` for private channels).
+/// - `bot`: configured bot name
+/// - `channel`: ID of the channel to fetch history for
+/// - `limit`: maximum number of messages to return
+/// - `oldest`: only include messages after this Slack timestamp
+pub fn conversations_history(
+    bot: &str,
+    channel: &str,
+    limit: Option<u32>,
+    oldest: Option<&str>,
+) -> Result<ConversationsHistoryResponse, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(slack, conversations_history);
+    }
+    // History responses carry full message payloads so they can be large.
+    const RETURN_BUFFER_SIZE: usize = 256 * 1024; // 256 KiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let params = serde_json::to_string(&ConversationsHistory {
+        bot: bot.to_string(),
+        channel: channel.to_string(),
+        limit,
+        oldest: oldest.map(|o| o.to_string()),
+    })
+    .unwrap();
+
+    let res = unsafe {
+        slack_conversations_history(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    let res = String::from_utf8(return_buffer).unwrap();
+
+    serde_json::from_str(&res).map_err(|_| PlaidFunctionError::Unknown)
+}

--- a/runtime/plaid-stl/src/slack/mod.rs
+++ b/runtime/plaid-stl/src/slack/mod.rs
@@ -985,7 +985,7 @@ impl SlackDeliveryResponse {
 
 /// Post a Slack message with Block Kit blocks, attachments and optional
 /// settings (unfurl behavior, message metadata). Returns a
-/// [`SlackDeliveryResponse`]; callers that set `schedule_on_ratelimit` should
+/// [`SlackDeliveryResponse`]; callers that set `surface_rate_limit` should
 /// check [`SlackDeliveryResponse::rate_limited`] and, when true, deliver the
 /// message themselves via [`schedule_message`] — the runtime does not schedule
 /// automatically, it only reports the rate limit.
@@ -1025,20 +1025,20 @@ pub fn post_message_with_options(
     const RETURN_BUFFER_SIZE: usize = 32 * 1024; // 32 KiB
     let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
 
-    // Opt in to the runtime's scheduleMessage fallback on rate limit. Only this
-    // helper sets the flag, so existing post helpers keep the historical 429
-    // behavior and never see a scheduled-delivery response.
+    // Ask the runtime to surface a rate limit (429) as a response body instead
+    // of a hard error, so the caller can react. Only this helper sets the flag,
+    // so existing post helpers keep the historical 429-is-an-error behavior.
     #[derive(Serialize)]
-    struct PostMessageScheduled {
+    struct PostMessageRequest {
         bot: String,
         body: String,
-        schedule_on_ratelimit: bool,
+        surface_rate_limit: bool,
     }
 
-    let params = serde_json::to_string(&PostMessageScheduled {
+    let params = serde_json::to_string(&PostMessageRequest {
         bot: bot.to_string(),
         body: serde_json::to_string(&message).unwrap(),
-        schedule_on_ratelimit: true,
+        surface_rate_limit: true,
     })
     .unwrap();
 

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "46.1.0"
+version = "46.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/slack/api.rs
+++ b/runtime/plaid/src/apis/slack/api.rs
@@ -41,13 +41,16 @@ struct GenericSlackResponse {
     ok: bool,
 }
 
-/// Detects whether a `post_message` caller opted in to rate-limit handling.
-/// Parsed alongside `PostMessage` so the opt-in is per call: callers that don't
-/// set it keep the historical behavior of a hard error on 429.
+/// Request shape for [`Slack::post_message`]: the standard `PostMessage` fields
+/// plus a per-call opt-in. Parsed in a single pass since the flag rides in the
+/// same JSON as the message.
 #[derive(serde::Deserialize)]
-struct RateLimitOptIn {
+struct PostMessageParams {
+    bot: String,
+    body: String,
     /// When true, a 429 returns Slack's rate-limited body to the caller instead
     /// of erroring, so the caller can react (e.g. schedule the message).
+    /// Defaults off, preserving the historical hard-error behavior.
     #[serde(default)]
     surface_rate_limit: bool,
 }
@@ -221,14 +224,22 @@ impl Slack {
     /// rate limit (delay, windows, retries) is intentionally left to the rule,
     /// not baked into the runtime.
     pub async fn post_message(&self, params: &str, module: Arc<PlaidModule>) -> Result<String> {
-        let p: PostMessage = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        // Single parse: message fields plus the per-call opt-in. A malformed
+        // `surface_rate_limit` now fails as BadRequest rather than being
+        // silently ignored.
+        let p: PostMessageParams =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
         let bot = p.bot.clone();
-        // Opt-in per call; unset means the historical "429 is an error" behavior.
-        let surface_rate_limit = serde_json::from_str::<RateLimitOptIn>(params)
-            .map(|o| o.surface_rate_limit)
-            .unwrap_or(false);
+        let surface_rate_limit = p.surface_rate_limit;
         match self
-            .call_slack(bot, Apis::PostMessage(p), module)
+            .call_slack(
+                bot,
+                Apis::PostMessage(PostMessage {
+                    bot: p.bot,
+                    body: p.body,
+                }),
+                module,
+            )
             .await
         {
             Ok((200, response)) => {

--- a/runtime/plaid/src/apis/slack/api.rs
+++ b/runtime/plaid/src/apis/slack/api.rs
@@ -45,9 +45,11 @@ struct GenericSlackResponse {
 /// Parsed alongside `PostMessage` so the opt-in is per call: callers that don't
 /// set it keep the historical behavior of a hard error on 429.
 #[derive(serde::Deserialize)]
-struct ScheduleOptIn {
+struct RateLimitOptIn {
+    /// When true, a 429 returns Slack's rate-limited body to the caller instead
+    /// of erroring, so the caller can react (e.g. schedule the message).
     #[serde(default)]
-    schedule_on_ratelimit: bool,
+    surface_rate_limit: bool,
 }
 
 impl Apis {
@@ -212,7 +214,7 @@ impl Slack {
     ///
     /// Slack rate limits chat.postMessage to roughly one message per second per
     /// channel, so a burst of posts to one channel gets HTTP 429s. A caller can
-    /// opt in (via `schedule_on_ratelimit` in the request) to receive Slack's
+    /// opt in (via `surface_rate_limit` in the request) to receive Slack's
     /// rate-limited response body on 429 (which carries `error: "ratelimited"`)
     /// instead of a hard error, so it can decide how to react — typically by
     /// scheduling the message with [`Self::schedule_message`]. How to handle the
@@ -222,8 +224,8 @@ impl Slack {
         let p: PostMessage = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
         let bot = p.bot.clone();
         // Opt-in per call; unset means the historical "429 is an error" behavior.
-        let schedule_on_ratelimit = serde_json::from_str::<ScheduleOptIn>(params)
-            .map(|o| o.schedule_on_ratelimit)
+        let surface_rate_limit = serde_json::from_str::<RateLimitOptIn>(params)
+            .map(|o| o.surface_rate_limit)
             .unwrap_or(false);
         match self
             .call_slack(bot, Apis::PostMessage(p), module)
@@ -244,7 +246,7 @@ impl Slack {
             // Pass Slack's own rate-limited response body through so the caller
             // sees the real payload (it carries `error: "ratelimited"`), rather
             // than a synthetic stand-in.
-            Ok((429, response)) if schedule_on_ratelimit => Ok(response),
+            Ok((429, response)) if surface_rate_limit => Ok(response),
             Ok((status, _)) => Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(
                 status,
             ))),

--- a/runtime/plaid/src/apis/slack/api.rs
+++ b/runtime/plaid/src/apis/slack/api.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
 use plaid_stl::slack::{
-    CreateChannel, CreateChannelResponse, GetDndInfo, GetDndInfoResponse, GetIdFromEmail,
-    GetPresence, GetPresenceResponse, InviteToChannel, PostMessage, RemoveFromChannel,
-    UpdateMessage, UserInfo, UserInfoResponse, ViewOpen,
+    ConversationsHistory, CreateChannel, CreateChannelResponse, DeleteScheduledMessage,
+    GetDndInfo, GetDndInfoResponse, GetIdFromEmail, GetPresence, GetPresenceResponse,
+    InviteToChannel, PostMessage, RemoveFromChannel, ScheduleMessage, UpdateMessage, UserInfo,
+    UserInfoResponse, ViewOpen,
 };
 use reqwest::{Client, RequestBuilder};
 
@@ -16,6 +17,9 @@ use super::Slack;
 
 enum Apis {
     PostMessage(plaid_stl::slack::PostMessage),
+    ScheduleMessage(plaid_stl::slack::ScheduleMessage),
+    DeleteScheduledMessage(plaid_stl::slack::DeleteScheduledMessage),
+    ConversationsHistory(plaid_stl::slack::ConversationsHistory),
     UpdateMessage(plaid_stl::slack::UpdateMessage),
     ViewsOpen(plaid_stl::slack::ViewOpen),
     LookupByEmail(plaid_stl::slack::GetIdFromEmail),
@@ -30,11 +34,27 @@ enum Apis {
 const SLACK_API_URL: &str = "https://slack.com/api/";
 type Result<T> = std::result::Result<T, ApiError>;
 
+/// Body returned to a `post_message` caller that opted in to rate-limit
+/// handling when Slack responds 429. It mirrors a Slack error payload so the
+/// STL response type can parse it uniformly; the rule reacts by scheduling the
+/// message itself (see the notifier's schedule ladder). Deciding *how* to react
+/// to a rate limit is deliberately left to the rule, not the runtime.
+const RATE_LIMITED_BODY: &str = r#"{"ok":false,"error":"ratelimited"}"#;
+
 /// This struct is used to deserialize a response from Slack API and
 /// just check if the result is OK or not.
 #[derive(serde::Deserialize)]
 struct GenericSlackResponse {
     ok: bool,
+}
+
+/// Detects whether a `post_message` caller opted in to rate-limit handling.
+/// Parsed alongside `PostMessage` so the opt-in is per call: callers that don't
+/// set it keep the historical behavior of a hard error on 429.
+#[derive(serde::Deserialize)]
+struct ScheduleOptIn {
+    #[serde(default)]
+    schedule_on_ratelimit: bool,
 }
 
 impl Apis {
@@ -44,6 +64,37 @@ impl Apis {
                 .post(format!("{SLACK_API_URL}{api}", api = "chat.postMessage"))
                 .body(p.body.clone())
                 .header("Content-Type", "application/json; charset=utf-8"),
+            Self::ScheduleMessage(p) => client
+                .post(format!("{SLACK_API_URL}{api}", api = "chat.scheduleMessage"))
+                .body(p.body.clone())
+                .header("Content-Type", "application/json; charset=utf-8"),
+            Self::DeleteScheduledMessage(p) => client
+                .post(format!(
+                    "{SLACK_API_URL}{api}",
+                    api = "chat.deleteScheduledMessage"
+                ))
+                .body(p.body().unwrap_or_default()) // TODO this is not great: maybe this method should be fallible
+                .header("Content-Type", "application/json; charset=utf-8"),
+            Self::ConversationsHistory(p) => {
+                let mut query: Vec<(&str, String)> = vec![
+                    ("channel", p.channel.clone()),
+                    // Metadata is only returned when explicitly requested. Callers use it
+                    // to correlate posted messages back to the event that generated them.
+                    ("include_all_metadata", "true".to_string()),
+                ];
+                if let Some(limit) = p.limit {
+                    query.push(("limit", limit.to_string()));
+                }
+                if let Some(oldest) = &p.oldest {
+                    query.push(("oldest", oldest.clone()));
+                }
+                client
+                    .get(format!(
+                        "{SLACK_API_URL}{api}",
+                        api = "conversations.history"
+                    ))
+                    .query(&query)
+            }
             Self::UpdateMessage(p) => client
                 .post(format!("{SLACK_API_URL}{api}", api = "chat.update"))
                 .body(p.body.clone())
@@ -90,6 +141,9 @@ impl std::fmt::Display for Apis {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::PostMessage(_) => write!(f, "PostMessage"),
+            Self::ScheduleMessage(_) => write!(f, "ScheduleMessage"),
+            Self::DeleteScheduledMessage(_) => write!(f, "DeleteScheduledMessage"),
+            Self::ConversationsHistory(_) => write!(f, "ConversationsHistory"),
             Self::UpdateMessage(_) => write!(f, "UpdateMessage"),
             Self::ViewsOpen(_) => write!(f, "ViewsOpen"),
             Self::LookupByEmail(_) => write!(f, "LookupByEmail"),
@@ -162,10 +216,115 @@ impl Slack {
 
     /// Call the Slack postMessage API. The message and location are defined by the module but the bot
     /// must be configured in Plaid.
+    ///
+    /// Slack rate limits chat.postMessage to roughly one message per second per
+    /// channel, so a burst of posts to one channel gets HTTP 429s. A caller can
+    /// opt in (via `schedule_on_ratelimit` in the request) to receive a
+    /// `{"ok":false,"error":"ratelimited"}` body on 429 instead of a hard error,
+    /// so it can decide how to react — typically by scheduling the message with
+    /// [`Self::schedule_message`]. How to handle the rate limit (delay, windows,
+    /// retries) is intentionally left to the rule, not baked into the runtime.
     pub async fn post_message(&self, params: &str, module: Arc<PlaidModule>) -> Result<String> {
         let p: PostMessage = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        let bot = p.bot.clone();
+        // Opt-in per call; unset means the historical "429 is an error" behavior.
+        let schedule_on_ratelimit = serde_json::from_str::<ScheduleOptIn>(params)
+            .map(|o| o.schedule_on_ratelimit)
+            .unwrap_or(false);
         match self
-            .call_slack(p.bot.clone(), Apis::PostMessage(p), module)
+            .call_slack(bot, Apis::PostMessage(p), module)
+            .await
+        {
+            Ok((200, response)) => {
+                let slack_response: GenericSlackResponse = serde_json::from_str(&response)
+                    .map_err(|_| {
+                        ApiError::SlackError(SlackError::UnexpectedPayload(response.clone()))
+                    })?;
+                if !slack_response.ok {
+                    return Err(ApiError::SlackError(SlackError::UnexpectedPayload(
+                        response,
+                    )));
+                }
+                Ok(response)
+            }
+            Ok((429, _)) if schedule_on_ratelimit => Ok(RATE_LIMITED_BODY.to_string()),
+            Ok((status, _)) => Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(
+                status,
+            ))),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Call the Slack chat.scheduleMessage API. The caller supplies a fully
+    /// rendered body (including `post_at`); the runtime just relays it.
+    ///
+    /// Returns the raw Slack response on a 200 even when `ok` is false, so the
+    /// caller can react to `restricted_too_many` (the 30-per-5-minute-window
+    /// limit) by choosing a different `post_at` — that policy lives in the rule.
+    pub async fn schedule_message(&self, params: &str, module: Arc<PlaidModule>) -> Result<String> {
+        let p: ScheduleMessage = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        match self
+            .call_slack(p.bot.clone(), Apis::ScheduleMessage(p), module)
+            .await
+        {
+            // Pass the body through regardless of `ok`: the caller needs to see
+            // `restricted_too_many` / `time_in_past` to pick another window.
+            Ok((200, response)) => {
+                serde_json::from_str::<GenericSlackResponse>(&response).map_err(|_| {
+                    ApiError::SlackError(SlackError::UnexpectedPayload(response.clone()))
+                })?;
+                Ok(response)
+            }
+            Ok((status, _)) => Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(
+                status,
+            ))),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Delete a scheduled message before it posts (chat.deleteScheduledMessage).
+    ///
+    /// Returns the raw Slack response even when `ok` is false: callers need the
+    /// error code to distinguish "already posted" (`invalid_scheduled_message_id`)
+    /// from real failures, since a scheduled message that has posted can no
+    /// longer be deleted and must be handled differently.
+    pub async fn delete_scheduled_message(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String> {
+        let p: DeleteScheduledMessage =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        match self
+            .call_slack(p.bot.clone(), Apis::DeleteScheduledMessage(p), module)
+            .await
+        {
+            Ok((200, response)) => {
+                // Validate it parses as a Slack response but pass it through
+                // regardless of `ok` — see doc comment.
+                serde_json::from_str::<GenericSlackResponse>(&response).map_err(|_| {
+                    ApiError::SlackError(SlackError::UnexpectedPayload(response.clone()))
+                })?;
+                Ok(response)
+            }
+            Ok((status, _)) => Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(
+                status,
+            ))),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Fetch recent message history for a channel (conversations.history),
+    /// including message metadata.
+    pub async fn conversations_history(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String> {
+        let p: ConversationsHistory =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+        match self
+            .call_slack(p.bot.clone(), Apis::ConversationsHistory(p), module)
             .await
         {
             Ok((200, response)) => {

--- a/runtime/plaid/src/apis/slack/api.rs
+++ b/runtime/plaid/src/apis/slack/api.rs
@@ -34,13 +34,6 @@ enum Apis {
 const SLACK_API_URL: &str = "https://slack.com/api/";
 type Result<T> = std::result::Result<T, ApiError>;
 
-/// Body returned to a `post_message` caller that opted in to rate-limit
-/// handling when Slack responds 429. It mirrors a Slack error payload so the
-/// STL response type can parse it uniformly; the rule reacts by scheduling the
-/// message itself (see the notifier's schedule ladder). Deciding *how* to react
-/// to a rate limit is deliberately left to the rule, not the runtime.
-const RATE_LIMITED_BODY: &str = r#"{"ok":false,"error":"ratelimited"}"#;
-
 /// This struct is used to deserialize a response from Slack API and
 /// just check if the result is OK or not.
 #[derive(serde::Deserialize)]
@@ -219,11 +212,12 @@ impl Slack {
     ///
     /// Slack rate limits chat.postMessage to roughly one message per second per
     /// channel, so a burst of posts to one channel gets HTTP 429s. A caller can
-    /// opt in (via `schedule_on_ratelimit` in the request) to receive a
-    /// `{"ok":false,"error":"ratelimited"}` body on 429 instead of a hard error,
-    /// so it can decide how to react — typically by scheduling the message with
-    /// [`Self::schedule_message`]. How to handle the rate limit (delay, windows,
-    /// retries) is intentionally left to the rule, not baked into the runtime.
+    /// opt in (via `schedule_on_ratelimit` in the request) to receive Slack's
+    /// rate-limited response body on 429 (which carries `error: "ratelimited"`)
+    /// instead of a hard error, so it can decide how to react — typically by
+    /// scheduling the message with [`Self::schedule_message`]. How to handle the
+    /// rate limit (delay, windows, retries) is intentionally left to the rule,
+    /// not baked into the runtime.
     pub async fn post_message(&self, params: &str, module: Arc<PlaidModule>) -> Result<String> {
         let p: PostMessage = serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
         let bot = p.bot.clone();
@@ -247,7 +241,10 @@ impl Slack {
                 }
                 Ok(response)
             }
-            Ok((429, _)) if schedule_on_ratelimit => Ok(RATE_LIMITED_BODY.to_string()),
+            // Pass Slack's own rate-limited response body through so the caller
+            // sees the real payload (it carries `error: "ratelimited"`), rather
+            // than a synthetic stand-in.
+            Ok((429, response)) if schedule_on_ratelimit => Ok(response),
             Ok((status, _)) => Err(ApiError::SlackError(SlackError::UnexpectedStatusCode(
                 status,
             ))),

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -587,6 +587,9 @@ impl_new_function_with_error_buffer!(rustica, new_mtls_cert, DISALLOW_IN_TEST_MO
 impl_new_function!(slack, views_open, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(slack, post_message, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(slack, update_message, ALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(slack, schedule_message, ALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(slack, delete_scheduled_message, ALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(slack, conversations_history, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(slack, get_id_from_email, ALLOW_IN_TEST_MODE);
 impl_new_function!(slack, post_to_arbitrary_webhook, ALLOW_IN_TEST_MODE);
 impl_new_function!(slack, post_to_named_webhook, ALLOW_IN_TEST_MODE);
@@ -919,6 +922,9 @@ define_api_functions! {
         "slack_invite_to_channel"         => slack_invite_to_channel,
         "slack_update_message"            => slack_update_message,
         "slack_remove_from_channel"       => slack_remove_from_channel,
+        "slack_schedule_message"          => slack_schedule_message,
+        "slack_delete_scheduled_message"  => slack_delete_scheduled_message,
+        "slack_conversations_history"     => slack_conversations_history,
 
         // General Calls
         "general_simple_json_post_request"          => general_simple_json_post_request,


### PR DESCRIPTION
## Problem

During alert bursts the notifier can exceed Slack’s per-channel chat.postMessage rate limit (~1 message/sec). Slack responds with HTTP 429, and these responses are currently treated as runtime errors, causing alerts to be dropped.

## Solution

Expose Slack’s scheduled message APIs and introduce an optional rate-limit mode where `postMessage` returns a structured ratelimited response instead of failing. 

This allows the PagerDuty Slack notifier to own the retry policy by scheduling messages into future delivery windows, retrying if a scheduling window is full, while keeping the runtime Slack-agnostic. 

Tested with a simulated 300-message alert storm resulted in zero dropped alerts and no runtime error logs.