### PR TITLE
Implement Prometheus metrics

### DIFF
--- a/local-dev/config/metrics.toml
+++ b/local-dev/config/metrics.toml
@@ -1,0 +1,2 @@
+[metrics]
+listen_address = "0.0.0.0:9464"

--- a/local-dev/docker-compose.yml
+++ b/local-dev/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     ports:
       - "8080:8080"
       - "8081:8081"
+      - "9464:9464"
     volumes:
       # Config files — edit these to configure APIs, webhooks, etc.
       - ./config:/config:ro
@@ -24,6 +25,15 @@ services:
       timeout: 5s
       retries: 3
       start_period: 30s
+
+  prometheus:
+    image: prom/prometheus:v3.2.1
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    depends_on:
+      - plaid
 
 volumes:
   plaid-data:

--- a/local-dev/prometheus.yml
+++ b/local-dev/prometheus.yml
@@ -22,4 +22,4 @@ scrape_configs:
       # Use "plaid:9464" when both services run via `docker compose up` (shared network).
       # Use "host.docker.internal:9464" when Prometheus runs in Docker but Plaid runs on the host (`cargo run`).
       # Use "localhost:9464" if Prometheus runs directly on the host.
-      - targets: ["host.docker.internal:9464"]
+      - targets: ["plaid:9464"]

--- a/local-dev/prometheus.yml
+++ b/local-dev/prometheus.yml
@@ -1,0 +1,25 @@
+# Quick Prometheus config for testing Plaid metrics.
+#
+# Start everything from local-dev/:
+#   docker compose up --build
+#
+# Prometheus UI: http://localhost:9090
+# Plaid metrics: http://localhost:9464/metrics
+#
+# Example queries:
+#   plaid_execution_queue_depth
+#   plaid_execution_queue_capacity_percentage
+#   plaid_github_logs_fetched_total
+
+global:
+  scrape_interval: 1s
+  evaluation_interval: 1s
+
+scrape_configs:
+  - job_name: plaid
+    metrics_path: /metrics
+    static_configs:
+      # Use "plaid:9464" when both services run via `docker compose up` (shared network).
+      # Use "host.docker.internal:9464" when Prometheus runs in Docker but Plaid runs on the host (`cargo run`).
+      # Use "localhost:9464" if Prometheus runs directly on the host.
+      - targets: ["host.docker.internal:9464"]

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "0.45.0"
+version = "46.0.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -4020,6 +4020,7 @@ dependencies = [
  "octocrab",
  "paste",
  "plaid_stl",
+ "prometheus",
  "pulldown-cmark",
  "rand 0.9.4",
  "rayon",
@@ -4146,6 +4147,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.5",
+ "protobuf",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4175,6 +4191,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3990,7 +3990,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "0.45.0"
+version = "46.0.0"
 dependencies = [
  "aes",
  "alkali",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "0.45.0"
+version = "46.0.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "0.45.0"
+version = "46.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -93,6 +93,7 @@ thiserror = "2.0.17"
 pulldown-cmark = "0.13.0"
 gcloud-bigquery = { version = "1.6", optional = true }
 rayon = "1.12.0"
+prometheus = "0.14.0"
 
 [[example]]
 name = "github-tailer"

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.45.0"
+version = "46.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/examples/tailers/github.rs
+++ b/runtime/plaid/examples/tailers/github.rs
@@ -56,7 +56,7 @@ async fn main() {
 
     let (logger_tx, logger_rx) = bounded(2048);
 
-    let mut gh = Github::new(config, logger_tx).unwrap();
+    let mut gh = Github::new(config, logger_tx, None).unwrap();
 
     loop {
         //println!("Start of log group");

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -18,7 +18,7 @@ use plaid::{
 
 use apis::Api;
 use data::Data;
-use executor::metrics::QueueMetrics;
+use executor::metrics::{ModuleExecutionMetrics, QueueMetrics};
 use executor::*;
 use plaid::metrics::MetricsHandle;
 use plaid_stl::messages::LogSource;
@@ -252,12 +252,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .metrics
         .as_ref()
         .map(|_| Arc::new(MetricsHandle::new()));
-    if let Some(handle) = &metrics {
-        let queue_metrics = QueueMetrics::from_pools(&exec_thread_pools);
-        if let Err(e) = handle.register(Box::new(queue_metrics)) {
-            error!("Failed to register queue metrics collector: {e}");
-        }
-    }
+
+    let module_execution_metrics = if let Some(handle) = &metrics {
+        QueueMetrics::register(handle, &exec_thread_pools);
+        Some(Arc::new(ModuleExecutionMetrics::register(handle)))
+    } else {
+        None
+    };
 
     // For convenience, keep a sender for the general channel, so that we can quickly clone it around
     let log_sender = exec_thread_pools.general_pool.sender.clone();
@@ -439,6 +440,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(cache),
         els.clone(),
         performance_sender.clone(),
+        module_execution_metrics.clone(),
         Arc::downgrade(&immediate_dispatch),
         delayed_log_sender.clone(),
         cancellation_token.clone(),

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -342,15 +342,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             metrics_config.listen_address
         );
 
-        let listen_addr = metrics_config.listen_address.clone();
+        let listen_addr = metrics_config.listen_address;
         server_tasks.spawn(async move {
-            let routes = warp::path!("metrics").and(warp::get()).map(move || {
-                warp::reply::with_header(
-                    handle.encode(),
-                    "content-type",
-                    "text/plain; version=0.0.4; charset=utf-8",
-                )
-            });
+            let routes =
+                warp::path!("metrics")
+                    .and(warp::get())
+                    .map(move || match handle.encode() {
+                        Ok(body) => {
+                            let reply = warp::reply::with_header(
+                                body,
+                                "content-type",
+                                "text/plain; version=0.0.4; charset=utf-8",
+                            );
+                            warp::reply::with_status(reply, StatusCode::OK)
+                        }
+                        Err(e) => {
+                            error!("Failed to encode metrics: {e}");
+                            warp::reply::with_status(
+                                warp::reply::with_header(
+                                    String::new(),
+                                    "content-type",
+                                    "text/plain; version=0.0.4; charset=utf-8",
+                                ),
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                            )
+                        }
+                    });
             let (_, server) =
                 warp::serve(routes).bind_with_graceful_shutdown(listen_addr, async move {
                     token.cancelled().await;

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -18,7 +18,9 @@ use plaid::{
 
 use apis::Api;
 use data::Data;
+use executor::metrics::QueueMetrics;
 use executor::*;
+use plaid::metrics::MetricsHandle;
 use plaid_stl::messages::LogSource;
 use storage::Storage;
 use tokio::{
@@ -246,6 +248,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create thread pools for log execution
     let exec_thread_pools = thread_pools::ExecutionThreadPools::new(&config.executor);
 
+    let metrics = config
+        .metrics
+        .as_ref()
+        .map(|_| Arc::new(MetricsHandle::new()));
+    if let Some(handle) = &metrics {
+        let queue_metrics = QueueMetrics::from_pools(&exec_thread_pools);
+        if let Err(e) = handle.register(Box::new(queue_metrics)) {
+            error!("Failed to register queue metrics collector: {e}");
+        }
+    }
+
     // For convenience, keep a sender for the general channel, so that we can quickly clone it around
     let log_sender = exec_thread_pools.general_pool.sender.clone();
 
@@ -317,6 +330,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         warn!("No probe_listen_address configured; readiness and liveness endpoints are disabled");
     }
 
+    if let Some(metrics_config) = &config.metrics {
+        let handle = metrics
+            .as_ref()
+            .expect("metrics handle must exist when metrics config is present")
+            .clone();
+        let token = cancellation_token.clone();
+        info!(
+            "Started metrics server at: {}",
+            metrics_config.listen_address
+        );
+
+        let listen_addr = metrics_config.listen_address.clone();
+        server_tasks.spawn(async move {
+            let routes = warp::path!("metrics").and(warp::get()).map(move || {
+                warp::reply::with_header(
+                    handle.encode(),
+                    "content-type",
+                    "text/plain; version=0.0.4; charset=utf-8",
+                )
+            });
+            let (_, server) =
+                warp::serve(routes).bind_with_graceful_shutdown(listen_addr, async move {
+                    token.cancelled().await;
+                });
+            server.await;
+            info!("Metrics server shut down");
+        });
+    }
+
     let (performance_sender, performance_handle) = match config.performance_monitoring {
         Some(perf) => {
             warn!("Plaid is running with performance monitoring enabled - this is NOT recommended for production deployments. Metadata about rule execution will be logged to a channel that aggregates and reports metrics.");
@@ -372,6 +414,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         els.clone(),
         &roles,
         cancellation_token.clone(),
+        metrics.clone(),
     )
     .await?;
     info!("Configuring APIs for Modules");
@@ -646,6 +689,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Drop every Sender<Message> so worker threads exit once the queues drain.
     info!("Waiting for executor threads to drain...");
+    drop(metrics);
     drop(log_sender);
     drop(exec_thread_pools);
     drop(immediate_dispatch);

--- a/runtime/plaid/src/config.rs
+++ b/runtime/plaid/src/config.rs
@@ -14,6 +14,7 @@ use super::cache::Config as CacheConfig;
 use super::data::DataConfig;
 use super::loader::Configuration as LoaderConfiguration;
 use super::logging::LoggingConfiguration;
+use super::metrics::MetricsConfiguration;
 use super::storage::Config as StorageConfig;
 
 /// How should responses to GET requests be cached.
@@ -161,6 +162,8 @@ pub struct Configuration {
     pub loading: LoaderConfiguration,
     /// Configuration for the cache system.
     pub cache: CacheConfig,
+    /// Optional Prometheus metrics endpoint configuration.
+    pub metrics: Option<MetricsConfiguration>,
 }
 
 /// Plaid's configuration augmented with the roles that this instance is playing.

--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -1,16 +1,19 @@
 use crate::apis::github::{build_github_clients, Authentication};
 use crate::apis::ApiError;
 use crate::executor::Message;
+use crate::metrics::MetricsHandle;
 use crate::parse_duration;
 use crossbeam_channel::Sender;
 use lru::LruCache;
 use octocrab::{self, Octocrab};
 use plaid_stl::messages::{Generator, LogSource, LogbacksAllowed};
+use prometheus::IntCounter;
 use serde::Deserialize;
 use serde_json::Value;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 use std::time::Duration;
 use time::OffsetDateTime;
 
@@ -170,10 +173,16 @@ pub struct Github {
     /// This LRU has a limited capacity: when this is reached, the least-recently-used item is removed to make space for a new insertion.
     /// Note: we only use the "key" part to keep track of the UUIDs we have seen. The "value" part is not used and always set to 0u32.
     seen_logs_uuid: LruCache<String, u32>,
+    /// Cumulative count of logs sent for processing, when metrics are enabled.
+    logs_fetched: Option<IntCounter>,
 }
 
 impl Github {
-    pub fn new(config: GithubConfig, logger: Sender<Message>) -> Result<Self, ApiError> {
+    pub fn new(
+        config: GithubConfig,
+        logger: Sender<Message>,
+        metrics: Option<Arc<MetricsHandle>>,
+    ) -> Result<Self, ApiError> {
         let default_client_auth: HashMap<String, Authentication> = [(
             "gh_data_generator".to_string(),
             config.authentication.clone(),
@@ -189,12 +198,25 @@ impl Github {
             size => NonZeroUsize::new(size).unwrap(),
         };
 
+        let logs_fetched = metrics.map(|handle| {
+            let counter = IntCounter::new(
+                "plaid_github_logs_fetched_total",
+                "Total number of GitHub logs sent for processing by the data generator",
+            )
+            .expect("valid metric definition");
+            if let Err(e) = handle.register(Box::new(counter.clone())) {
+                error!("Failed to register GitHub logs_fetched counter: {e}");
+            }
+            counter
+        });
+
         Ok(Self {
             config,
             client,
             last_seen: OffsetDateTime::now_utc(),
             seen_logs_uuid: LruCache::new(lru_cache_size),
             logger,
+            logs_fetched,
         })
     }
 }
@@ -364,7 +386,13 @@ impl DataGenerator for Github {
                 LogSource::Generator(Generator::Github),
                 self.config.logbacks_allowed.clone(),
             ))
-            .map_err(|_| ())
+            .map_err(|_| ())?;
+
+        if let Some(counter) = &self.logs_fetched {
+            counter.inc();
+        }
+
+        Ok(())
     }
 
     fn list_already_seen(&self) -> Vec<String> {

--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -204,9 +204,11 @@ impl Github {
                 "Total number of GitHub logs sent for processing by the data generator",
             )
             .expect("valid metric definition");
-            if let Err(e) = handle.register(Box::new(counter.clone())) {
-                error!("Failed to register GitHub logs_fetched counter: {e}");
-            }
+
+            handle
+                .register(Box::new(counter.clone()))
+                .expect("expected unique collector");
+
             counter
         });
 

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -97,7 +97,7 @@ impl DataInternal {
 
         let okta = config
             .okta
-            .map(|okta| okta::Okta::new(okta, logger.clone()));
+            .map(|okta| okta::Okta::new(okta, logger.clone(), metrics.clone()));
 
         let (internal, persister) = internal::Internal::new(logger.clone(), storage.clone())?;
 

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     apis::ApiError,
     executor::Message,
     logging::Logger,
+    metrics::MetricsHandle,
     storage::{Storage, StorageError},
     InstanceRoles,
 };
@@ -84,10 +85,14 @@ impl DataInternal {
         logger: Sender<Message>,
         storage: Arc<Storage>,
         els: Logger,
+        metrics: Option<Arc<MetricsHandle>>,
     ) -> Result<(Self, internal::DelayedLogPersister), DataError> {
         let github = config
             .github
-            .map(|gh| github::Github::new(gh, logger.clone()).map_err(DataError::ApiError))
+            .map(|gh| {
+                github::Github::new(gh, logger.clone(), metrics.clone())
+                    .map_err(DataError::ApiError)
+            })
             .transpose()?;
 
         let okta = config
@@ -134,9 +139,10 @@ impl Data {
         els: Logger,
         roles: &InstanceRoles,
         cancellation_token: CancellationToken,
+        metrics: Option<Arc<MetricsHandle>>,
     ) -> Result<(Sender<DelayedMessage>, DelayedLogPersister, JoinSet<()>), DataError> {
         let (mut di, delayed_log_persister) =
-            DataInternal::new(config, sender, storage.clone(), els).await?;
+            DataInternal::new(config, sender, storage.clone(), els, metrics).await?;
 
         let mut join_set = JoinSet::new();
 

--- a/runtime/plaid/src/data/okta/mod.rs
+++ b/runtime/plaid/src/data/okta/mod.rs
@@ -143,9 +143,11 @@ impl Okta {
                 "Total number of Okta logs sent for processing by the data generator",
             )
             .expect("valid metric definition");
-            if let Err(e) = handle.register(Box::new(counter.clone())) {
-                error!("Failed to register Okta logs_fetched counter: {e}");
-            }
+
+            handle
+                .register(Box::new(counter.clone()))
+                .expect("expected unique collector");
+
             counter
         });
 

--- a/runtime/plaid/src/data/okta/mod.rs
+++ b/runtime/plaid/src/data/okta/mod.rs
@@ -1,10 +1,12 @@
-use crate::{data::DataGeneratorLog, executor::Message, parse_duration};
+use crate::{data::DataGeneratorLog, executor::Message, metrics::MetricsHandle, parse_duration};
 use crossbeam_channel::Sender;
 use lru::LruCache;
 use plaid_stl::messages::{Generator, LogSource, LogbacksAllowed};
+use prometheus::IntCounter;
 use reqwest::Client;
 use serde::Deserialize;
 use serde_json::Value;
+use std::sync::Arc;
 use std::{num::NonZeroUsize, time::Duration};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
@@ -119,15 +121,33 @@ pub struct Okta {
     /// This LRU has a limited capacity: when this is reached, the least-recently-used item is removed to make space for a new insertion.
     /// Note: we only use the "key" part to keep track of the UUIDs we have seen. The "value" part is not used and always set to 0u32.
     seen_logs_uuid: LruCache<String, u32>,
+    /// Cumulative count of logs sent for processing, when metrics are enabled.
+    logs_fetched: Option<IntCounter>,
 }
 
 impl Okta {
-    pub fn new(config: OktaConfig, logger: Sender<Message>) -> Self {
+    pub fn new(
+        config: OktaConfig,
+        logger: Sender<Message>,
+        metrics: Option<Arc<MetricsHandle>>,
+    ) -> Self {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(5))
             .build()
             .unwrap();
         let lru_cache_size = config.lru_cache_size;
+
+        let logs_fetched = metrics.map(|handle| {
+            let counter = IntCounter::new(
+                "plaid_okta_logs_fetched_total",
+                "Total number of Okta logs sent for processing by the data generator",
+            )
+            .expect("valid metric definition");
+            if let Err(e) = handle.register(Box::new(counter.clone())) {
+                error!("Failed to register Okta logs_fetched counter: {e}");
+            }
+            counter
+        });
 
         Self {
             client,
@@ -135,6 +155,7 @@ impl Okta {
             last_seen: OffsetDateTime::now_utc(),
             logger,
             seen_logs_uuid: LruCache::new(NonZeroUsize::new(lru_cache_size).unwrap()),
+            logs_fetched,
         }
     }
 }
@@ -313,7 +334,13 @@ impl DataGenerator for Okta {
                 LogSource::Generator(Generator::Okta),
                 self.config.logbacks_allowed.clone(),
             ))
-            .map_err(|_| ())
+            .map_err(|_| ())?;
+
+        if let Some(counter) = &self.logs_fetched {
+            counter.inc();
+        }
+
+        Ok(())
     }
 
     fn list_already_seen(&self) -> Vec<String> {

--- a/runtime/plaid/src/executor/metrics.rs
+++ b/runtime/plaid/src/executor/metrics.rs
@@ -3,10 +3,67 @@ use std::collections::HashMap;
 use crossbeam_channel::Sender;
 use prometheus::core::{Collector, Desc};
 use prometheus::proto::MetricFamily;
-use prometheus::{GaugeVec, IntGaugeVec, Opts};
+use prometheus::{GaugeVec, HistogramOpts, HistogramVec, IntGaugeVec, Opts};
+
+use crate::metrics::MetricsHandle;
 
 use super::thread_pools::ExecutionThreadPools;
 use super::Message;
+
+/// Histograms for per-module execution stats, updated after each successful run.
+pub struct ModuleExecutionMetrics {
+    computation_percentage: HistogramVec,
+    execution_duration_seconds: HistogramVec,
+}
+
+impl ModuleExecutionMetrics {
+    pub fn register(handle: &MetricsHandle) -> Self {
+        let computation_percentage = HistogramVec::new(
+            HistogramOpts::new(
+                "plaid_module_computation_percentage_used",
+                "Percentage of a module's computation budget consumed per execution",
+            )
+            .buckets(vec![10.0, 25.0, 50.0, 75.0, 90.0, 95.0, 99.0, 100.0]),
+            &["module"],
+        )
+        .expect("valid metric definition");
+
+        let execution_duration_seconds = HistogramVec::new(
+            HistogramOpts::new(
+                "plaid_module_execution_duration_seconds",
+                "Wall-clock duration of a successful module execution",
+            ),
+            &["module"],
+        )
+        .expect("valid metric definition");
+
+        handle
+            .register(Box::new(computation_percentage.clone()))
+            .expect("expected unique collector");
+        handle
+            .register(Box::new(execution_duration_seconds.clone()))
+            .expect("expected unique collector");
+
+        Self {
+            computation_percentage,
+            execution_duration_seconds,
+        }
+    }
+
+    pub fn record_successful_execution(
+        &self,
+        module: &str,
+        computation_used_percentage: f64,
+        duration: std::time::Duration,
+    ) {
+        self.computation_percentage
+            .with_label_values(&[module])
+            .observe(computation_used_percentage);
+        self.execution_duration_seconds
+            .with_label_values(&[module])
+            .observe(duration.as_secs_f64());
+    }
+}
 
 /// Reports depth and percentage capacity of each execution queue. Values are
 /// read from the live channel senders at scrape time, so there are no writers.
@@ -18,7 +75,13 @@ pub struct QueueMetrics {
 }
 
 impl QueueMetrics {
-    pub fn from_pools(pools: &ExecutionThreadPools) -> Self {
+    pub fn register(handle: &MetricsHandle, pools: &ExecutionThreadPools) {
+        handle
+            .register(Box::new(Self::new(pools)))
+            .expect("expected unique collector");
+    }
+
+    fn new(pools: &ExecutionThreadPools) -> Self {
         let mut senders = HashMap::new();
         senders.insert("general".to_string(), pools.general_pool.sender.clone());
         for (log_type, tp) in &pools.dedicated_pools {

--- a/runtime/plaid/src/executor/metrics.rs
+++ b/runtime/plaid/src/executor/metrics.rs
@@ -1,0 +1,80 @@
+use std::collections::HashMap;
+
+use crossbeam_channel::Sender;
+use prometheus::core::{Collector, Desc};
+use prometheus::proto::MetricFamily;
+use prometheus::{GaugeVec, IntGaugeVec, Opts};
+
+use super::thread_pools::ExecutionThreadPools;
+use super::Message;
+
+/// Reports depth and percentage capacity of each execution queue. Values are
+/// read from the live channel senders at scrape time, so there are no writers.
+pub struct QueueMetrics {
+    /// One sender per queue: "general" + each dedicated log type.
+    senders: HashMap<String, Sender<Message>>,
+    depth: IntGaugeVec,
+    capacity_percentage: GaugeVec,
+}
+
+impl QueueMetrics {
+    pub fn from_pools(pools: &ExecutionThreadPools) -> Self {
+        let mut senders = HashMap::new();
+        senders.insert("general".to_string(), pools.general_pool.sender.clone());
+        for (log_type, tp) in &pools.dedicated_pools {
+            senders.insert(log_type.clone(), tp.sender.clone());
+        }
+
+        let depth = IntGaugeVec::new(
+            Opts::new(
+                "plaid_execution_queue_depth",
+                "Number of messages currently queued for execution",
+            ),
+            &["queue"],
+        )
+        .expect("valid metric definition");
+
+        let capacity_percentage = GaugeVec::new(
+            Opts::new(
+                "plaid_execution_queue_capacity_percentage",
+                "Percentage of the execution queue's capacity currently in use",
+            ),
+            &["queue"],
+        )
+        .expect("valid metric definition");
+
+        Self {
+            senders,
+            depth,
+            capacity_percentage,
+        }
+    }
+}
+
+impl Collector for QueueMetrics {
+    fn desc(&self) -> Vec<&Desc> {
+        let mut descs = self.depth.desc();
+        descs.extend(self.capacity_percentage.desc());
+        descs
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        for (queue, sender) in &self.senders {
+            let depth = sender.len();
+            let capacity = sender.capacity().unwrap_or(0);
+            let pct = if capacity == 0 {
+                0.0
+            } else {
+                (depth as f64 / capacity as f64) * 100.0
+            };
+            self.depth.with_label_values(&[queue]).set(depth as i64);
+            self.capacity_percentage
+                .with_label_values(&[queue])
+                .set(pct);
+        }
+
+        let mut families = self.depth.collect();
+        families.extend(self.capacity_percentage.collect());
+        families
+    }
+}

--- a/runtime/plaid/src/executor/mod.rs
+++ b/runtime/plaid/src/executor/mod.rs
@@ -1,3 +1,4 @@
+pub mod metrics;
 pub mod thread_pools;
 
 use crate::apis::Api;

--- a/runtime/plaid/src/executor/mod.rs
+++ b/runtime/plaid/src/executor/mod.rs
@@ -14,6 +14,7 @@ use crate::performance::ModulePerformanceMetadata;
 use crate::storage::Storage;
 
 use crossbeam_channel::{Receiver, RecvError, Sender, TrySendError};
+use metrics::ModuleExecutionMetrics;
 use thread_pools::ExecutionThreadPools;
 use tokio::sync::oneshot::Sender as OneShotSender;
 use tokio_util::sync::CancellationToken;
@@ -509,6 +510,7 @@ fn process_message_with_module(
     cache: Option<Arc<Cache>>,
     els: Logger,
     performance_mode: Option<Sender<ModulePerformanceMetadata>>,
+    module_execution_metrics: Option<Arc<ModuleExecutionMetrics>>,
     immediate_sender: Option<Sender<Message>>,
     delayed_log_sender: Sender<DelayedMessage>,
     cancellation_token: CancellationToken,
@@ -563,14 +565,14 @@ fn process_message_with_module(
                     let computation_remaining_percentage =
                         (remaining as f32 / computation_limit as f32) * 100.0;
                     let computation_used = 100.0 - computation_remaining_percentage;
-                    els.log_ts(
-                        format!("{}_computation_percentage_used", module.name),
-                        computation_used as i64,
-                    )?;
-                    els.log_ts(
-                        format!("{}_execution_duration", module.name),
-                        begin.elapsed().as_micros() as i64,
-                    )?;
+
+                    if let Some(metrics) = &module_execution_metrics {
+                        metrics.record_successful_execution(
+                            &module.name,
+                            computation_used as f64,
+                            begin.elapsed(),
+                        );
+                    }
 
                     // If performance monitoring is enabled, log data to the monitoring system
                     if let Some(ref sender) = performance_mode {
@@ -637,6 +639,7 @@ fn execution_loop(
     cache: Option<Arc<Cache>>,
     els: Logger,
     performance_monitoring_mode: Option<Sender<ModulePerformanceMetadata>>,
+    module_execution_metrics: Option<Arc<ModuleExecutionMetrics>>,
     immediate_sender: Weak<Sender<Message>>,
     delayed_log_sender: Sender<DelayedMessage>,
     cancellation_token: CancellationToken,
@@ -668,6 +671,7 @@ fn execution_loop(
                     cache.clone(),
                     els.clone(),
                     performance_monitoring_mode.clone(),
+                    module_execution_metrics.clone(),
                     immediate_sender.clone(),
                     delayed_log_sender.clone(),
                     cancellation_token.clone(),
@@ -684,6 +688,7 @@ fn execution_loop(
                         cache.clone(),
                         els.clone(),
                         performance_monitoring_mode.clone(),
+                        module_execution_metrics.clone(),
                         immediate_sender.clone(),
                         delayed_log_sender.clone(),
                         cancellation_token.clone(),
@@ -732,6 +737,7 @@ impl Executor {
         cache: Option<Arc<Cache>>,
         els: Logger,
         performance_monitoring_mode: Option<Sender<ModulePerformanceMetadata>>,
+        module_execution_metrics: Option<Arc<ModuleExecutionMetrics>>,
         immediate_sender: Weak<Sender<Message>>,
         delayed_log_sender: Sender<DelayedMessage>,
         cancellation_token: CancellationToken,
@@ -748,6 +754,7 @@ impl Executor {
             let modules = modules.clone();
             let els = els.clone();
             let performance_sender = performance_monitoring_mode.clone();
+            let module_execution_metrics = module_execution_metrics.clone();
             let immediate_sender = immediate_sender.clone();
             let delayed_log_sender = delayed_log_sender.clone();
             let cancellation_token = cancellation_token.clone();
@@ -760,6 +767,7 @@ impl Executor {
                     cache.clone(),
                     els.clone(),
                     performance_sender.clone(),
+                    module_execution_metrics.clone(),
                     immediate_sender.clone(),
                     delayed_log_sender.clone(),
                     cancellation_token.clone(),
@@ -781,6 +789,7 @@ impl Executor {
                 let modules = modules.clone();
                 let els = els.clone();
                 let performance_sender = performance_monitoring_mode.clone();
+                let module_execution_metrics = module_execution_metrics.clone();
                 let log_type = log_type.clone();
                 let immediate_sender = immediate_sender.clone();
                 let delayed_log_sender = delayed_log_sender.clone();
@@ -794,6 +803,7 @@ impl Executor {
                         cache.clone(),
                         els.clone(),
                         performance_sender.clone(),
+                        module_execution_metrics.clone(),
                         immediate_sender.clone(),
                         delayed_log_sender.clone(),
                         cancellation_token.clone(),

--- a/runtime/plaid/src/lib.rs
+++ b/runtime/plaid/src/lib.rs
@@ -17,6 +17,7 @@ pub mod executor;
 pub mod functions;
 pub mod loader;
 pub mod logging;
+pub mod metrics;
 pub mod performance;
 pub mod storage;
 

--- a/runtime/plaid/src/logging/mod.rs
+++ b/runtime/plaid/src/logging/mod.rs
@@ -40,10 +40,6 @@ pub enum Log {
         function: String,
         test_mode: bool,
     },
-    TimeseriesPoint {
-        measurement: String,
-        value: i64,
-    },
     ModuleExecutionError {
         module: String,
         error: String,
@@ -143,12 +139,6 @@ pub struct Logger {
 }
 
 impl Logger {
-    pub fn log_ts(&self, measurement: String, value: i64) -> Result<(), LoggingError> {
-        self.sender
-            .send(Log::TimeseriesPoint { measurement, value })
-            .map_err(|_| LoggingError::LoggingSystemDead)
-    }
-
     pub fn log_function_call(
         &self,
         module: String,
@@ -202,9 +192,8 @@ impl Logger {
     /// This is the entry point of our logging thread started from main. This
     /// should be running in its own thread waiting for logs to come in from
     /// the tonic server. If it does not receive a message in 300 seconds it
-    /// will send a heartbeat message instead. For stdout, and influx, this is
-    /// a noop and will not actually be sent to the backend (or logged to the
-    /// screen).
+    /// will send a heartbeat message instead. For stdout, this is a noop and
+    /// will not actually be sent to the backend (or logged to the screen).
     fn logging_thread_loop(
         config: LoggingConfiguration,
         log_receiver: Receiver<Log>,

--- a/runtime/plaid/src/logging/stdout.rs
+++ b/runtime/plaid/src/logging/stdout.rs
@@ -37,9 +37,6 @@ impl PlaidLogger for StdoutLogger {
             Log::ModuleExecutionError { module, error, log } => {
                 debug!("[{module}] errored with error [{error}]. Provided Log: {log}")
             }
-            Log::TimeseriesPoint { measurement, value } => {
-                trace!("New TS Point: ({measurement}, {value})")
-            }
             Log::WebSocketConnectionDropped { socket_name } => {
                 warn!("Connection to socket: {socket_name} dropped unexpectedly");
             }

--- a/runtime/plaid/src/metrics/mod.rs
+++ b/runtime/plaid/src/metrics/mod.rs
@@ -1,8 +1,24 @@
 use std::net::SocketAddr;
+use std::string::FromUtf8Error;
 
 use prometheus::core::Collector;
 use prometheus::{Encoder, Registry, TextEncoder};
 use serde::Deserialize;
+
+#[derive(Debug)]
+pub enum EncodeError {
+    Prometheus(prometheus::Error),
+    Utf8(FromUtf8Error),
+}
+
+impl std::fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Prometheus(e) => write!(f, "{e}"),
+            Self::Utf8(e) => write!(f, "{e}"),
+        }
+    }
+}
 
 #[derive(Deserialize)]
 pub struct MetricsConfiguration {
@@ -16,12 +32,14 @@ pub struct MetricsConfiguration {
 /// with this handle. The metrics module itself has no domain knowledge.
 pub struct MetricsHandle {
     registry: Registry,
+    encoder: TextEncoder,
 }
 
 impl MetricsHandle {
     pub fn new() -> Self {
         Self {
             registry: Registry::new(),
+            encoder: TextEncoder::new(),
         }
     }
 
@@ -29,12 +47,12 @@ impl MetricsHandle {
         self.registry.register(collector)
     }
 
-    pub fn encode(&self) -> String {
+    pub fn encode(&self) -> Result<String, EncodeError> {
         let metric_families = self.registry.gather();
         let mut buffer = Vec::new();
-        TextEncoder::new()
+        self.encoder
             .encode(&metric_families, &mut buffer)
-            .unwrap_or_default();
-        String::from_utf8(buffer).unwrap_or_default()
+            .map_err(EncodeError::Prometheus)?;
+        String::from_utf8(buffer).map_err(EncodeError::Utf8)
     }
 }

--- a/runtime/plaid/src/metrics/mod.rs
+++ b/runtime/plaid/src/metrics/mod.rs
@@ -1,0 +1,40 @@
+use std::net::SocketAddr;
+
+use prometheus::core::Collector;
+use prometheus::{Encoder, Registry, TextEncoder};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct MetricsConfiguration {
+    /// The address and port to listen on for Prometheus metrics scraping.
+    pub listen_address: SocketAddr,
+}
+
+/// A generic handle to the Prometheus metrics registry.
+///
+/// Subsystems register their own collectors (pull) or counters/gauges (push)
+/// with this handle. The metrics module itself has no domain knowledge.
+pub struct MetricsHandle {
+    registry: Registry,
+}
+
+impl MetricsHandle {
+    pub fn new() -> Self {
+        Self {
+            registry: Registry::new(),
+        }
+    }
+
+    pub fn register(&self, collector: Box<dyn Collector>) -> Result<(), prometheus::Error> {
+        self.registry.register(collector)
+    }
+
+    pub fn encode(&self) -> String {
+        let metric_families = self.registry.gather();
+        let mut buffer = Vec::new();
+        TextEncoder::new()
+            .encode(&metric_families, &mut buffer)
+            .unwrap_or_default();
+        String::from_utf8(buffer).unwrap_or_default()
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds Prometheus metrics support to Plaid, including a configurable scrape endpoint and runtime metric registration.

It instruments execution queues, module execution behavior, and data-generator fetch counts for GitHub and Okta. It also updates local development setup to run Prometheus alongside Plaid for quick validation and dashboard/query development.

## Changes
- Runtime metrics foundation:
  - Add a dedicated metrics module with MetricsConfiguration and a registry-backed MetricsHandle.
  - Add prometheus crate dependency and lockfile updates.
  - Wire optional metrics config into global runtime configuration.
- Metrics endpoint and runtime wiring:
  - Start a `/metrics` HTTP endpoint when metrics config is present.
  - Register queue metrics at startup and expose them through the shared registry.
  - Register module execution histograms and propagate metric handles through executor/data initialization paths.
- Execution and data-source instrumentation:
  - Add queue depth and queue capacity percentage metrics using live channel state at scrape time.
  - Add per-module computation-percentage and execution-duration histograms for successful runs.
  - Add cumulative `logs_fetched` counters for GitHub and Okta data generators.
- Logging cleanup and behavior shift:
  - Remove timeseries log event type and related stdout handling.
  - Replace previous logger-based execution timeseries emission with Prometheus-native metrics collection.
- Local development support:
  - Add local-dev metrics config with listen address on port 9464.
  - Add Prometheus service to docker-compose and expose Prometheus UI on port 9090.
  - Add a sample Prometheus scrape config and example queries.

## Rationale
Prometheus-native instrumentation provides standardized, pull-based observability and avoids coupling operational metrics to application log streams.

The shared metrics handle keeps registration centralized while allowing subsystems to own their metric definitions.
Using scrape-time queue collection avoids writer-side overhead and contention in hot paths.

## Breaking Changes
Logger-based timeseries points were removed from the logging subsystem. Any downstream workflows that consumed those timeseries log events should migrate to Prometheus scraping and queries.