### PR TITLE
Add durable execution-queue overflow (opt-in)

### DIFF
--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -121,7 +121,11 @@ async fn post_handler(
         if let Err(e) = exec.execute_webhook_message(message) {
             match e {
                 TrySendError::Full(message) => {
-                    handle_full_queue(message, &webhook_configuration.log_type, &spill_sender);
+                    let _ = executor::overflow::offer_to_spill(
+                        message,
+                        &webhook_configuration.log_type,
+                        &spill_sender,
+                    );
                 }
                 // TODO: Have this actually cause Plaid to exit
                 TrySendError::Disconnected(_) => panic!(
@@ -134,30 +138,30 @@ async fn post_handler(
     Box::new(warp::reply())
 }
 
-/// Handle a message that could not be enqueued because the execution queue is full.
-///
-/// If durable overflow is enabled, hand the message to the (non-blocking) spill channel
-/// so it is persisted rather than lost. If overflow is disabled, or the spill channel is
-/// itself saturated, fall back to the historical behaviour of logging a dropped message.
-fn handle_full_queue(
-    message: Message,
-    log_type: &str,
-    spill_sender: &Option<tokio::sync::mpsc::Sender<Message>>,
+/// Force-persist every message still sitting in the given execution-queue receivers.
+/// Used when the executor drain times out (wedged workers) so queued work survives reboot.
+async fn spill_queued_messages(
+    store: &executor::overflow::OverflowStore,
+    receivers: &[crossbeam_channel::Receiver<Message>],
 ) {
-    match spill_sender {
-        Some(tx) => match tx.try_send(message) {
-            Ok(()) => {
-                debug!("Queue Full! [{log_type}] message routed to durable overflow");
+    let mut spilled = 0usize;
+    let mut failed = 0usize;
+    for rx in receivers {
+        while let Ok(message) = rx.try_recv() {
+            let id = message.id.clone();
+            let source = message.source.clone();
+            let outcome = store.persist_forced(&message).await;
+            if matches!(outcome, executor::overflow::PersistOutcome::Persisted) {
+                spilled += 1;
+            } else {
+                failed += 1;
+                outcome.log_if_not_persisted("executor-drain", &id, &source);
             }
-            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                error!("Queue Full AND overflow spill backlog full! [{log_type}] log dropped!");
-            }
-            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                error!("Queue Full and overflow spill channel closed! [{log_type}] log dropped!");
-            }
-        },
-        None => error!("Queue Full! [{log_type}] log dropped!"),
+        }
     }
+    warn!(
+        "Persisted {spilled} queued message(s) to durable overflow before exit ({failed} failed)"
+    );
 }
 
 /// Read the body of a request with a maximum size limit
@@ -336,7 +340,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Set up the durable execution-queue overflow store if the feature is enabled. It
     // requires a persistent backend: without one, "durable" would be a lie (data would
     // still be lost on reboot), so we refuse to boot rather than silently no-op.
-    let overflow_store = match queue_overflow_config {
+    let (overflow_store, spill_channel_capacity) = match queue_overflow_config {
         Some(cfg) => {
             let backing = storage.clone().ok_or_else(|| {
                 error!("[executor.queue_overflow] is enabled but no storage system is configured");
@@ -346,12 +350,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 error!("[executor.queue_overflow] is enabled but the configured storage backend is not persistent; refusing to start");
                 return Err(Errors::InvalidQueueOverflowConfig.into());
             }
-            info!("Durable execution-queue overflow is ENABLED");
-            Some(Arc::new(
-                executor::overflow::OverflowStore::new(backing, cfg).await,
-            ))
+            let capacity = cfg.spill_channel_capacity.max(1);
+            info!(
+                "Durable execution-queue overflow is ENABLED (spill_channel_capacity={capacity}, max_persisted={}, claim_lease_secs={})",
+                cfg.max_persisted, cfg.claim_lease_secs
+            );
+            (
+                Some(Arc::new(
+                    executor::overflow::OverflowStore::new(backing, cfg).await,
+                )),
+                capacity,
+            )
         }
-        None => None,
+        None => (None, 0),
     };
 
     // Graceful shutdown handling
@@ -462,36 +473,46 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // write, so a slow storage backend can never block webhook ingress (which is exactly
     // the failure mode this feature exists to survive). If the spill channel itself is
     // full, the handler drops and logs, bounding memory.
+    let mut spill_handle = None;
     let spill_sender = match &overflow_store {
         Some(store) => {
-            let (tx, rx) = tokio::sync::mpsc::channel::<Message>(4096);
+            let (tx, rx) = tokio::sync::mpsc::channel::<Message>(spill_channel_capacity);
             let store = store.clone();
             let ct = cancellation_token.clone();
-            spawn(async move {
+            spill_handle = Some(spawn(async move {
                 let mut rx = rx;
                 loop {
                     tokio::select! {
                         maybe_msg = rx.recv() => {
                             match maybe_msg {
                                 // None means all senders dropped; nothing left to persist.
-                                Some(message) => { let _ = store.persist(&message).await; }
+                                Some(message) => {
+                                    let id = message.id.clone();
+                                    let source = message.source.clone();
+                                    let outcome = store.persist(&message).await;
+                                    outcome.log_if_not_persisted("spill", &id, &source);
+                                }
                                 None => break,
                             }
                         }
                         _ = ct.cancelled() => {
-                            // Shutdown started: drain what is buffered now and stop. Any
-                            // queue-full event racing in after this is caught by the
-                            // executor-drain step at the end of main(), which is the real
-                            // backstop for un-enqueued messages during shutdown.
+                            // Shutdown started: drain what is buffered with *forced*
+                            // persist so a store already at the soft cap does not drop
+                            // the last messages this feature exists to save. The
+                            // executor-drain step at the end of main() is the backstop
+                            // for messages still sitting in the execution queues.
                             while let Ok(message) = rx.try_recv() {
-                                let _ = store.persist(&message).await;
+                                let id = message.id.clone();
+                                let source = message.source.clone();
+                                let outcome = store.persist_forced(&message).await;
+                                outcome.log_if_not_persisted("spill-shutdown", &id, &source);
                             }
                             break;
                         }
                     }
                 }
                 info!("Overflow spill task shut down");
-            });
+            }));
             Some(tx)
         }
         None => None,
@@ -500,14 +521,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Same-role reload: only pods that own the execution queue (the webhook role) replay
     // overflowed messages. A pod without this role writes to the overflow store (on
     // shutdown) but never drains it, mirroring how logback replay is gated on the logback
-    // role. Claiming is atomic (delete-returns-value), so several webhook replicas can run
-    // this concurrently without double-injecting a message.
+    // role. Claiming parks rows in an inflight lease namespace so a crash mid-reload is
+    // recoverable; several webhook replicas can run this concurrently without double-
+    // claiming a ready row (delete-returns-value).
     //
     // We keep the task handle: it holds an `Arc<Executor>` (and therefore queue senders),
     // so it must be awaited to completion BEFORE the executor is torn down at shutdown, or
     // the worker-thread join would block on senders this task keeps alive. We await (not
-    // abort) so a message it claimed from storage but has not yet reinjected is never
-    // dropped mid-flight.
+    // abort) so a message mid-claim is either reinjected, returned to ready, or left in
+    // inflight for lease reclaim — never dropped on the floor.
     let mut reload_handle = None;
     if roles.webhooks {
         if let Some(store) = &overflow_store {
@@ -520,11 +542,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     if ct.is_cancelled() {
                         return;
                     }
+                    // Age-based reaper runs even when the executor queue is full, so
+                    // poison / obsolete messages cannot pin the namespace forever.
+                    let _ = store.reap_expired().await;
                     // Keep draining while the executor accepts messages; reload_batch stops
                     // itself the moment the queue is full, so this cannot busy-loop.
                     let reinjected = store.reload_batch(&executor).await;
-                    // If we reinjected anything there may be more ready to go, so loop again
-                    // immediately. Only sleep once a poll comes back empty.
+                    // If we reinjected a full-ish batch there may be more ready to go.
+                    // Only sleep once a poll comes back empty (or partial under load).
                     if reinjected > 0 {
                         continue;
                     }
@@ -785,10 +810,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         log_join_result("webhook server", result);
     }
 
+    // Spill senders are only held by webhook handlers (now joined). Drop ours so the
+    // spill task sees channel close after it finishes its cancel-path drain.
+    drop(spill_sender);
+    if let Some(handle) = spill_handle {
+        info!("Waiting for overflow spill task to shutdown...");
+        if let Err(e) = handle.await {
+            error!("Overflow spill task failed during shutdown: {e}");
+        }
+    }
+
     // The overflow reload task holds an Arc<Executor> (and therefore queue senders). It
     // was cancelled above; await it now so those senders are released before we join the
-    // worker threads. Awaiting (rather than aborting) guarantees a message it claimed from
-    // storage is either reinjected or safely left in storage, never dropped in flight.
+    // worker threads. Awaiting (rather than aborting) guarantees a message mid-claim is
+    // either reinjected, returned to ready, or left in the inflight lease namespace.
     if let Some(handle) = reload_handle {
         info!("Waiting for overflow reload task to shutdown...");
         if let Err(e) = handle.await {
@@ -828,24 +863,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // overflow drain below to run before a SIGKILL.
             const EXECUTOR_DRAIN_DEADLINE: std::time::Duration =
                 std::time::Duration::from_secs(30);
-            let join_handle = tokio::task::spawn_blocking(move || executor_threads.join());
-            match tokio::time::timeout(EXECUTOR_DRAIN_DEADLINE, join_handle).await {
-                Ok(_) => info!("Executor threads drained cleanly"),
+            // Detach join onto a plain OS thread + oneshot so a wedged worker cannot pin
+            // a Tokio blocking-pool slot for the rest of process lifetime after timeout.
+            let (join_tx, join_rx) = tokio::sync::oneshot::channel::<()>();
+            std::thread::Builder::new()
+                .name("executor-drain-join".into())
+                .spawn(move || {
+                    executor_threads.join();
+                    let _ = join_tx.send(());
+                })
+                .expect("spawn executor drain join thread");
+            match tokio::time::timeout(EXECUTOR_DRAIN_DEADLINE, join_rx).await {
+                Ok(Ok(())) => info!("Executor threads drained cleanly"),
+                Ok(Err(_)) => {
+                    // Join thread dropped the sender without sending — treat like timeout.
+                    warn!("Executor drain join thread ended unexpectedly; persisting still-queued messages");
+                    spill_queued_messages(&store, &receivers).await;
+                }
                 Err(_) => {
-                    warn!("Executor threads did not drain within {EXECUTOR_DRAIN_DEADLINE:?}; persisting still-queued messages to overflow");
-                    let mut spilled = 0usize;
-                    for rx in &receivers {
-                        while let Ok(message) = rx.try_recv() {
-                            // Bypass the cap: this is the last chance to save these messages.
-                            if matches!(
-                                store.persist_forced(&message).await,
-                                executor::overflow::PersistOutcome::Persisted
-                            ) {
-                                spilled += 1;
-                            }
-                        }
-                    }
-                    warn!("Persisted {spilled} queued message(s) to durable overflow before exit");
+                    warn!(
+                        "Executor threads did not drain within {EXECUTOR_DRAIN_DEADLINE:?}; persisting still-queued messages to overflow (join thread left detached if still blocked)"
+                    );
+                    spill_queued_messages(&store, &receivers).await;
                 }
             }
         }

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -52,6 +52,7 @@ use warp::{
 enum Errors {
     FailedToStartApiSystem(ApiError),
     FailedToLoadModules,
+    InvalidQueueOverflowConfig,
 }
 
 impl std::fmt::Display for Errors {
@@ -59,6 +60,9 @@ impl std::fmt::Display for Errors {
         match self {
             Errors::FailedToStartApiSystem(e) => write!(f, "Failed to start API system: {:?}", e),
             Errors::FailedToLoadModules => write!(f, "Failed to load modules"),
+            Errors::InvalidQueueOverflowConfig => {
+                write!(f, "Invalid queue overflow configuration")
+            }
         }
     }
 }
@@ -71,6 +75,7 @@ async fn post_handler(
     headers: HeaderMap,
     webhooks: HashMap<String, WebhookConfig>,
     exec: Arc<Executor>,
+    spill_sender: Option<tokio::sync::mpsc::Sender<Message>>,
 ) -> impl warp::Reply {
     // If this is a webhook that is configured
     if let Some(webhook_configuration) = webhooks.get(&webhook) {
@@ -115,10 +120,9 @@ async fn post_handler(
         // Webhook exists, buffer log
         if let Err(e) = exec.execute_webhook_message(message) {
             match e {
-                TrySendError::Full(_) => error!(
-                    "Queue Full! [{}] log dropped!",
-                    webhook_configuration.log_type
-                ),
+                TrySendError::Full(message) => {
+                    handle_full_queue(message, &webhook_configuration.log_type, &spill_sender);
+                }
                 // TODO: Have this actually cause Plaid to exit
                 TrySendError::Disconnected(_) => panic!(
                     "The execution system is no longer accepting messages. Nothing can continue."
@@ -128,6 +132,32 @@ async fn post_handler(
     }
     // Always Empty Response
     Box::new(warp::reply())
+}
+
+/// Handle a message that could not be enqueued because the execution queue is full.
+///
+/// If durable overflow is enabled, hand the message to the (non-blocking) spill channel
+/// so it is persisted rather than lost. If overflow is disabled, or the spill channel is
+/// itself saturated, fall back to the historical behaviour of logging a dropped message.
+fn handle_full_queue(
+    message: Message,
+    log_type: &str,
+    spill_sender: &Option<tokio::sync::mpsc::Sender<Message>>,
+) {
+    match spill_sender {
+        Some(tx) => match tx.try_send(message) {
+            Ok(()) => {
+                debug!("Queue Full! [{log_type}] message routed to durable overflow");
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                error!("Queue Full AND overflow spill backlog full! [{log_type}] log dropped!");
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                error!("Queue Full and overflow spill channel closed! [{log_type}] log dropped!");
+            }
+        },
+        None => error!("Queue Full! [{log_type}] log dropped!"),
+    }
 }
 
 /// Read the body of a request with a maximum size limit
@@ -246,6 +276,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create thread pools for log execution
     let exec_thread_pools = thread_pools::ExecutionThreadPools::new(&config.executor);
 
+    // Durable execution-queue overflow configuration, if the operator enabled it.
+    let queue_overflow_config = config.executor.queue_overflow.clone();
+
     // For convenience, keep a sender for the general channel, so that we can quickly clone it around
     let log_sender = exec_thread_pools.general_pool.sender.clone();
 
@@ -298,6 +331,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let internal_storage = match &storage {
         Some(s) => s.clone(),
         None => Arc::new(Storage::new_in_memory()),
+    };
+
+    // Set up the durable execution-queue overflow store if the feature is enabled. It
+    // requires a persistent backend: without one, "durable" would be a lie (data would
+    // still be lost on reboot), so we refuse to boot rather than silently no-op.
+    let overflow_store = match queue_overflow_config {
+        Some(cfg) => {
+            let backing = storage.clone().ok_or_else(|| {
+                error!("[executor.queue_overflow] is enabled but no storage system is configured");
+                Errors::InvalidQueueOverflowConfig
+            })?;
+            if !backing.is_persistent() {
+                error!("[executor.queue_overflow] is enabled but the configured storage backend is not persistent; refusing to start");
+                return Err(Errors::InvalidQueueOverflowConfig.into());
+            }
+            info!("Durable execution-queue overflow is ENABLED");
+            Some(Arc::new(
+                executor::overflow::OverflowStore::new(backing, cfg).await,
+            ))
+        }
+        None => None,
     };
 
     // Graceful shutdown handling
@@ -403,6 +457,87 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let executor = Arc::new(executor);
 
+    // When overflow is enabled, webhook handlers hand messages they cannot enqueue to this
+    // bounded channel instead of persisting inline. A dedicated task does the storage
+    // write, so a slow storage backend can never block webhook ingress (which is exactly
+    // the failure mode this feature exists to survive). If the spill channel itself is
+    // full, the handler drops and logs, bounding memory.
+    let spill_sender = match &overflow_store {
+        Some(store) => {
+            let (tx, rx) = tokio::sync::mpsc::channel::<Message>(4096);
+            let store = store.clone();
+            let ct = cancellation_token.clone();
+            spawn(async move {
+                let mut rx = rx;
+                loop {
+                    tokio::select! {
+                        maybe_msg = rx.recv() => {
+                            match maybe_msg {
+                                // None means all senders dropped; nothing left to persist.
+                                Some(message) => { let _ = store.persist(&message).await; }
+                                None => break,
+                            }
+                        }
+                        _ = ct.cancelled() => {
+                            // Shutdown started: drain what is buffered now and stop. Any
+                            // queue-full event racing in after this is caught by the
+                            // executor-drain step at the end of main(), which is the real
+                            // backstop for un-enqueued messages during shutdown.
+                            while let Ok(message) = rx.try_recv() {
+                                let _ = store.persist(&message).await;
+                            }
+                            break;
+                        }
+                    }
+                }
+                info!("Overflow spill task shut down");
+            });
+            Some(tx)
+        }
+        None => None,
+    };
+
+    // Same-role reload: only pods that own the execution queue (the webhook role) replay
+    // overflowed messages. A pod without this role writes to the overflow store (on
+    // shutdown) but never drains it, mirroring how logback replay is gated on the logback
+    // role. Claiming is atomic (delete-returns-value), so several webhook replicas can run
+    // this concurrently without double-injecting a message.
+    //
+    // We keep the task handle: it holds an `Arc<Executor>` (and therefore queue senders),
+    // so it must be awaited to completion BEFORE the executor is torn down at shutdown, or
+    // the worker-thread join would block on senders this task keeps alive. We await (not
+    // abort) so a message it claimed from storage but has not yet reinjected is never
+    // dropped mid-flight.
+    let mut reload_handle = None;
+    if roles.webhooks {
+        if let Some(store) = &overflow_store {
+            let store = store.clone();
+            let executor = executor.clone();
+            let ct = cancellation_token.clone();
+            reload_handle = Some(spawn(async move {
+                let poll_interval = std::time::Duration::from_secs(10);
+                loop {
+                    if ct.is_cancelled() {
+                        return;
+                    }
+                    // Keep draining while the executor accepts messages; reload_batch stops
+                    // itself the moment the queue is full, so this cannot busy-loop.
+                    let reinjected = store.reload_batch(&executor).await;
+                    // If we reinjected anything there may be more ready to go, so loop again
+                    // immediately. Only sleep once a poll comes back empty.
+                    if reinjected > 0 {
+                        continue;
+                    }
+                    tokio::select! {
+                        _ = ct.cancelled() => return,
+                        _ = tokio::time::sleep(poll_interval) => {}
+                    }
+                }
+            }));
+            info!("Overflow reload task started");
+        }
+    }
+
     if roles.webhooks {
         info!("Configured Webhook Servers");
         for (server_name, config) in config.webhooks {
@@ -413,12 +548,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let webhooks = config.webhooks.clone();
             let exec = executor.clone();
+            let post_spill_sender = spill_sender.clone();
             let post_route = warp::post()
                 .and(path!("webhook" / String))
                 .and(warp::body::stream())
                 .and(warp::header::headers_cloned())
                 .and(with(webhooks))
                 .and(with(exec.clone()))
+                .and(with(post_spill_sender))
                 .then(post_handler);
 
             // This is a cache for get requests that are configured to be cached
@@ -544,7 +681,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     }
                                 }
 
-                                // Put the message into the standard message queue
+                                // Put the message into the standard message queue.
+                                // Note: GET-mode messages carry a response_sender and block the
+                                // caller on a reply, so they are intentionally NOT routed to the
+                                // durable overflow store (they cannot be meaningfully replayed on a
+                                // later boot). On a full queue they are dropped as before.
                                 if let Err(e) = log_sender.try_send(message) {
                                     match e {
                                         TrySendError::Full(_) => error!("Queue Full! [{}] log dropped!", webhook_configuration.log_type),
@@ -644,13 +785,72 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         log_join_result("webhook server", result);
     }
 
+    // The overflow reload task holds an Arc<Executor> (and therefore queue senders). It
+    // was cancelled above; await it now so those senders are released before we join the
+    // worker threads. Awaiting (rather than aborting) guarantees a message it claimed from
+    // storage is either reinjected or safely left in storage, never dropped in flight.
+    if let Some(handle) = reload_handle {
+        info!("Waiting for overflow reload task to shutdown...");
+        if let Err(e) = handle.await {
+            error!("Overflow reload task failed during shutdown: {e}");
+        }
+    }
+
     // Drop every Sender<Message> so worker threads exit once the queues drain.
     info!("Waiting for executor threads to drain...");
     drop(log_sender);
+
+    // If durable overflow is enabled, keep a clone of every execution-queue receiver
+    // BEFORE dropping the pools. If the executor is wedged (workers stuck, not pulling),
+    // joining would block until the orchestrator SIGKILLs us and the queued messages
+    // would be lost; instead we time-box the join and, on timeout, persist whatever is
+    // still queued so it can be replayed after the next boot. Messages already being
+    // processed by a stuck worker are not recoverable this way (they are not in the
+    // channel), which is the documented residual gap of a hard wedge.
+    let overflow_drain = overflow_store.as_ref().map(|store| {
+        let mut receivers = vec![exec_thread_pools.general_pool.receiver.clone()];
+        receivers.extend(
+            exec_thread_pools
+                .dedicated_pools
+                .values()
+                .map(|tp| tp.receiver.clone()),
+        );
+        (store.clone(), receivers)
+    });
+
     drop(exec_thread_pools);
     drop(immediate_dispatch);
     drop(executor);
-    executor_threads.join();
+
+    match overflow_drain {
+        Some((store, receivers)) => {
+            // Well under the orchestrator's termination grace period, leaving time for the
+            // overflow drain below to run before a SIGKILL.
+            const EXECUTOR_DRAIN_DEADLINE: std::time::Duration =
+                std::time::Duration::from_secs(30);
+            let join_handle = tokio::task::spawn_blocking(move || executor_threads.join());
+            match tokio::time::timeout(EXECUTOR_DRAIN_DEADLINE, join_handle).await {
+                Ok(_) => info!("Executor threads drained cleanly"),
+                Err(_) => {
+                    warn!("Executor threads did not drain within {EXECUTOR_DRAIN_DEADLINE:?}; persisting still-queued messages to overflow");
+                    let mut spilled = 0usize;
+                    for rx in &receivers {
+                        while let Ok(message) = rx.try_recv() {
+                            // Bypass the cap: this is the last chance to save these messages.
+                            if matches!(
+                                store.persist_forced(&message).await,
+                                executor::overflow::PersistOutcome::Persisted
+                            ) {
+                                spilled += 1;
+                            }
+                        }
+                    }
+                    warn!("Persisted {spilled} queued message(s) to durable overflow before exit");
+                }
+            }
+        }
+        None => executor_threads.join(),
+    }
 
     // Persist any delayed logbacks still in the in-memory channel.
     info!("Flushing delayed logbacks to storage...");

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -77,10 +77,10 @@ async fn post_handler(
     headers: HeaderMap,
     webhooks: HashMap<String, WebhookConfig>,
     exec: Arc<Executor>,
-    spill_sender: Option<tokio::sync::mpsc::Sender<Message>>,
+    spill: Option<executor::overflow::SpillIngress>,
 ) -> impl warp::Reply {
-    // The status code we'll return. Defaults to 200, but is bumped to 429 if the
-    // execution system's bounded queue is full so the sender can back off and retry.
+    // 200 = enqueued for execution; 202 = accepted onto async spill path (not yet
+    // durable); 429 = rejected (queue full and spill under pressure / disabled).
     let mut status = StatusCode::OK;
     // If this is a webhook that is configured
     if let Some(webhook_configuration) = webhooks.get(&webhook) {
@@ -126,15 +126,19 @@ async fn post_handler(
         if let Err(e) = exec.execute_webhook_message(message) {
             match e {
                 TrySendError::Full(message) => {
-                    // Prefer durable spill when enabled. Only signal 429 backpressure if
-                    // the message could not be accepted onto the spill path either
-                    // (overflow disabled, spill backlog full, or channel closed).
-                    if !executor::overflow::offer_to_spill(
+                    match executor::overflow::offer_to_spill(
                         message,
                         &webhook_configuration.log_type,
-                        &spill_sender,
+                        &spill,
                     ) {
-                        status = StatusCode::TOO_MANY_REQUESTS;
+                        // Accepted onto spill: not yet durable — tell the client so it
+                        // can treat this differently from a fully enqueued log if needed.
+                        executor::overflow::SpillOffer::Accepted => {
+                            status = StatusCode::ACCEPTED;
+                        }
+                        executor::overflow::SpillOffer::Rejected => {
+                            status = StatusCode::TOO_MANY_REQUESTS;
+                        }
                     }
                 }
                 // TODO: Have this actually cause Plaid to exit
@@ -359,33 +363,55 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => Arc::new(Storage::new_in_memory()),
     };
 
+    // Overflow metrics (registered early so the store can publish gauges at seed time).
+    let overflow_metrics = metrics
+        .as_ref()
+        .map(|h| executor::overflow::OverflowMetrics::register(h));
+
     // Set up the durable execution-queue overflow store if the feature is enabled. It
     // requires a persistent backend: without one, "durable" would be a lie (data would
     // still be lost on reboot), so we refuse to boot rather than silently no-op.
-    let (overflow_store, spill_channel_capacity) = match queue_overflow_config {
-        Some(cfg) => {
-            let backing = storage.clone().ok_or_else(|| {
-                error!("[executor.queue_overflow] is enabled but no storage system is configured");
-                Errors::InvalidQueueOverflowConfig
-            })?;
-            if !backing.is_persistent() {
-                error!("[executor.queue_overflow] is enabled but the configured storage backend is not persistent; refusing to start");
-                return Err(Errors::InvalidQueueOverflowConfig.into());
+    let (overflow_store, mut spill_rx, spill_ingress, spill_concurrency) =
+        match queue_overflow_config {
+            Some(cfg) => {
+                let backing = storage.clone().ok_or_else(|| {
+                    error!(
+                        "[executor.queue_overflow] is enabled but no storage system is configured"
+                    );
+                    Errors::InvalidQueueOverflowConfig
+                })?;
+                if !backing.is_persistent() {
+                    error!("[executor.queue_overflow] is enabled but the configured storage backend is not persistent; refusing to start");
+                    return Err(Errors::InvalidQueueOverflowConfig.into());
+                }
+                let capacity = cfg.spill_channel_capacity.max(1);
+                let concurrency = cfg.spill_concurrency.max(1);
+                info!(
+                    "Durable execution-queue overflow is ENABLED (spill_channel_capacity={capacity}, spill_concurrency={concurrency}, max_persisted={}, claim_lease_secs={}, spill_hwm={}%, reinject_hwm={}%)",
+                    cfg.max_persisted,
+                    cfg.claim_lease_secs,
+                    cfg.spill_high_watermark_pct,
+                    cfg.reinject_high_watermark_pct
+                );
+                let store = Arc::new(
+                    executor::overflow::OverflowStore::new_with_metrics(
+                        backing,
+                        cfg.clone(),
+                        overflow_metrics.clone(),
+                    )
+                    .await,
+                );
+                let (tx, rx) = tokio::sync::mpsc::channel::<Message>(capacity);
+                let ingress = executor::overflow::SpillIngress::new(
+                    tx,
+                    capacity,
+                    cfg.spill_high_watermark_pct,
+                    overflow_metrics.clone(),
+                );
+                (Some(store), Some(rx), Some(ingress), concurrency)
             }
-            let capacity = cfg.spill_channel_capacity.max(1);
-            info!(
-                "Durable execution-queue overflow is ENABLED (spill_channel_capacity={capacity}, max_persisted={}, claim_lease_secs={})",
-                cfg.max_persisted, cfg.claim_lease_secs
-            );
-            (
-                Some(Arc::new(
-                    executor::overflow::OverflowStore::new(backing, cfg).await,
-                )),
-                capacity,
-            )
-        }
-        None => (None, 0),
-    };
+            None => (None, None, None, 1),
+        };
 
     // Graceful shutdown handling
     let cancellation_token = CancellationToken::new();
@@ -497,7 +523,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         info!("Starting {} {thread_or_threads} dedicated to log type [{log_type}]. Log queue size = {}", tp.num_threads, tp.sender.capacity().unwrap_or_default());
     }
     // This sender provides an internal route to sending logs. This is what
-    // powers the logback functions.
+    // powers the logback functions. Spill ingress (if any) lets data generators
+    // persist on queue-full instead of blocking or dropping.
     let (delayed_log_sender, delayed_log_persister, mut dg_tasks) = Data::start(
         config.data,
         log_sender.clone(),
@@ -506,6 +533,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         &roles,
         cancellation_token.clone(),
         metrics.clone(),
+        spill_ingress.clone(),
     )
     .await?;
     info!("Configuring APIs for Modules");
@@ -538,89 +566,71 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let executor = Arc::new(executor);
 
-    // When overflow is enabled, webhook handlers hand messages they cannot enqueue to this
-    // bounded channel instead of persisting inline. A dedicated task does the storage
-    // write, so a slow storage backend can never block webhook ingress (which is exactly
-    // the failure mode this feature exists to survive). If the spill channel itself is
-    // full, the handler drops and logs, bounding memory.
+    // When overflow is enabled, producers hand messages they cannot enqueue to the spill
+    // channel. Concurrent workers drain it to storage so a slow backend cannot block
+    // ingress. High-watermark admission rejects before the channel hard-fills (429 / drop).
     let mut spill_handle = None;
-    let spill_sender = match &overflow_store {
-        Some(store) => {
-            let (tx, rx) = tokio::sync::mpsc::channel::<Message>(spill_channel_capacity);
-            let store = store.clone();
-            let ct = cancellation_token.clone();
-            spill_handle = Some(spawn(async move {
-                let mut rx = rx;
-                loop {
-                    tokio::select! {
-                        maybe_msg = rx.recv() => {
-                            match maybe_msg {
-                                // None means all senders dropped; nothing left to persist.
-                                Some(message) => {
-                                    let id = message.id.clone();
-                                    let source = message.source.clone();
-                                    let outcome = store.persist(&message).await;
-                                    outcome.log_if_not_persisted("spill", &id, &source);
-                                }
-                                None => break,
-                            }
-                        }
-                        _ = ct.cancelled() => {
-                            // Shutdown started: drain what is buffered with *forced*
-                            // persist so a store already at the soft cap does not drop
-                            // the last messages this feature exists to save. The
-                            // executor-drain step at the end of main() is the backstop
-                            // for messages still sitting in the execution queues.
-                            while let Ok(message) = rx.try_recv() {
-                                let id = message.id.clone();
-                                let source = message.source.clone();
-                                let outcome = store.persist_forced(&message).await;
-                                outcome.log_if_not_persisted("spill-shutdown", &id, &source);
-                            }
-                            break;
-                        }
-                    }
-                }
-                info!("Overflow spill task shut down");
-            }));
-            Some(tx)
-        }
-        None => None,
-    };
+    if let (Some(store), Some(rx)) = (overflow_store.clone(), spill_rx.take()) {
+        let depth = spill_ingress
+            .as_ref()
+            .map(|s| s.depth_handle())
+            .expect("spill ingress present when store is");
+        let last_failure = spill_ingress
+            .as_ref()
+            .map(|s| s.failure_handle())
+            .expect("spill ingress present when store is");
+        let ct = cancellation_token.clone();
+        let concurrency = spill_concurrency;
+        spill_handle = Some(spawn(async move {
+            executor::overflow::run_spill_workers(
+                store,
+                rx,
+                depth,
+                last_failure,
+                concurrency,
+                ct,
+            )
+            .await;
+        }));
+    }
 
     // Same-role reload: only pods that own the execution queue (the webhook role) replay
-    // overflowed messages. A pod without this role writes to the overflow store (on
-    // shutdown) but never drains it, mirroring how logback replay is gated on the logback
-    // role. Claiming parks rows in an inflight lease namespace so a crash mid-reload is
-    // recoverable; several webhook replicas can run this concurrently without double-
-    // claiming a ready row (delete-returns-value).
+    // overflowed messages. Claiming parks rows in an inflight lease namespace so a crash
+    // mid-reload is recoverable. Age reaper runs on a slower cadence than reload so
+    // catch-up does not full-scan the namespace every poll.
     //
     // We keep the task handle: it holds an `Arc<Executor>` (and therefore queue senders),
-    // so it must be awaited to completion BEFORE the executor is torn down at shutdown, or
-    // the worker-thread join would block on senders this task keeps alive. We await (not
-    // abort) so a message mid-claim is either reinjected, returned to ready, or left in
-    // inflight for lease reclaim — never dropped on the floor.
+    // so it must be awaited to completion BEFORE the executor is torn down at shutdown.
     let mut reload_handle = None;
     if roles.webhooks {
         if let Some(store) = &overflow_store {
             let store = store.clone();
             let executor = executor.clone();
             let ct = cancellation_token.clone();
+            let poll_interval = std::time::Duration::from_secs(
+                store.config().reload_poll_interval_secs.max(1),
+            );
+            let reaper_interval = std::time::Duration::from_secs(
+                store.config().reaper_interval_secs.max(1),
+            );
             reload_handle = Some(spawn(async move {
-                let poll_interval = std::time::Duration::from_secs(10);
+                let mut last_reap = std::time::Instant::now()
+                    .checked_sub(reaper_interval)
+                    .unwrap_or_else(std::time::Instant::now);
                 loop {
                     if ct.is_cancelled() {
                         return;
                     }
-                    // Age-based reaper runs even when the executor queue is full, so
-                    // poison / obsolete messages cannot pin the namespace forever.
-                    let _ = store.reap_expired().await;
+                    if last_reap.elapsed() >= reaper_interval {
+                        let _ = store.reap_expired().await;
+                        last_reap = std::time::Instant::now();
+                    }
                     // Keep draining while the executor accepts messages; reload_batch stops
-                    // itself the moment the queue is full, so this cannot busy-loop.
+                    // itself at the reinject high watermark or when the queue is full.
                     let reinjected = store.reload_batch(&executor).await;
-                    // If we reinjected a full-ish batch there may be more ready to go.
-                    // Only sleep once a poll comes back empty (or partial under load).
                     if reinjected > 0 {
+                        // Small yield so we do not peg a core against storage under catch-up.
+                        tokio::task::yield_now().await;
                         continue;
                     }
                     tokio::select! {
@@ -643,14 +653,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let webhooks = config.webhooks.clone();
             let exec = executor.clone();
-            let post_spill_sender = spill_sender.clone();
+            let post_spill = spill_ingress.clone();
             let post_route = warp::post()
                 .and(path!("webhook" / String))
                 .and(warp::body::stream())
                 .and(warp::header::headers_cloned())
                 .and(with(webhooks))
                 .and(with(exec.clone()))
-                .and(with(post_spill_sender))
+                .and(with(post_spill))
                 .then(post_handler);
 
             // This is a cache for get requests that are configured to be cached
@@ -882,7 +892,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Spill senders are only held by webhook handlers (now joined). Drop ours so the
     // spill task sees channel close after it finishes its cancel-path drain.
-    drop(spill_sender);
+    drop(spill_ingress);
     if let Some(handle) = spill_handle {
         info!("Waiting for overflow spill task to shutdown...");
         if let Err(e) = handle.await {

--- a/runtime/plaid/src/config.rs
+++ b/runtime/plaid/src/config.rs
@@ -140,11 +140,16 @@ pub struct ExecutorConfig {
     /// Requires a persistent storage backend; enabling it without one is a
     /// configuration error caught at startup.
     ///
-    /// Coverage today: webhook POST path on queue-full, plus force-persist of still-queued
-    /// messages on timeboxed shutdown. GET-mode requests are never spilled (they carry a
-    /// live response channel). Delayed logbacks already have their own durable store and
-    /// are left there when the executor queue is full. Other data generators (interval,
-    /// SQS, …) are not yet routed through this path.
+    /// Coverage: webhook POST and data generators (interval, SQS, GitHub, Okta, websocket)
+    /// on queue-full, plus force-persist of still-queued messages on timeboxed shutdown.
+    /// GET-mode requests are never spilled (they carry a live response channel). Delayed
+    /// logbacks already have their own durable store and stay there when the executor
+    /// queue is full.
+    ///
+    /// HTTP admission: messages accepted onto the executor return 200; messages accepted
+    /// onto the spill path return **202 Accepted** (not yet durable — persistence is
+    /// async). When the spill channel is over its high watermark, closed, or overflow is
+    /// off, the handler returns **429** so clients can retry.
     ///
     /// Delivery is **at-least-once**: a crash after enqueue but before lease ack can cause
     /// a duplicate reinject. Rules should tolerate reprocessing.
@@ -165,7 +170,8 @@ pub struct QueueOverflowConfig {
     /// Soft cap on the number of messages held in the overflow store (ready + inflight)
     /// as counted by *this* process. Once reached, further hot-path persists are dropped
     /// (and logged) rather than written, bounding blast radius when the executor is
-    /// wedged. Defaults to 100_000. Forced shutdown persists may exceed this up to
+    /// wedged. Defaults to 50_000 (lower than earlier drafts so full-namespace scans at
+    /// startup stay tractable). Forced shutdown persists may exceed this up to
     /// `2 * max_persisted` (hard ceiling).
     #[serde(default = "default_overflow_max_persisted")]
     pub max_persisted: u64,
@@ -174,9 +180,9 @@ pub struct QueueOverflowConfig {
     /// forever. Defaults to 86_400 (24h).
     #[serde(default = "default_overflow_max_age_secs")]
     pub max_message_age_secs: u64,
-    /// How many ready overflow messages to claim and reinject per reload poll. Bounds
-    /// claim work per cycle; each poll still lists keys in the ready namespace (memory
-    /// scales with total persisted rows, not this setting). Defaults to 256.
+    /// How many ready overflow messages to claim and reinject per reload poll. Also
+    /// bounds how many keys are listed from storage per cycle (oldest-first, limited
+    /// query — not a full namespace scan). Defaults to 256.
     #[serde(default = "default_overflow_reload_batch")]
     pub reload_batch_size: usize,
     /// How long a claimed (inflight) message may sit before another reloader reclaims it
@@ -185,11 +191,32 @@ pub struct QueueOverflowConfig {
     /// short enough that a dead claimer's messages recover promptly.
     #[serde(default = "default_overflow_claim_lease_secs")]
     pub claim_lease_secs: u64,
-    /// Capacity of the in-process spill channel that decouples webhook ingress from
-    /// storage writes. Bounds memory under burst (each slot holds one `Message`). Defaults
-    /// to 512.
+    /// Capacity of the in-process spill channel that decouples ingress from storage
+    /// writes. Bounds memory under burst (each slot holds one `Message`). Defaults to
+    /// 4096. Size as `peak_excess_rps * p99_persist_latency_secs * safety`.
     #[serde(default = "default_overflow_spill_channel_capacity")]
     pub spill_channel_capacity: usize,
+    /// How many storage persists may run concurrently on the spill path. Serial writes
+    /// bottleneck bursts; defaults to 8.
+    #[serde(default = "default_overflow_spill_concurrency")]
+    pub spill_concurrency: usize,
+    /// When the spill channel is at least this full (percent), new spill offers are
+    /// rejected so clients see 429 / generators back off *before* the channel hard-fills.
+    /// Defaults to 75.
+    #[serde(default = "default_overflow_spill_high_watermark_pct")]
+    pub spill_high_watermark_pct: u8,
+    /// Stop reinjecting when the target execution queue is at least this full (percent),
+    /// avoiding claim→restore thrash against a near-full queue. Defaults to 70.
+    #[serde(default = "default_overflow_reinject_high_watermark_pct")]
+    pub reinject_high_watermark_pct: u8,
+    /// How often (seconds) the age reaper scans ready overflow. Kept slower than reload
+    /// so reaping does not amplify storage load during catch-up. Defaults to 300.
+    #[serde(default = "default_overflow_reaper_interval_secs")]
+    pub reaper_interval_secs: u64,
+    /// Idle poll interval (seconds) for the reload task when nothing was reinjected.
+    /// Defaults to 10.
+    #[serde(default = "default_overflow_reload_poll_interval_secs")]
+    pub reload_poll_interval_secs: u64,
 }
 
 impl Default for QueueOverflowConfig {
@@ -200,12 +227,17 @@ impl Default for QueueOverflowConfig {
             reload_batch_size: default_overflow_reload_batch(),
             claim_lease_secs: default_overflow_claim_lease_secs(),
             spill_channel_capacity: default_overflow_spill_channel_capacity(),
+            spill_concurrency: default_overflow_spill_concurrency(),
+            spill_high_watermark_pct: default_overflow_spill_high_watermark_pct(),
+            reinject_high_watermark_pct: default_overflow_reinject_high_watermark_pct(),
+            reaper_interval_secs: default_overflow_reaper_interval_secs(),
+            reload_poll_interval_secs: default_overflow_reload_poll_interval_secs(),
         }
     }
 }
 
 fn default_overflow_max_persisted() -> u64 {
-    100_000
+    50_000
 }
 
 fn default_overflow_max_age_secs() -> u64 {
@@ -221,7 +253,27 @@ fn default_overflow_claim_lease_secs() -> u64 {
 }
 
 fn default_overflow_spill_channel_capacity() -> usize {
-    512
+    4096
+}
+
+fn default_overflow_spill_concurrency() -> usize {
+    8
+}
+
+fn default_overflow_spill_high_watermark_pct() -> u8 {
+    75
+}
+
+fn default_overflow_reinject_high_watermark_pct() -> u8 {
+    70
+}
+
+fn default_overflow_reaper_interval_secs() -> u64 {
+    300
+}
+
+fn default_overflow_reload_poll_interval_secs() -> u64 {
+    10
 }
 
 /// The full configuration of Plaid

--- a/runtime/plaid/src/config.rs
+++ b/runtime/plaid/src/config.rs
@@ -139,11 +139,21 @@ pub struct ExecutorConfig {
     /// Requires a persistent storage backend; enabling it without one is a
     /// configuration error caught at startup.
     ///
+    /// Coverage today: webhook POST path on queue-full, plus force-persist of still-queued
+    /// messages on timeboxed shutdown. GET-mode requests are never spilled (they carry a
+    /// live response channel). Delayed logbacks already have their own durable store and
+    /// are left there when the executor queue is full. Other data generators (interval,
+    /// SQS, …) are not yet routed through this path.
+    ///
+    /// Delivery is **at-least-once**: a crash after enqueue but before lease ack can cause
+    /// a duplicate reinject. Rules should tolerate reprocessing.
+    ///
     /// Note on multi-replica deployments: cross-pod recovery (a message spilled by a pod
     /// that then dies being replayed by a sibling) only works with a *shared* backend such
     /// as DynamoDB. With a node-local backend (Sled), each replica sees only its own
     /// spilled messages, so a dead pod's overflow is recovered only when that pod's storage
-    /// comes back. Single-replica roles are unaffected.
+    /// comes back. Single-replica roles are unaffected. The `max_persisted` cap is enforced
+    /// per process, so N replicas can hold roughly up to `N * max_persisted` rows combined.
     #[serde(default)]
     pub queue_overflow: Option<QueueOverflowConfig>,
 }
@@ -151,21 +161,34 @@ pub struct ExecutorConfig {
 /// Configuration for the durable execution-queue overflow feature.
 #[derive(Deserialize, Clone)]
 pub struct QueueOverflowConfig {
-    /// Hard cap on the number of messages held in the overflow store at once. Once the
-    /// store holds this many, further messages are dropped (and logged) rather than
-    /// persisted, bounding the blast radius on the storage backend when the executor is
-    /// wedged. Defaults to 100_000.
+    /// Soft cap on the number of messages held in the overflow store (ready + inflight)
+    /// as counted by *this* process. Once reached, further hot-path persists are dropped
+    /// (and logged) rather than written, bounding blast radius when the executor is
+    /// wedged. Defaults to 100_000. Forced shutdown persists may exceed this up to
+    /// `2 * max_persisted` (hard ceiling).
     #[serde(default = "default_overflow_max_persisted")]
     pub max_persisted: u64,
-    /// Messages older than this many seconds are discarded by the reloader instead of
-    /// being replayed, so a message for a since-removed rule cannot loop forever.
-    /// Defaults to 86_400 (24h).
+    /// Messages older than this many seconds are discarded by the reaper / reloader
+    /// instead of being replayed, so a message for a since-removed rule cannot loop
+    /// forever. Defaults to 86_400 (24h).
     #[serde(default = "default_overflow_max_age_secs")]
     pub max_message_age_secs: u64,
-    /// How many overflow messages to claim and reinject per reload poll. Keeps a single
-    /// poll from loading an unbounded namespace into memory. Defaults to 256.
+    /// How many ready overflow messages to claim and reinject per reload poll. Bounds
+    /// claim work per cycle; each poll still lists keys in the ready namespace (memory
+    /// scales with total persisted rows, not this setting). Defaults to 256.
     #[serde(default = "default_overflow_reload_batch")]
     pub reload_batch_size: usize,
+    /// How long a claimed (inflight) message may sit before another reloader reclaims it
+    /// back to ready. Covers the crash window between claim and enqueue-ack. Defaults to
+    /// 120 seconds. Must be long enough for a single decompress + try_send under load,
+    /// short enough that a dead claimer's messages recover promptly.
+    #[serde(default = "default_overflow_claim_lease_secs")]
+    pub claim_lease_secs: u64,
+    /// Capacity of the in-process spill channel that decouples webhook ingress from
+    /// storage writes. Bounds memory under burst (each slot holds one `Message`). Defaults
+    /// to 512.
+    #[serde(default = "default_overflow_spill_channel_capacity")]
+    pub spill_channel_capacity: usize,
 }
 
 impl Default for QueueOverflowConfig {
@@ -174,6 +197,8 @@ impl Default for QueueOverflowConfig {
             max_persisted: default_overflow_max_persisted(),
             max_message_age_secs: default_overflow_max_age_secs(),
             reload_batch_size: default_overflow_reload_batch(),
+            claim_lease_secs: default_overflow_claim_lease_secs(),
+            spill_channel_capacity: default_overflow_spill_channel_capacity(),
         }
     }
 }
@@ -188,6 +213,14 @@ fn default_overflow_max_age_secs() -> u64 {
 
 fn default_overflow_reload_batch() -> usize {
     256
+}
+
+fn default_overflow_claim_lease_secs() -> u64 {
+    120
+}
+
+fn default_overflow_spill_channel_capacity() -> usize {
+    512
 }
 
 /// The full configuration of Plaid

--- a/runtime/plaid/src/config.rs
+++ b/runtime/plaid/src/config.rs
@@ -131,6 +131,63 @@ pub struct ExecutorConfig {
     /// This is a mapping {log type --> num threads}.
     #[serde(default)]
     pub dedicated_threads: HashMap<String, DedicatedThreadsConfig>,
+    /// Optional durable overflow for the execution queue. When present, messages that
+    /// would otherwise be dropped (queue full, or still queued when the process is told
+    /// to stop) are persisted to storage and replayed on a later boot instead of being
+    /// lost. Absent = feature disabled (default), and behaviour is unchanged.
+    ///
+    /// Requires a persistent storage backend; enabling it without one is a
+    /// configuration error caught at startup.
+    ///
+    /// Note on multi-replica deployments: cross-pod recovery (a message spilled by a pod
+    /// that then dies being replayed by a sibling) only works with a *shared* backend such
+    /// as DynamoDB. With a node-local backend (Sled), each replica sees only its own
+    /// spilled messages, so a dead pod's overflow is recovered only when that pod's storage
+    /// comes back. Single-replica roles are unaffected.
+    #[serde(default)]
+    pub queue_overflow: Option<QueueOverflowConfig>,
+}
+
+/// Configuration for the durable execution-queue overflow feature.
+#[derive(Deserialize, Clone)]
+pub struct QueueOverflowConfig {
+    /// Hard cap on the number of messages held in the overflow store at once. Once the
+    /// store holds this many, further messages are dropped (and logged) rather than
+    /// persisted, bounding the blast radius on the storage backend when the executor is
+    /// wedged. Defaults to 100_000.
+    #[serde(default = "default_overflow_max_persisted")]
+    pub max_persisted: u64,
+    /// Messages older than this many seconds are discarded by the reloader instead of
+    /// being replayed, so a message for a since-removed rule cannot loop forever.
+    /// Defaults to 86_400 (24h).
+    #[serde(default = "default_overflow_max_age_secs")]
+    pub max_message_age_secs: u64,
+    /// How many overflow messages to claim and reinject per reload poll. Keeps a single
+    /// poll from loading an unbounded namespace into memory. Defaults to 256.
+    #[serde(default = "default_overflow_reload_batch")]
+    pub reload_batch_size: usize,
+}
+
+impl Default for QueueOverflowConfig {
+    fn default() -> Self {
+        Self {
+            max_persisted: default_overflow_max_persisted(),
+            max_message_age_secs: default_overflow_max_age_secs(),
+            reload_batch_size: default_overflow_reload_batch(),
+        }
+    }
+}
+
+fn default_overflow_max_persisted() -> u64 {
+    100_000
+}
+
+fn default_overflow_max_age_secs() -> u64 {
+    86_400
+}
+
+fn default_overflow_reload_batch() -> usize {
+    256
 }
 
 /// The full configuration of Plaid

--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -167,6 +167,8 @@ pub struct Github {
     last_seen: OffsetDateTime,
     /// The logger used to send logs to the execution system for processing
     logger: Sender<Message>,
+    /// Optional durable spill when the executor queue is full.
+    spill: Option<crate::executor::overflow::SpillIngress>,
     /// An LRU where we store the UUIDs of logs that we have already seen and sent into the logging system.
     /// This, together with some overlapping queries to the GH API, helps us ensure that all logs are processed
     /// exactly once.
@@ -182,6 +184,7 @@ impl Github {
         config: GithubConfig,
         logger: Sender<Message>,
         metrics: Option<Arc<MetricsHandle>>,
+        spill: Option<crate::executor::overflow::SpillIngress>,
     ) -> Result<Self, ApiError> {
         let default_client_auth: HashMap<String, Authentication> = [(
             "gh_data_generator".to_string(),
@@ -218,6 +221,7 @@ impl Github {
             last_seen: OffsetDateTime::now_utc(),
             seen_logs_uuid: LruCache::new(lru_cache_size),
             logger,
+            spill,
             logs_fetched,
         })
     }
@@ -381,14 +385,18 @@ impl DataGenerator for Github {
     }
 
     fn send_for_processing(&self, payload: Vec<u8>) -> Result<(), ()> {
-        self.logger
-            .send(Message::new(
-                format!("github"),
-                payload,
-                LogSource::Generator(Generator::Github),
-                self.config.logbacks_allowed.clone(),
-            ))
-            .map_err(|_| ())?;
+        let message = Message::new(
+            "github".to_string(),
+            payload,
+            LogSource::Generator(Generator::Github),
+            self.config.logbacks_allowed.clone(),
+        );
+        crate::executor::overflow::send_or_spill(
+            &self.logger,
+            message,
+            "github",
+            &self.spill,
+        )?;
 
         if let Some(counter) = &self.logs_fetched {
             counter.inc();

--- a/runtime/plaid/src/data/interval/mod.rs
+++ b/runtime/plaid/src/data/interval/mod.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use cron::Schedule;
-use crossbeam_channel::{Sender, TrySendError};
+use crossbeam_channel::Sender;
 use plaid_stl::messages::{Generator, LogSource, LogbacksAllowed};
 use serde::Deserialize;
 use std::str::FromStr;
@@ -109,12 +109,18 @@ pub struct Interval {
     // config: IntervalConfig,
     /// Sends logs to executor
     sender: Sender<Message>,
+    /// Optional durable spill when the executor queue is full.
+    spill: Option<crate::executor::overflow::SpillIngress>,
     /// Stores jobs while they are waiting to be processed
     job_heap: BinaryHeap<Reverse<ScheduledJob>>,
 }
 
 impl Interval {
-    pub fn new(config: IntervalConfig, log_sender: Sender<Message>) -> Self {
+    pub fn new(
+        config: IntervalConfig,
+        log_sender: Sender<Message>,
+        spill: Option<crate::executor::overflow::SpillIngress>,
+    ) -> Self {
         let mut job_heap = BinaryHeap::new();
 
         // Initialize job heap
@@ -143,6 +149,7 @@ impl Interval {
 
         Interval {
             sender: log_sender,
+            spill,
             job_heap,
         }
     }
@@ -165,22 +172,23 @@ impl Interval {
                 break;
             }
 
-            // Send job to executor
+            // Send job to executor (or durable spill on queue-full when configured).
             // safe unwrap because if the job_heap was empty, the call to `peek()` above would have returned None
             let job = self.job_heap.pop().unwrap();
-            let _ = self
-                .sender
-                .try_send(job.0.message.create_duplicate())
-                .inspect_err(|e| match e {
-                    TrySendError::Disconnected(_) => {
-                        error!("Interval job sender channel has been disconnected. Unable to send interval job message.");
-                    }
-                    TrySendError::Full(_) => {
-                        error!(
-                            "Interval job sender channel is full. Unable to send interval job message."
-                        );
-                    }
-                });
+            let msg = job.0.message.create_duplicate();
+            let log_type = msg.type_.clone();
+            if crate::executor::overflow::send_or_spill(
+                &self.sender,
+                msg,
+                &log_type,
+                &self.spill,
+            )
+            .is_err()
+            {
+                error!(
+                    "Interval job sender channel is full/disconnected and spill rejected. Unable to send interval job message."
+                );
+            }
 
             // Try to get next execution time. If there are no more scheduled executions for this job, we'll exit early.
             let next_execution = job.0.schedule.upcoming(Utc).take(1).collect::<Vec<_>>();

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -8,7 +8,7 @@ mod websocket;
 
 use crate::{
     apis::ApiError,
-    executor::Message,
+    executor::{overflow::SpillIngress, Message},
     logging::Logger,
     metrics::MetricsHandle,
     storage::{Storage, StorageError},
@@ -86,35 +86,37 @@ impl DataInternal {
         storage: Arc<Storage>,
         els: Logger,
         metrics: Option<Arc<MetricsHandle>>,
+        spill: Option<SpillIngress>,
     ) -> Result<(Self, internal::DelayedLogPersister), DataError> {
         let github = config
             .github
             .map(|gh| {
-                github::Github::new(gh, logger.clone(), metrics.clone())
+                github::Github::new(gh, logger.clone(), metrics.clone(), spill.clone())
                     .map_err(DataError::ApiError)
             })
             .transpose()?;
 
         let okta = config
             .okta
-            .map(|okta| okta::Okta::new(okta, logger.clone(), metrics.clone()));
+            .map(|okta| okta::Okta::new(okta, logger.clone(), metrics.clone(), spill.clone()));
 
+        // Logbacks keep their own durable store on queue-full; do not route through spill.
         let (internal, persister) = internal::Internal::new(logger.clone(), storage.clone())?;
 
         let interval = config
             .interval
-            .map(|config| interval::Interval::new(config, logger.clone()));
+            .map(|config| interval::Interval::new(config, logger.clone(), spill.clone()));
 
         #[cfg(feature = "aws")]
         let sqs = if let Some(cfg) = config.sqs {
-            Some(sqs::SQS::new(cfg, logger.clone()).await)
+            Some(sqs::SQS::new(cfg, logger.clone(), spill.clone()).await)
         } else {
             None
         };
 
         let websocket_external = config
             .websocket
-            .map(|ws| websocket::WebsocketGenerator::new(ws, logger.clone(), els));
+            .map(|ws| websocket::WebsocketGenerator::new(ws, logger.clone(), els, spill.clone()));
 
         Ok((
             Self {
@@ -140,9 +142,10 @@ impl Data {
         roles: &InstanceRoles,
         cancellation_token: CancellationToken,
         metrics: Option<Arc<MetricsHandle>>,
+        spill: Option<SpillIngress>,
     ) -> Result<(Sender<DelayedMessage>, DelayedLogPersister, JoinSet<()>), DataError> {
         let (mut di, delayed_log_persister) =
-            DataInternal::new(config, sender, storage.clone(), els, metrics).await?;
+            DataInternal::new(config, sender, storage.clone(), els, metrics, spill).await?;
 
         let mut join_set = JoinSet::new();
 

--- a/runtime/plaid/src/data/okta/mod.rs
+++ b/runtime/plaid/src/data/okta/mod.rs
@@ -115,6 +115,8 @@ pub struct Okta {
     last_seen: OffsetDateTime,
     /// Sending channel used to send logs into the execution system
     logger: Sender<Message>,
+    /// Optional durable spill when the executor queue is full.
+    spill: Option<crate::executor::overflow::SpillIngress>,
     /// An LRU where we store the UUIDs of Okta logs that we have already seen and sent into the logging system.
     /// This, together with some overlapping queries to the Okta API, helps us ensure that all Okta logs are processed
     /// exactly once.
@@ -130,6 +132,7 @@ impl Okta {
         config: OktaConfig,
         logger: Sender<Message>,
         metrics: Option<Arc<MetricsHandle>>,
+        spill: Option<crate::executor::overflow::SpillIngress>,
     ) -> Self {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(5))
@@ -156,6 +159,7 @@ impl Okta {
             config,
             last_seen: OffsetDateTime::now_utc(),
             logger,
+            spill,
             seen_logs_uuid: LruCache::new(NonZeroUsize::new(lru_cache_size).unwrap()),
             logs_fetched,
         }
@@ -329,14 +333,13 @@ impl DataGenerator for Okta {
     }
 
     fn send_for_processing(&self, payload: Vec<u8>) -> Result<(), ()> {
-        self.logger
-            .send(Message::new(
-                "okta".to_string(),
-                payload,
-                LogSource::Generator(Generator::Okta),
-                self.config.logbacks_allowed.clone(),
-            ))
-            .map_err(|_| ())?;
+        let message = Message::new(
+            "okta".to_string(),
+            payload,
+            LogSource::Generator(Generator::Okta),
+            self.config.logbacks_allowed.clone(),
+        );
+        crate::executor::overflow::send_or_spill(&self.logger, message, "okta", &self.spill)?;
 
         if let Some(counter) = &self.logs_fetched {
             counter.inc();

--- a/runtime/plaid/src/data/sqs/mod.rs
+++ b/runtime/plaid/src/data/sqs/mod.rs
@@ -55,6 +55,8 @@ pub struct SQS {
     client: Client,
     /// The logger used to send logs to the execution system for processing
     logger: Sender<Message>,
+    /// Optional durable spill when the executor queue is full.
+    spill: Option<crate::executor::overflow::SpillIngress>,
     /// SQS sends messages 'at least once' so we use this cache to dedup messages
     /// An LRU where we store the UUIDs of messages that we have already seen and sent into the logging system.
     /// This LRU has a limited capacity: when this is reached, the least-recently-used item is removed to make space for a new insertion.
@@ -63,7 +65,11 @@ pub struct SQS {
 }
 
 impl SQS {
-    pub async fn new(config: SQSConfig, logger: Sender<Message>) -> Self {
+    pub async fn new(
+        config: SQSConfig,
+        logger: Sender<Message>,
+        spill: Option<crate::executor::overflow::SpillIngress>,
+    ) -> Self {
         let sdk_config = get_aws_sdk_config(&config.authentication).await;
         let client = aws_sdk_sqs::Client::new(&sdk_config);
 
@@ -72,6 +78,7 @@ impl SQS {
             client,
             seen_messages: LruCache::new(NonZeroUsize::new(4096).unwrap()),
             logger,
+            spill,
         }
     }
 
@@ -154,16 +161,17 @@ impl SQS {
     }
 
     fn send_for_processing(&self, payload: Vec<u8>) -> Result<(), String> {
-        self.logger
-            .send(Message::new(
-                format!("sqs/{}", self.config.name),
-                payload,
-                LogSource::Generator(Generator::SQS(self.config.name.clone())),
-                self.config.logbacks_allowed.clone(),
-            ))
-            .map_err(|e| {
+        let log_type = format!("sqs/{}", self.config.name);
+        let message = Message::new(
+            log_type.clone(),
+            payload,
+            LogSource::Generator(Generator::SQS(self.config.name.clone())),
+            self.config.logbacks_allowed.clone(),
+        );
+        crate::executor::overflow::send_or_spill(&self.logger, message, &log_type, &self.spill)
+            .map_err(|_| {
                 format!(
-                    "sqs/{} send_for_processing failed. error: {e}",
+                    "sqs/{} send_for_processing failed (queue full/disconnected and spill rejected)",
                     self.config.name
                 )
             })

--- a/runtime/plaid/src/data/websocket/mod.rs
+++ b/runtime/plaid/src/data/websocket/mod.rs
@@ -187,7 +187,12 @@ pub struct WebsocketGenerator {
 /// # Returns
 /// A new `WebsocketGenerator` instance.
 impl WebsocketGenerator {
-    pub fn new(config: WebSocketDataGenerator, sender: Sender<Message>, logger: Logger) -> Self {
+    pub fn new(
+        config: WebSocketDataGenerator,
+        sender: Sender<Message>,
+        logger: Logger,
+        spill: Option<crate::executor::overflow::SpillIngress>,
+    ) -> Self {
         let clients = config
             .websockets
             .into_iter()
@@ -198,6 +203,7 @@ impl WebsocketGenerator {
                     name,
                     config.max_message_size,
                     config.max_frame_size,
+                    spill.clone(),
                 )
             })
             .collect();
@@ -269,6 +275,8 @@ struct WebSocketClient {
     configuration: WebSocket,
     /// The sending channel to send logs to the executor.
     sender: Sender<Message>,
+    /// Optional durable spill when the executor queue is full.
+    spill: Option<crate::executor::overflow::SpillIngress>,
     /// The name of the WebSocket as defined in the configuration.
     name: String,
     /// Manages a list of URI entries and handles the selection and retry logic for connection attempts.
@@ -290,6 +298,7 @@ impl WebSocketClient {
         name: String,
         max_message_size: usize,
         max_frame_size: usize,
+        spill: Option<crate::executor::overflow::SpillIngress>,
     ) -> Self {
         let uri_selector = UriSelector::new(
             configuration.uris.clone(),
@@ -301,6 +310,7 @@ impl WebSocketClient {
         Self {
             configuration,
             sender,
+            spill,
             name,
             uri_selector,
             max_message_size,
@@ -409,9 +419,17 @@ impl WebSocketClient {
                     self.configuration.logbacks_allowed.clone(),
                 );
 
-                if let Err(e) = self.sender.send(log_message) {
+                let log_type = log_message.type_.clone();
+                if crate::executor::overflow::send_or_spill(
+                    &self.sender,
+                    log_message,
+                    &log_type,
+                    &self.spill,
+                )
+                .is_err()
+                {
                     error!(
-                        "Failed to send log generated from WebSocket {} ({uri_name}) to executor: {e}",
+                        "Failed to send log generated from WebSocket {} ({uri_name}) to executor (queue full/disconnected and spill rejected)",
                         self.name
                     );
                 }

--- a/runtime/plaid/src/executor/mod.rs
+++ b/runtime/plaid/src/executor/mod.rs
@@ -1,3 +1,4 @@
+pub mod overflow;
 pub mod thread_pools;
 
 use crate::apis::Api;

--- a/runtime/plaid/src/executor/mod.rs
+++ b/runtime/plaid/src/executor/mod.rs
@@ -825,16 +825,28 @@ impl Executor {
         self: &Self,
         message: Message,
     ) -> Result<(), TrySendError<Message>> {
-        let sender = match self.thread_pools.dedicated_pools.get(&message.type_) {
-            Some(tp) => {
-                // We have a dedicated thread pool for this type: send the log to that channel
-                &tp.sender
-            }
-            None => {
-                // We have no dedicated thread pool for this type: just send to the general one.
-                &self.thread_pools.general_pool.sender
-            }
-        };
+        let sender = self.sender_for_type(&message.type_);
         sender.try_send(message)
+    }
+
+    /// Sender for a log type (dedicated pool if configured, else general).
+    fn sender_for_type(&self, type_: &str) -> &Sender<Message> {
+        match self.thread_pools.dedicated_pools.get(type_) {
+            Some(tp) => &tp.sender,
+            None => &self.thread_pools.general_pool.sender,
+        }
+    }
+
+    /// Approximate occupancy of the execution queue that would receive `type_`, as a
+    /// percentage of capacity (0–100). Used by overflow reload to stop reinjecting before
+    /// the queue hard-fills (avoids claim→restore thrash under load).
+    pub fn queue_occupancy_pct(&self, type_: &str) -> u8 {
+        let sender = self.sender_for_type(type_);
+        let depth = sender.len();
+        let capacity = sender.capacity().unwrap_or(0);
+        if capacity == 0 {
+            return 100;
+        }
+        ((depth.saturating_mul(100)) / capacity).min(100) as u8
     }
 }

--- a/runtime/plaid/src/executor/overflow.rs
+++ b/runtime/plaid/src/executor/overflow.rs
@@ -5,12 +5,33 @@
 //! they survive a queue-full burst or an ungraceful shutdown, and are replayed on a
 //! later boot instead of being lost.
 //!
-//! Multi-replica safety: every message is a single row keyed by `{millis}:{id}`. A
-//! replica claims a message by `delete`-ing its row; the storage layer returns the
-//! previous value only to the caller whose delete actually removed it, so exactly one
-//! replica ever reinjects a given message even when several webhook pods reload
-//! concurrently.
+//! # Durability model
+//!
+//! Messages live in two namespaces:
+//! - **ready** (`queue_overflow`): messages waiting to be reinjected
+//! - **inflight** (`queue_overflow_inflight`): messages claimed by a reloader but not yet
+//!   successfully enqueued (or returned to ready)
+//!
+//! Claim protocol (at-least-once under multi-replica):
+//! 1. Atomically claim a ready row via `delete` (only one replica gets the value).
+//! 2. **Immediately** park the raw bytes in the inflight namespace (lease). This closes the
+//!    crash window for the subsequent decompress / enqueue work: if we die after this
+//!    point, a later reloader reclaims the expired lease and puts the message back to ready.
+//! 3. Enqueue into the executor. On success, delete the inflight row (ack). On queue full
+//!    or disconnect, move the original bytes back to ready under the same key and ack
+//!    inflight.
+//!
+//! Residual crash window: between `delete(ready)` and `insert(inflight)` (one storage
+//! round-trip). Closing that fully requires compare-and-swap / transactions in the storage
+//! trait. Everything after the inflight park is recoverable.
+//!
+//! At-least-once: a crash after a successful `try_send` but before inflight ack can cause
+//! a duplicate reinject once the lease expires. Rules must tolerate reprocessing.
+//!
+//! Multi-replica: delete-returns-value ensures a given ready row is claimed by at most one
+//! reloader at a time. Cross-pod recovery requires a *shared* backend (e.g. DynamoDB).
 
+use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -20,21 +41,37 @@ use crossbeam_channel::TrySendError;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
+use plaid_stl::messages::{LogSource, LogbacksAllowed};
+use serde::{Deserialize, Serialize};
 
 use crate::config::QueueOverflowConfig;
 use crate::executor::{Executor, Message};
 use crate::storage::Storage;
 
-/// Storage namespace holding overflowed execution-queue messages.
+/// Storage namespace holding ready (not yet claimed) overflow messages.
 pub const QUEUE_OVERFLOW_NS: &str = "queue_overflow";
+
+/// Storage namespace for claimed-but-not-acked messages. Leased rows here are reclaimed
+/// back into the ready namespace after `claim_lease_secs`.
+pub const QUEUE_OVERFLOW_INFLIGHT_NS: &str = "queue_overflow_inflight";
 
 /// DynamoDB caps a single item at 400 KB (key + all attributes). We refuse to persist a
 /// compressed message larger than this, leaving headroom for the key and attribute
 /// overhead, and log a distinct error instead of letting the backend reject the write.
 const MAX_ITEM_BYTES: usize = 380 * 1024;
 
+/// Wire format version for stored message envelopes (base64 payloads).
+const STORED_MESSAGE_VERSION: u8 = 1;
+
+/// Even forced persists (shutdown) refuse to grow the store beyond this multiple of
+/// `max_persisted`, so a crash loop cannot fill the backend without bound.
+const FORCED_CAP_MULTIPLIER: u64 = 2;
+
+/// Log a warning when the ready namespace exceeds this many keys (list cost / memory).
+const LIST_SIZE_WARN_THRESHOLD: usize = 10_000;
+
 /// The result of trying to persist a single message to the overflow store.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PersistOutcome {
     /// The message was written to durable storage.
     Persisted,
@@ -49,28 +86,150 @@ pub enum PersistOutcome {
     Failed,
 }
 
+impl PersistOutcome {
+    /// Human-readable label for logs / metrics.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Persisted => "persisted",
+            Self::CapExceeded => "cap_exceeded",
+            Self::NotReplayable => "not_replayable",
+            Self::TooLarge => "too_large",
+            Self::Failed => "failed",
+        }
+    }
+
+    /// Log a non-success outcome at an appropriate level. No-op for `Persisted`.
+    pub fn log_if_not_persisted(self, context: &str, message_id: &str, source: &LogSource) {
+        match self {
+            Self::Persisted => {}
+            Self::CapExceeded => {
+                error!(
+                    "Overflow {context}: cap exceeded, dropping message {message_id} from {source}"
+                );
+            }
+            Self::NotReplayable => {
+                debug!(
+                    "Overflow {context}: message {message_id} from {source} is not replayable (GET-mode); not persisted"
+                );
+            }
+            Self::TooLarge => {
+                // persist path already logs details; keep a one-liner here for callers
+                // that only see the outcome.
+                error!(
+                    "Overflow {context}: message {message_id} from {source} exceeds item size limit"
+                );
+            }
+            Self::Failed => {
+                error!(
+                    "Overflow {context}: failed to persist message {message_id} from {source}"
+                );
+            }
+        }
+    }
+}
+
+/// Compact on-disk envelope: binary fields are base64 so gzip sees compressible text and
+/// we avoid JSON's array-of-bytes blow-up (which caused many false `TooLarge` drops).
+#[derive(Serialize, Deserialize)]
+struct StoredMessageV1 {
+    v: u8,
+    id: String,
+    type_: String,
+    data_b64: String,
+    headers: HashMap<String, String>,
+    query_params: HashMap<String, String>,
+    source: LogSource,
+    logbacks_allowed: LogbacksAllowed,
+}
+
+impl StoredMessageV1 {
+    fn from_message(message: &Message) -> Self {
+        Self {
+            v: STORED_MESSAGE_VERSION,
+            id: message.id.clone(),
+            type_: message.type_.clone(),
+            data_b64: base64::encode(&message.data),
+            headers: message
+                .headers
+                .iter()
+                .map(|(k, v)| (k.clone(), base64::encode(v)))
+                .collect(),
+            query_params: message
+                .query_params
+                .iter()
+                .map(|(k, v)| (k.clone(), base64::encode(v)))
+                .collect(),
+            source: message.source.clone(),
+            logbacks_allowed: message.logbacks_allowed.clone(),
+        }
+    }
+
+    fn into_message(self) -> Result<Message, String> {
+        let data = base64::decode(&self.data_b64).map_err(|e| format!("data base64: {e}"))?;
+        let mut headers = HashMap::new();
+        for (k, v) in self.headers {
+            headers.insert(
+                k,
+                base64::decode(&v).map_err(|e| format!("header base64: {e}"))?,
+            );
+        }
+        let mut query_params = HashMap::new();
+        for (k, v) in self.query_params {
+            query_params.insert(
+                k,
+                base64::decode(&v).map_err(|e| format!("query base64: {e}"))?,
+            );
+        }
+        Ok(Message {
+            id: self.id,
+            type_: self.type_,
+            data,
+            headers,
+            query_params,
+            source: self.source,
+            logbacks_allowed: self.logbacks_allowed,
+            response_sender: None,
+            module: None,
+        })
+    }
+}
+
 /// Durable overflow store for execution-queue messages.
 pub struct OverflowStore {
     storage: Arc<Storage>,
     config: QueueOverflowConfig,
-    /// Approximate number of messages currently persisted by *this* process. Seeded once
-    /// at startup and adjusted as we persist/claim. Per-pod (not global), so with several
-    /// replicas the true count can exceed `max_persisted`; it is a blast-radius bound, not
-    /// exact accounting.
+    /// Approximate number of messages currently held in ready + inflight by *this*
+    /// process's accounting. Seeded at startup and adjusted as we persist / ack.
+    ///
+    /// Per-pod (not a global hard cap): with N replicas the true occupancy can approach
+    /// roughly `N * max_persisted`. It is a blast-radius bound, not exact distributed
+    /// accounting. Uses saturating arithmetic so concurrent claims can never wrap the
+    /// counter into a permanent self-DoS.
     count: AtomicU64,
 }
 
 impl OverflowStore {
-    /// Build a store and seed the approximate count from what is already persisted.
+    /// Build a store and seed the approximate count from ready + inflight namespaces.
     pub async fn new(storage: Arc<Storage>, config: QueueOverflowConfig) -> Self {
-        let count = match storage.list_keys(QUEUE_OVERFLOW_NS, None).await {
+        let ready = match storage.list_keys(QUEUE_OVERFLOW_NS, None).await {
             Ok(keys) => keys.len() as u64,
             Err(e) => {
-                error!("Could not seed overflow count from storage: {e}. Starting from 0.");
+                error!("Could not seed overflow ready count from storage: {e}. Starting that half from 0.");
                 0
             }
         };
-        info!("Overflow store initialized with {count} persisted message(s)");
+        let inflight = match storage.list_keys(QUEUE_OVERFLOW_INFLIGHT_NS, None).await {
+            Ok(keys) => keys.len() as u64,
+            Err(e) => {
+                error!("Could not seed overflow inflight count from storage: {e}. Starting that half from 0.");
+                0
+            }
+        };
+        let count = ready.saturating_add(inflight);
+        info!(
+            "Overflow store initialized with {count} persisted message(s) ({ready} ready, {inflight} inflight); max_persisted={}",
+            config.max_persisted
+        );
         Self {
             storage,
             config,
@@ -78,29 +237,34 @@ impl OverflowStore {
         }
     }
 
+    /// Current approximate persisted count (ready + inflight) for this process.
+    pub fn approximate_count(&self) -> u64 {
+        self.count.load(Ordering::Relaxed)
+    }
+
     /// Persist a single message, subject to the configured cap. Never blocks on the
     /// executor; only touches storage. Used on the hot path (queue-full spill).
     pub async fn persist(&self, message: &Message) -> PersistOutcome {
-        self.persist_inner(message, false).await
+        self.persist_with_key(message, false, None).await
     }
 
-    /// Persist a single message, bypassing the cap. Used at shutdown, where dropping a
-    /// message would be permanent data loss and there is no ongoing load to bound.
+    /// Persist a single message, bypassing the soft cap up to a hard multiple of
+    /// `max_persisted`. Used at shutdown / repersist, where dropping would be permanent
+    /// data loss — but still refuse unbounded growth across crash loops.
     pub async fn persist_forced(&self, message: &Message) -> PersistOutcome {
-        self.persist_inner(message, true).await
-    }
-
-    async fn persist_inner(&self, message: &Message, bypass_cap: bool) -> PersistOutcome {
-        self.persist_with_key(message, bypass_cap, None).await
+        self.persist_with_key(message, true, None).await
     }
 
     /// Persist `message`. If `existing_key` is given (a message being put back after a
     /// failed reinject), reuse it so the original creation time, and therefore the age
     /// used by the reaper, is preserved. Otherwise mint a fresh timestamped key.
+    ///
+    /// When `existing_key` is set we do **not** bump the count: the message was already
+    /// accounted for (claimed into inflight without decrementing).
     async fn persist_with_key(
         &self,
         message: &Message,
-        bypass_cap: bool,
+        bypass_soft_cap: bool,
         existing_key: Option<String>,
     ) -> PersistOutcome {
         // GET-mode messages block an HTTP client on a response channel that cannot be
@@ -109,47 +273,57 @@ impl OverflowStore {
             return PersistOutcome::NotReplayable;
         }
 
-        if !bypass_cap && self.count.load(Ordering::Relaxed) >= self.config.max_persisted {
+        let count = self.count.load(Ordering::Relaxed);
+        if bypass_soft_cap {
+            let hard = self
+                .config
+                .max_persisted
+                .saturating_mul(FORCED_CAP_MULTIPLIER);
+            if count >= hard {
+                error!(
+                    "Overflow hard cap ({hard}) reached during forced persist; dropping message {} from {}",
+                    message.id, message.source
+                );
+                return PersistOutcome::CapExceeded;
+            }
+        } else if count >= self.config.max_persisted {
             return PersistOutcome::CapExceeded;
         }
 
-        let serialized = match serde_json::to_vec(message) {
+        let encoded = match encode_message(message) {
             Ok(bytes) => bytes,
             Err(e) => {
                 error!(
-                    "Failed to serialize overflow message {} from {}: {e}",
+                    "Failed to encode overflow message {} from {}: {e}",
                     message.id, message.source
                 );
                 return PersistOutcome::Failed;
             }
         };
 
-        let compressed = match compress(&serialized) {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                error!("Failed to compress overflow message {}: {e}", message.id);
-                return PersistOutcome::Failed;
-            }
-        };
-
-        if compressed.len() > MAX_ITEM_BYTES {
+        if encoded.len() > MAX_ITEM_BYTES {
             error!(
                 "Overflow message {} from {} is {} bytes compressed, over the {MAX_ITEM_BYTES} byte item limit; dropping to avoid a storage rejection",
                 message.id,
                 message.source,
-                compressed.len()
+                encoded.len()
             );
             return PersistOutcome::TooLarge;
         }
 
+        let is_restore = existing_key.is_some();
         let key = existing_key.unwrap_or_else(|| overflow_key(now_millis(), &message.id));
         match self
             .storage
-            .insert(QUEUE_OVERFLOW_NS.to_string(), key, compressed)
+            .insert(QUEUE_OVERFLOW_NS.to_string(), key, encoded)
             .await
         {
-            Ok(_) => {
-                self.count.fetch_add(1, Ordering::Relaxed);
+            Ok(previous) => {
+                // Only count a net-new row. Restores and overwrites of an existing key
+                // must not inflate the approximate counter.
+                if !is_restore && previous.is_none() {
+                    self.count.fetch_add(1, Ordering::Relaxed);
+                }
                 PersistOutcome::Persisted
             }
             Err(e) => {
@@ -162,12 +336,149 @@ impl OverflowStore {
         }
     }
 
+    /// Drop ready messages older than `max_message_age_secs` without reinjecting them.
+    /// Safe to run while the executor queue is full (unlike claim/reinject).
+    ///
+    /// Returns the number of messages reaped.
+    pub async fn reap_expired(&self) -> usize {
+        let keys = match self.storage.list_keys(QUEUE_OVERFLOW_NS, None).await {
+            Ok(keys) => keys,
+            Err(e) => {
+                error!("Could not list overflow messages to reap: {e}");
+                return 0;
+            }
+        };
+
+        if keys.is_empty() {
+            return 0;
+        }
+
+        let now = now_secs();
+        let mut reaped = 0usize;
+
+        for key in keys {
+            let Some(created) = millis_from_key(&key) else {
+                // Malformed keys never age out via the normal path; delete them so they
+                // cannot pin the namespace forever.
+                warn!("Reaping overflow message with unparseable key {key}");
+                match self.storage.delete(QUEUE_OVERFLOW_NS, &key).await {
+                    Ok(Some(_)) => {
+                        self.saturating_dec();
+                        reaped += 1;
+                    }
+                    Ok(None) => {}
+                    Err(e) => error!("Could not reap malformed overflow key {key}: {e}"),
+                }
+                continue;
+            };
+            let age_secs = now.saturating_sub(created / 1000);
+            if age_secs <= self.config.max_message_age_secs {
+                continue;
+            }
+            match self.storage.delete(QUEUE_OVERFLOW_NS, &key).await {
+                Ok(Some(_)) => {
+                    warn!("Reaped overflow message {key}: age {age_secs}s exceeds limit");
+                    self.saturating_dec();
+                    reaped += 1;
+                }
+                Ok(None) => {}
+                Err(e) => error!("Could not reap overflow message {key}: {e}"),
+            }
+        }
+
+        if reaped > 0 {
+            info!("Reaped {reaped} expired overflow message(s)");
+        }
+        reaped
+    }
+
+    /// Move expired inflight leases back to the ready namespace so they can be claimed
+    /// again after a crash mid-reload. Returns how many rows were reclaimed.
+    pub async fn reclaim_stale_inflight(&self) -> usize {
+        let keys = match self
+            .storage
+            .list_keys(QUEUE_OVERFLOW_INFLIGHT_NS, None)
+            .await
+        {
+            Ok(keys) => keys,
+            Err(e) => {
+                error!("Could not list inflight overflow messages: {e}");
+                return 0;
+            }
+        };
+
+        if keys.is_empty() {
+            return 0;
+        }
+
+        let now = now_secs();
+        let lease = self.config.claim_lease_secs;
+        let mut reclaimed = 0usize;
+
+        for key in keys {
+            let value = match self.storage.get(QUEUE_OVERFLOW_INFLIGHT_NS, &key).await {
+                Ok(Some(v)) => v,
+                Ok(None) => continue,
+                Err(e) => {
+                    error!("Could not read inflight overflow {key}: {e}");
+                    continue;
+                }
+            };
+            let Some((claimed_at, body)) = unwrap_inflight(&value) else {
+                warn!("Dropping corrupt inflight overflow record {key}");
+                let _ = self.storage.delete(QUEUE_OVERFLOW_INFLIGHT_NS, &key).await;
+                self.saturating_dec();
+                continue;
+            };
+            if now.saturating_sub(claimed_at) < lease {
+                continue; // still within lease; another reloader may be working it
+            }
+
+            // Claim the inflight row so only one reclaimer restores it.
+            match self.storage.delete(QUEUE_OVERFLOW_INFLIGHT_NS, &key).await {
+                Ok(Some(_)) => {}
+                Ok(None) => continue, // lost the race
+                Err(e) => {
+                    error!("Could not claim stale inflight overflow {key}: {e}");
+                    continue;
+                }
+            }
+
+            // Put original ready bytes back under the original key (preserves age).
+            match self
+                .storage
+                .insert(QUEUE_OVERFLOW_NS.to_string(), key.clone(), body)
+                .await
+            {
+                Ok(_) => {
+                    info!("Reclaimed stale inflight overflow message {key} back to ready");
+                    reclaimed += 1;
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to restore reclaimed inflight overflow {key} to ready: {e}; message may be lost"
+                    );
+                    self.saturating_dec();
+                }
+            }
+        }
+
+        reclaimed
+    }
+
     /// Claim and reinject up to `reload_batch_size` overflowed messages into the executor.
     ///
     /// Returns the number of messages successfully reinjected. Stops early (leaving the
     /// rest for a later poll) as soon as the executor queue is full, so a wedged executor
-    /// does not spin this into a delete/reinsert loop. Over-age messages are dropped.
+    /// does not spin this into a claim loop. Over-age messages are dropped.
+    ///
+    /// Note: this lists keys in the ready namespace each call. `reload_batch_size` bounds
+    /// how many are *claimed*, not how many keys are loaded into memory. Prefer keeping
+    /// `max_persisted` reasonable for the storage backend.
     pub async fn reload_batch(&self, executor: &Executor) -> usize {
+        // Recover anything left mid-claim by a crashed peer / prior boot first.
+        let _ = self.reclaim_stale_inflight().await;
+
         let keys = match self.storage.list_keys(QUEUE_OVERFLOW_NS, None).await {
             Ok(keys) => keys,
             Err(e) => {
@@ -180,17 +491,24 @@ impl OverflowStore {
             return 0;
         }
 
+        if keys.len() > LIST_SIZE_WARN_THRESHOLD {
+            warn!(
+                "Overflow ready namespace has {} keys; full list_keys each reload poll is expensive. Consider lowering max_persisted or draining backlog.",
+                keys.len()
+            );
+        }
+
         // Keys are `{zero-padded-millis}:{id}`, so a lexical sort is oldest-first.
         let mut keys = keys;
         keys.sort();
 
         let now = now_secs();
         let mut reinjected = 0usize;
+        let batch_limit = self.config.reload_batch_size;
 
-        for key in keys.into_iter().take(self.config.reload_batch_size) {
-            // Claim the message: whoever's delete returns the value owns it. A concurrent
-            // replica that already claimed it gets None here and we simply skip.
-            let value = match self.storage.delete(QUEUE_OVERFLOW_NS, &key).await {
+        for key in keys.into_iter().take(batch_limit) {
+            // Step 1: claim ready row. Only one replica receives Some(value).
+            let body = match self.storage.delete(QUEUE_OVERFLOW_NS, &key).await {
                 Ok(Some(value)) => value,
                 Ok(None) => continue,
                 Err(e) => {
@@ -198,47 +516,79 @@ impl OverflowStore {
                     continue;
                 }
             };
-            // We removed a row that we had counted; reflect that regardless of what
-            // happens next (reinjected, reaped, or dropped as corrupt).
-            self.count.fetch_sub(1, Ordering::Relaxed);
 
-            // Drop messages that have outlived their max age.
+            // Step 2: park in inflight IMMEDIATELY so a crash from here on is recoverable.
+            let inflight_blob = wrap_inflight(now, &body);
+            if let Err(e) = self
+                .storage
+                .insert(
+                    QUEUE_OVERFLOW_INFLIGHT_NS.to_string(),
+                    key.clone(),
+                    inflight_blob,
+                )
+                .await
+            {
+                error!(
+                    "Could not park claimed overflow {key} in inflight: {e}; restoring to ready"
+                );
+                if let Err(e2) = self
+                    .storage
+                    .insert(QUEUE_OVERFLOW_NS.to_string(), key.clone(), body)
+                    .await
+                {
+                    error!(
+                        "Failed to restore overflow {key} after inflight park failure: {e2}; message may be lost"
+                    );
+                    self.saturating_dec();
+                }
+                continue;
+            }
+
+            // Drop messages that have outlived their max age (already claimed; just ack).
             if let Some(created) = millis_from_key(&key) {
                 let age_secs = now.saturating_sub(created / 1000);
                 if age_secs > self.config.max_message_age_secs {
                     warn!("Dropping overflow message {key}: age {age_secs}s exceeds limit");
+                    self.ack_inflight(&key).await;
+                    self.saturating_dec();
                     continue;
                 }
+            } else {
+                // Unparseable key: drop rather than immortalize.
+                warn!("Dropping overflow message with unparseable key {key}");
+                self.ack_inflight(&key).await;
+                self.saturating_dec();
+                continue;
             }
 
-            let decompressed = match decompress(&value) {
-                Ok(bytes) => bytes,
-                Err(e) => {
-                    error!("Could not decompress overflow message {key}: {e}; dropping");
-                    continue;
-                }
-            };
-
-            let message = match serde_json::from_slice::<Message>(&decompressed) {
+            let message = match decode_message(&body) {
                 Ok(message) => message,
                 Err(e) => {
-                    error!("Could not deserialize overflow message {key}: {e}; dropping");
+                    error!("Could not decode overflow message {key}: {e}; dropping");
+                    self.ack_inflight(&key).await;
+                    self.saturating_dec();
                     continue;
                 }
             };
 
             match executor.execute_webhook_message(message) {
-                Ok(()) => reinjected += 1,
+                Ok(()) => {
+                    self.ack_inflight(&key).await;
+                    self.saturating_dec();
+                    reinjected += 1;
+                }
                 Err(TrySendError::Full(message)) => {
-                    // No capacity right now. Put it back under its ORIGINAL key so its true
-                    // age is preserved (otherwise a perpetually-full queue would keep
-                    // refreshing timestamps and the age reaper would never fire), then stop:
-                    // continuing would just delete/reinsert the rest against a full queue.
-                    self.repersist(message, key).await;
+                    // No capacity. Put original bytes back under the ORIGINAL key so age
+                    // is preserved, then stop: continuing would thrash against a full queue.
+                    self.return_to_ready(&key, &body, &message).await;
                     break;
                 }
-                Err(TrySendError::Disconnected(_)) => {
-                    error!("Executor channel disconnected while reloading overflow {key}");
+                Err(TrySendError::Disconnected(message)) => {
+                    // Executor is going away. Must NOT drop the claimed message.
+                    error!(
+                        "Executor channel disconnected while reloading overflow {key}; returning to ready"
+                    );
+                    self.return_to_ready(&key, &body, &message).await;
                     break;
                 }
             }
@@ -250,20 +600,57 @@ impl OverflowStore {
         reinjected
     }
 
-    /// Re-persist a message we claimed but could not reinject (queue was full), reusing its
-    /// original storage key so the reaper still sees its true age. Bypasses the cap: we are
-    /// putting back something we just removed, not adding new load, and dropping it would be
-    /// the data loss this feature exists to prevent.
-    async fn repersist(&self, message: Message, original_key: String) {
-        if self
-            .persist_with_key(&message, true, Some(original_key))
+    /// Delete the inflight lease for `key` (ack after successful enqueue or drop).
+    async fn ack_inflight(&self, key: &str) {
+        if let Err(e) = self.storage.delete(QUEUE_OVERFLOW_INFLIGHT_NS, key).await {
+            // Worst case: lease expires and we reinject a duplicate (at-least-once).
+            error!("Could not ack inflight overflow {key}: {e}; may reinject after lease expiry");
+        }
+    }
+
+    /// After a failed reinject, restore the original ready bytes and drop the inflight
+    /// lease. Falls back to re-encoding `message` if the raw body restore fails.
+    async fn return_to_ready(&self, key: &str, body: &[u8], message: &Message) {
+        match self
+            .storage
+            .insert(QUEUE_OVERFLOW_NS.to_string(), key.to_string(), body.to_vec())
             .await
-            != PersistOutcome::Persisted
         {
-            error!(
-                "Failed to re-persist unreinjected overflow message {}; it may be lost",
-                message.id
-            );
+            Ok(_) => {
+                self.ack_inflight(key).await;
+            }
+            Err(e) => {
+                error!(
+                    "Failed to restore overflow {key} to ready with original bytes: {e}; trying re-encode"
+                );
+                self.ack_inflight(key).await;
+                // Re-encode path bumps accounting carefully via persist_with_key restore.
+                if self
+                    .persist_with_key(message, true, Some(key.to_string()))
+                    .await
+                    != PersistOutcome::Persisted
+                {
+                    error!(
+                        "Failed to re-persist unreinjected overflow message {}; it may be lost",
+                        message.id
+                    );
+                    self.saturating_dec();
+                }
+            }
+        }
+    }
+
+    fn saturating_dec(&self) {
+        let mut cur = self.count.load(Ordering::Relaxed);
+        loop {
+            let next = cur.saturating_sub(1);
+            match self
+                .count
+                .compare_exchange_weak(cur, next, Ordering::Relaxed, Ordering::Relaxed)
+            {
+                Ok(_) => break,
+                Err(actual) => cur = actual,
+            }
         }
     }
 }
@@ -277,6 +664,48 @@ fn overflow_key(millis: u128, id: &str) -> String {
 /// Extract the creation-time millis from an overflow key, if it parses.
 fn millis_from_key(key: &str) -> Option<u64> {
     key.split(':').next()?.parse::<u64>().ok()
+}
+
+/// Encode a message to the on-disk format: gzip(json StoredMessageV1).
+fn encode_message(message: &Message) -> Result<Vec<u8>, String> {
+    let envelope = StoredMessageV1::from_message(message);
+    let serialized =
+        serde_json::to_vec(&envelope).map_err(|e| format!("serialize envelope: {e}"))?;
+    compress(&serialized).map_err(|e| format!("compress: {e}"))
+}
+
+/// Decode on-disk bytes. Accepts the v1 base64 envelope and falls back to legacy
+/// `serde_json::Message` payloads so an in-place upgrade does not strand rows.
+fn decode_message(bytes: &[u8]) -> Result<Message, String> {
+    let decompressed = decompress(bytes).map_err(|e| format!("decompress: {e}"))?;
+
+    if let Ok(env) = serde_json::from_slice::<StoredMessageV1>(&decompressed) {
+        if env.v == STORED_MESSAGE_VERSION {
+            return env.into_message();
+        }
+    }
+
+    // Legacy: direct Message JSON (array-of-bytes data field).
+    serde_json::from_slice::<Message>(&decompressed)
+        .map_err(|e| format!("deserialize legacy or v1 message: {e}"))
+}
+
+/// Inflight blob: 8-byte big-endian claimed_at_secs || original ready body.
+fn wrap_inflight(claimed_at_secs: u64, body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(8 + body.len());
+    out.extend_from_slice(&claimed_at_secs.to_be_bytes());
+    out.extend_from_slice(body);
+    out
+}
+
+fn unwrap_inflight(blob: &[u8]) -> Option<(u64, Vec<u8>)> {
+    if blob.len() < 8 {
+        return None;
+    }
+    let mut ts = [0u8; 8];
+    ts.copy_from_slice(&blob[..8]);
+    let claimed_at = u64::from_be_bytes(ts);
+    Some((claimed_at, blob[8..].to_vec()))
 }
 
 fn compress(data: &[u8]) -> std::io::Result<Vec<u8>> {
@@ -306,6 +735,42 @@ fn now_secs() -> u64 {
         .unwrap_or(0)
 }
 
+/// Offer a message that could not be enqueued to the spill channel (non-blocking).
+///
+/// Returns `true` if the message was accepted onto the spill path (persistence is async).
+/// Returns `false` if overflow is disabled or the spill backlog itself is saturated /
+/// closed — the message is then dropped and the caller should treat it as lost.
+pub fn offer_to_spill(
+    message: Message,
+    log_type: &str,
+    spill_sender: &Option<tokio::sync::mpsc::Sender<Message>>,
+) -> bool {
+    match spill_sender {
+        Some(tx) => match tx.try_send(message) {
+            Ok(()) => {
+                debug!("Queue Full! [{log_type}] message routed to durable overflow");
+                true
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                error!(
+                    "Queue Full AND overflow spill backlog full! [{log_type}] log dropped!"
+                );
+                false
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                error!(
+                    "Queue Full and overflow spill channel closed! [{log_type}] log dropped!"
+                );
+                false
+            }
+        },
+        None => {
+            error!("Queue Full! [{log_type}] log dropped!");
+            false
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -322,7 +787,6 @@ mod tests {
 
     #[test]
     fn key_padding_survives_magnitude_change() {
-        // A 13-digit and a 14-digit millis value must still sort correctly.
         let smaller = overflow_key(9_999_999_999_999, "a");
         let larger = overflow_key(10_000_000_000_000, "b");
         assert!(smaller < larger);
@@ -344,22 +808,66 @@ mod tests {
 
     #[test]
     fn millis_parses_even_when_id_contains_colon() {
-        // UUIDs don't contain ':', but be defensive: only the first segment is the time.
         let key = overflow_key(1234, "id:with:colons");
         assert_eq!(millis_from_key(&key), Some(1234));
     }
 
+    #[test]
+    fn inflight_wrap_roundtrip() {
+        let body = b"compressed-payload".to_vec();
+        let wrapped = wrap_inflight(1_700_000_000, &body);
+        let (ts, got) = unwrap_inflight(&wrapped).unwrap();
+        assert_eq!(ts, 1_700_000_000);
+        assert_eq!(got, body);
+    }
+
+    #[test]
+    fn envelope_roundtrip_preserves_binary_data() {
+        let message = test_message_with_data(vec![0, 1, 2, 255, 128]);
+        let encoded = encode_message(&message).unwrap();
+        let restored = decode_message(&encoded).unwrap();
+        assert_eq!(restored.id, message.id);
+        assert_eq!(restored.data, message.data);
+        assert_eq!(restored.type_, message.type_);
+    }
+
+    #[test]
+    fn envelope_is_much_smaller_than_legacy_json_array_for_binary() {
+        // 50 KiB of binary: legacy JSON array-of-bytes is enormous; v1+gzip should fit
+        // comfortably under the DynamoDB item guard.
+        let message = test_message_with_data(vec![0xABu8; 50 * 1024]);
+        let encoded = encode_message(&message).unwrap();
+        assert!(
+            encoded.len() < MAX_ITEM_BYTES,
+            "encoded {} bytes should be under limit",
+            encoded.len()
+        );
+
+        // Legacy path for comparison: raw Message JSON then gzip.
+        let legacy = compress(&serde_json::to_vec(&message).unwrap()).unwrap();
+        assert!(
+            encoded.len() < legacy.len(),
+            "v1 envelope ({}) should beat legacy json-array ({})",
+            encoded.len(),
+            legacy.len()
+        );
+    }
+
     fn test_message() -> Message {
+        test_message_with_data(b"hello world".to_vec())
+    }
+
+    fn test_message_with_data(data: Vec<u8>) -> Message {
         Message::new(
             "test_type".to_string(),
-            b"hello world".to_vec(),
+            data,
             LogSource::WebhookPost("test".to_string()),
             LogbacksAllowed::Limited(0),
         )
     }
 
     #[tokio::test]
-    async fn persist_then_reload_roundtrips_message() {
+    async fn persist_then_decode_roundtrips_message() {
         let storage = Arc::new(Storage::new_in_memory());
         let store = OverflowStore::new(storage.clone(), QueueOverflowConfig::default()).await;
         let message = test_message();
@@ -367,8 +875,6 @@ mod tests {
 
         assert_eq!(store.persist(&message).await, PersistOutcome::Persisted);
 
-        // The message is now in storage under a single key; claim it back and verify it
-        // deserializes to the same message.
         let keys = storage.list_keys(QUEUE_OVERFLOW_NS, None).await.unwrap();
         assert_eq!(keys.len(), 1);
         let value = storage
@@ -376,7 +882,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        let restored: Message = serde_json::from_slice(&decompress(&value).unwrap()).unwrap();
+        let restored = decode_message(&value).unwrap();
         assert_eq!(restored.id, id);
         assert_eq!(restored.data, b"hello world");
     }
@@ -389,7 +895,10 @@ mod tests {
         let mut message = test_message();
         message.response_sender = Some(tx);
 
-        assert_eq!(store.persist(&message).await, PersistOutcome::NotReplayable);
+        assert_eq!(
+            store.persist(&message).await,
+            PersistOutcome::NotReplayable
+        );
         assert!(storage
             .list_keys(QUEUE_OVERFLOW_NS, None)
             .await
@@ -398,7 +907,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cap_is_enforced_then_bypassed_by_forced() {
+    async fn cap_is_enforced_then_bypassed_by_forced_until_hard_cap() {
         let storage = Arc::new(Storage::new_in_memory());
         let cfg = QueueOverflowConfig {
             max_persisted: 1,
@@ -407,12 +916,215 @@ mod tests {
         let store = OverflowStore::new(storage.clone(), cfg).await;
 
         assert_eq!(store.persist(&test_message()).await, PersistOutcome::Persisted);
-        // At cap now: a normal persist is rejected...
-        assert_eq!(store.persist(&test_message()).await, PersistOutcome::CapExceeded);
-        // ...but a forced persist (shutdown / repersist) still goes through.
+        assert_eq!(
+            store.persist(&test_message()).await,
+            PersistOutcome::CapExceeded
+        );
+        // Forced bypasses soft cap...
         assert_eq!(
             store.persist_forced(&test_message()).await,
             PersistOutcome::Persisted
         );
+        // ...but hard cap (2x) still binds: count is 2, hard is 2, so next forced fails.
+        assert_eq!(
+            store.persist_forced(&test_message()).await,
+            PersistOutcome::CapExceeded
+        );
+    }
+
+    #[tokio::test]
+    async fn saturating_dec_never_wraps_count() {
+        let storage = Arc::new(Storage::new_in_memory());
+        let store = OverflowStore::new(storage, QueueOverflowConfig::default()).await;
+        assert_eq!(store.approximate_count(), 0);
+        // Simulate claiming messages we never counted (peer-written rows).
+        store.saturating_dec();
+        store.saturating_dec();
+        assert_eq!(store.approximate_count(), 0);
+        // Cap must still allow persists after underflow attempts.
+        assert_eq!(store.persist(&test_message()).await, PersistOutcome::Persisted);
+    }
+
+    #[tokio::test]
+    async fn claim_parks_inflight_then_ack_clears_it() {
+        let storage = Arc::new(Storage::new_in_memory());
+        let store = OverflowStore::new(storage.clone(), QueueOverflowConfig::default()).await;
+        assert_eq!(store.persist(&test_message()).await, PersistOutcome::Persisted);
+
+        let keys = storage.list_keys(QUEUE_OVERFLOW_NS, None).await.unwrap();
+        let key = keys[0].clone();
+        let body = storage
+            .delete(QUEUE_OVERFLOW_NS, &key)
+            .await
+            .unwrap()
+            .unwrap();
+        storage
+            .insert(
+                QUEUE_OVERFLOW_INFLIGHT_NS.to_string(),
+                key.clone(),
+                wrap_inflight(now_secs(), &body),
+            )
+            .await
+            .unwrap();
+
+        assert!(storage
+            .list_keys(QUEUE_OVERFLOW_NS, None)
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            storage
+                .list_keys(QUEUE_OVERFLOW_INFLIGHT_NS, None)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        store.ack_inflight(&key).await;
+        assert!(storage
+            .list_keys(QUEUE_OVERFLOW_INFLIGHT_NS, None)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn stale_inflight_is_reclaimed_to_ready() {
+        let storage = Arc::new(Storage::new_in_memory());
+        let cfg = QueueOverflowConfig {
+            claim_lease_secs: 1,
+            ..QueueOverflowConfig::default()
+        };
+        let store = OverflowStore::new(storage.clone(), cfg).await;
+        let message = test_message();
+        let id = message.id.clone();
+        assert_eq!(store.persist(&message).await, PersistOutcome::Persisted);
+
+        let keys = storage.list_keys(QUEUE_OVERFLOW_NS, None).await.unwrap();
+        let key = keys[0].clone();
+        let body = storage
+            .delete(QUEUE_OVERFLOW_NS, &key)
+            .await
+            .unwrap()
+            .unwrap();
+        // Claimed far in the past → lease expired.
+        storage
+            .insert(
+                QUEUE_OVERFLOW_INFLIGHT_NS.to_string(),
+                key.clone(),
+                wrap_inflight(1, &body),
+            )
+            .await
+            .unwrap();
+
+        let n = store.reclaim_stale_inflight().await;
+        assert_eq!(n, 1);
+        assert!(storage
+            .list_keys(QUEUE_OVERFLOW_INFLIGHT_NS, None)
+            .await
+            .unwrap()
+            .is_empty());
+        let ready = storage.list_keys(QUEUE_OVERFLOW_NS, None).await.unwrap();
+        assert_eq!(ready.len(), 1);
+        let restored = decode_message(
+            &storage
+                .get(QUEUE_OVERFLOW_NS, &ready[0])
+                .await
+                .unwrap()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(restored.id, id);
+    }
+
+    #[tokio::test]
+    async fn fresh_inflight_is_not_reclaimed() {
+        let storage = Arc::new(Storage::new_in_memory());
+        let cfg = QueueOverflowConfig {
+            claim_lease_secs: 3600,
+            ..QueueOverflowConfig::default()
+        };
+        let store = OverflowStore::new(storage.clone(), cfg).await;
+        assert_eq!(store.persist(&test_message()).await, PersistOutcome::Persisted);
+
+        let keys = storage.list_keys(QUEUE_OVERFLOW_NS, None).await.unwrap();
+        let key = keys[0].clone();
+        let body = storage
+            .delete(QUEUE_OVERFLOW_NS, &key)
+            .await
+            .unwrap()
+            .unwrap();
+        storage
+            .insert(
+                QUEUE_OVERFLOW_INFLIGHT_NS.to_string(),
+                key,
+                wrap_inflight(now_secs(), &body),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(store.reclaim_stale_inflight().await, 0);
+        assert_eq!(
+            storage
+                .list_keys(QUEUE_OVERFLOW_INFLIGHT_NS, None)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn reap_expired_removes_old_ready_messages() {
+        let storage = Arc::new(Storage::new_in_memory());
+        let cfg = QueueOverflowConfig {
+            max_message_age_secs: 1,
+            ..QueueOverflowConfig::default()
+        };
+        let store = OverflowStore::new(storage.clone(), cfg).await;
+
+        // Insert directly with an ancient key so age check fires.
+        let message = test_message();
+        let encoded = encode_message(&message).unwrap();
+        let ancient_key = overflow_key(1_000, &message.id); // year ~1970
+        storage
+            .insert(QUEUE_OVERFLOW_NS.to_string(), ancient_key, encoded)
+            .await
+            .unwrap();
+        // Manually bump count to match (persist path would have).
+        store.count.store(1, Ordering::Relaxed);
+
+        let reaped = store.reap_expired().await;
+        assert_eq!(reaped, 1);
+        assert!(storage
+            .list_keys(QUEUE_OVERFLOW_NS, None)
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(store.approximate_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn legacy_json_message_still_decodes() {
+        let message = test_message();
+        let legacy = compress(&serde_json::to_vec(&message).unwrap()).unwrap();
+        let restored = decode_message(&legacy).unwrap();
+        assert_eq!(restored.id, message.id);
+        assert_eq!(restored.data, message.data);
+    }
+
+    #[tokio::test]
+    async fn concurrent_delete_claim_only_one_wins() {
+        let storage = Arc::new(Storage::new_in_memory());
+        let store = OverflowStore::new(storage.clone(), QueueOverflowConfig::default()).await;
+        assert_eq!(store.persist(&test_message()).await, PersistOutcome::Persisted);
+        let keys = storage.list_keys(QUEUE_OVERFLOW_NS, None).await.unwrap();
+        let key = keys[0].clone();
+
+        let a = storage.delete(QUEUE_OVERFLOW_NS, &key).await.unwrap();
+        let b = storage.delete(QUEUE_OVERFLOW_NS, &key).await.unwrap();
+        assert!(a.is_some());
+        assert!(b.is_none());
     }
 }

--- a/runtime/plaid/src/executor/overflow.rs
+++ b/runtime/plaid/src/executor/overflow.rs
@@ -1,0 +1,418 @@
+//! Durable overflow for the execution queue.
+//!
+//! When enabled (via `[executor.queue_overflow]`), messages that would otherwise be
+//! dropped are serialized, compressed, and written to a dedicated storage namespace so
+//! they survive a queue-full burst or an ungraceful shutdown, and are replayed on a
+//! later boot instead of being lost.
+//!
+//! Multi-replica safety: every message is a single row keyed by `{millis}:{id}`. A
+//! replica claims a message by `delete`-ing its row; the storage layer returns the
+//! previous value only to the caller whose delete actually removed it, so exactly one
+//! replica ever reinjects a given message even when several webhook pods reload
+//! concurrently.
+
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crossbeam_channel::TrySendError;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+
+use crate::config::QueueOverflowConfig;
+use crate::executor::{Executor, Message};
+use crate::storage::Storage;
+
+/// Storage namespace holding overflowed execution-queue messages.
+pub const QUEUE_OVERFLOW_NS: &str = "queue_overflow";
+
+/// DynamoDB caps a single item at 400 KB (key + all attributes). We refuse to persist a
+/// compressed message larger than this, leaving headroom for the key and attribute
+/// overhead, and log a distinct error instead of letting the backend reject the write.
+const MAX_ITEM_BYTES: usize = 380 * 1024;
+
+/// The result of trying to persist a single message to the overflow store.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PersistOutcome {
+    /// The message was written to durable storage.
+    Persisted,
+    /// The overflow store already holds `max_persisted` messages; caller should drop.
+    CapExceeded,
+    /// The message is a GET-mode request (carries a response channel) and cannot be
+    /// meaningfully replayed, so it is not persisted.
+    NotReplayable,
+    /// The compressed message exceeds the per-item storage limit.
+    TooLarge,
+    /// Serialization or the storage write failed.
+    Failed,
+}
+
+/// Durable overflow store for execution-queue messages.
+pub struct OverflowStore {
+    storage: Arc<Storage>,
+    config: QueueOverflowConfig,
+    /// Approximate number of messages currently persisted by *this* process. Seeded once
+    /// at startup and adjusted as we persist/claim. Per-pod (not global), so with several
+    /// replicas the true count can exceed `max_persisted`; it is a blast-radius bound, not
+    /// exact accounting.
+    count: AtomicU64,
+}
+
+impl OverflowStore {
+    /// Build a store and seed the approximate count from what is already persisted.
+    pub async fn new(storage: Arc<Storage>, config: QueueOverflowConfig) -> Self {
+        let count = match storage.list_keys(QUEUE_OVERFLOW_NS, None).await {
+            Ok(keys) => keys.len() as u64,
+            Err(e) => {
+                error!("Could not seed overflow count from storage: {e}. Starting from 0.");
+                0
+            }
+        };
+        info!("Overflow store initialized with {count} persisted message(s)");
+        Self {
+            storage,
+            config,
+            count: AtomicU64::new(count),
+        }
+    }
+
+    /// Persist a single message, subject to the configured cap. Never blocks on the
+    /// executor; only touches storage. Used on the hot path (queue-full spill).
+    pub async fn persist(&self, message: &Message) -> PersistOutcome {
+        self.persist_inner(message, false).await
+    }
+
+    /// Persist a single message, bypassing the cap. Used at shutdown, where dropping a
+    /// message would be permanent data loss and there is no ongoing load to bound.
+    pub async fn persist_forced(&self, message: &Message) -> PersistOutcome {
+        self.persist_inner(message, true).await
+    }
+
+    async fn persist_inner(&self, message: &Message, bypass_cap: bool) -> PersistOutcome {
+        self.persist_with_key(message, bypass_cap, None).await
+    }
+
+    /// Persist `message`. If `existing_key` is given (a message being put back after a
+    /// failed reinject), reuse it so the original creation time, and therefore the age
+    /// used by the reaper, is preserved. Otherwise mint a fresh timestamped key.
+    async fn persist_with_key(
+        &self,
+        message: &Message,
+        bypass_cap: bool,
+        existing_key: Option<String>,
+    ) -> PersistOutcome {
+        // GET-mode messages block an HTTP client on a response channel that cannot be
+        // serialized or reconstructed on reload, so replaying them is pointless.
+        if message.response_sender.is_some() {
+            return PersistOutcome::NotReplayable;
+        }
+
+        if !bypass_cap && self.count.load(Ordering::Relaxed) >= self.config.max_persisted {
+            return PersistOutcome::CapExceeded;
+        }
+
+        let serialized = match serde_json::to_vec(message) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                error!(
+                    "Failed to serialize overflow message {} from {}: {e}",
+                    message.id, message.source
+                );
+                return PersistOutcome::Failed;
+            }
+        };
+
+        let compressed = match compress(&serialized) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                error!("Failed to compress overflow message {}: {e}", message.id);
+                return PersistOutcome::Failed;
+            }
+        };
+
+        if compressed.len() > MAX_ITEM_BYTES {
+            error!(
+                "Overflow message {} from {} is {} bytes compressed, over the {MAX_ITEM_BYTES} byte item limit; dropping to avoid a storage rejection",
+                message.id,
+                message.source,
+                compressed.len()
+            );
+            return PersistOutcome::TooLarge;
+        }
+
+        let key = existing_key.unwrap_or_else(|| overflow_key(now_millis(), &message.id));
+        match self
+            .storage
+            .insert(QUEUE_OVERFLOW_NS.to_string(), key, compressed)
+            .await
+        {
+            Ok(_) => {
+                self.count.fetch_add(1, Ordering::Relaxed);
+                PersistOutcome::Persisted
+            }
+            Err(e) => {
+                error!(
+                    "Storage could not persist overflow message {} from {}: {e}",
+                    message.id, message.source
+                );
+                PersistOutcome::Failed
+            }
+        }
+    }
+
+    /// Claim and reinject up to `reload_batch_size` overflowed messages into the executor.
+    ///
+    /// Returns the number of messages successfully reinjected. Stops early (leaving the
+    /// rest for a later poll) as soon as the executor queue is full, so a wedged executor
+    /// does not spin this into a delete/reinsert loop. Over-age messages are dropped.
+    pub async fn reload_batch(&self, executor: &Executor) -> usize {
+        let keys = match self.storage.list_keys(QUEUE_OVERFLOW_NS, None).await {
+            Ok(keys) => keys,
+            Err(e) => {
+                error!("Could not list overflow messages to reload: {e}");
+                return 0;
+            }
+        };
+
+        if keys.is_empty() {
+            return 0;
+        }
+
+        // Keys are `{zero-padded-millis}:{id}`, so a lexical sort is oldest-first.
+        let mut keys = keys;
+        keys.sort();
+
+        let now = now_secs();
+        let mut reinjected = 0usize;
+
+        for key in keys.into_iter().take(self.config.reload_batch_size) {
+            // Claim the message: whoever's delete returns the value owns it. A concurrent
+            // replica that already claimed it gets None here and we simply skip.
+            let value = match self.storage.delete(QUEUE_OVERFLOW_NS, &key).await {
+                Ok(Some(value)) => value,
+                Ok(None) => continue,
+                Err(e) => {
+                    error!("Could not claim overflow message {key}: {e}");
+                    continue;
+                }
+            };
+            // We removed a row that we had counted; reflect that regardless of what
+            // happens next (reinjected, reaped, or dropped as corrupt).
+            self.count.fetch_sub(1, Ordering::Relaxed);
+
+            // Drop messages that have outlived their max age.
+            if let Some(created) = millis_from_key(&key) {
+                let age_secs = now.saturating_sub(created / 1000);
+                if age_secs > self.config.max_message_age_secs {
+                    warn!("Dropping overflow message {key}: age {age_secs}s exceeds limit");
+                    continue;
+                }
+            }
+
+            let decompressed = match decompress(&value) {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    error!("Could not decompress overflow message {key}: {e}; dropping");
+                    continue;
+                }
+            };
+
+            let message = match serde_json::from_slice::<Message>(&decompressed) {
+                Ok(message) => message,
+                Err(e) => {
+                    error!("Could not deserialize overflow message {key}: {e}; dropping");
+                    continue;
+                }
+            };
+
+            match executor.execute_webhook_message(message) {
+                Ok(()) => reinjected += 1,
+                Err(TrySendError::Full(message)) => {
+                    // No capacity right now. Put it back under its ORIGINAL key so its true
+                    // age is preserved (otherwise a perpetually-full queue would keep
+                    // refreshing timestamps and the age reaper would never fire), then stop:
+                    // continuing would just delete/reinsert the rest against a full queue.
+                    self.repersist(message, key).await;
+                    break;
+                }
+                Err(TrySendError::Disconnected(_)) => {
+                    error!("Executor channel disconnected while reloading overflow {key}");
+                    break;
+                }
+            }
+        }
+
+        if reinjected > 0 {
+            info!("Reinjected {reinjected} overflow message(s) into the executor");
+        }
+        reinjected
+    }
+
+    /// Re-persist a message we claimed but could not reinject (queue was full), reusing its
+    /// original storage key so the reaper still sees its true age. Bypasses the cap: we are
+    /// putting back something we just removed, not adding new load, and dropping it would be
+    /// the data loss this feature exists to prevent.
+    async fn repersist(&self, message: Message, original_key: String) {
+        if self
+            .persist_with_key(&message, true, Some(original_key))
+            .await
+            != PersistOutcome::Persisted
+        {
+            error!(
+                "Failed to re-persist unreinjected overflow message {}; it may be lost",
+                message.id
+            );
+        }
+    }
+}
+
+/// Build the storage key for an overflow message. Millis are zero-padded to 20 digits so
+/// that a lexical (string) sort of keys is also a chronological sort.
+fn overflow_key(millis: u128, id: &str) -> String {
+    format!("{millis:020}:{id}")
+}
+
+/// Extract the creation-time millis from an overflow key, if it parses.
+fn millis_from_key(key: &str) -> Option<u64> {
+    key.split(':').next()?.parse::<u64>().ok()
+}
+
+fn compress(data: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(data)?;
+    encoder.finish()
+}
+
+fn decompress(data: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut decoder = GzDecoder::new(data);
+    let mut out = Vec::new();
+    decoder.read_to_end(&mut out)?;
+    Ok(out)
+}
+
+fn now_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use plaid_stl::messages::{LogSource, LogbacksAllowed};
+
+    #[test]
+    fn key_roundtrips_and_sorts_chronologically() {
+        let early = overflow_key(1000, "aaa");
+        let late = overflow_key(2000, "bbb");
+        assert!(early < late, "older key must sort before newer key");
+        assert_eq!(millis_from_key(&early), Some(1000));
+        assert_eq!(millis_from_key(&late), Some(2000));
+    }
+
+    #[test]
+    fn key_padding_survives_magnitude_change() {
+        // A 13-digit and a 14-digit millis value must still sort correctly.
+        let smaller = overflow_key(9_999_999_999_999, "a");
+        let larger = overflow_key(10_000_000_000_000, "b");
+        assert!(smaller < larger);
+    }
+
+    #[test]
+    fn millis_from_malformed_key_is_none() {
+        assert_eq!(millis_from_key("not-a-number:id"), None);
+        assert_eq!(millis_from_key(""), None);
+    }
+
+    #[test]
+    fn compress_decompress_roundtrip() {
+        let original = b"the quick brown fox jumps over the lazy dog".repeat(100);
+        let compressed = compress(&original).unwrap();
+        let restored = decompress(&compressed).unwrap();
+        assert_eq!(original, restored);
+    }
+
+    #[test]
+    fn millis_parses_even_when_id_contains_colon() {
+        // UUIDs don't contain ':', but be defensive: only the first segment is the time.
+        let key = overflow_key(1234, "id:with:colons");
+        assert_eq!(millis_from_key(&key), Some(1234));
+    }
+
+    fn test_message() -> Message {
+        Message::new(
+            "test_type".to_string(),
+            b"hello world".to_vec(),
+            LogSource::WebhookPost("test".to_string()),
+            LogbacksAllowed::Limited(0),
+        )
+    }
+
+    #[tokio::test]
+    async fn persist_then_reload_roundtrips_message() {
+        let storage = Arc::new(Storage::new_in_memory());
+        let store = OverflowStore::new(storage.clone(), QueueOverflowConfig::default()).await;
+        let message = test_message();
+        let id = message.id.clone();
+
+        assert_eq!(store.persist(&message).await, PersistOutcome::Persisted);
+
+        // The message is now in storage under a single key; claim it back and verify it
+        // deserializes to the same message.
+        let keys = storage.list_keys(QUEUE_OVERFLOW_NS, None).await.unwrap();
+        assert_eq!(keys.len(), 1);
+        let value = storage
+            .delete(QUEUE_OVERFLOW_NS, &keys[0])
+            .await
+            .unwrap()
+            .unwrap();
+        let restored: Message = serde_json::from_slice(&decompress(&value).unwrap()).unwrap();
+        assert_eq!(restored.id, id);
+        assert_eq!(restored.data, b"hello world");
+    }
+
+    #[tokio::test]
+    async fn get_mode_message_is_not_persisted() {
+        let storage = Arc::new(Storage::new_in_memory());
+        let store = OverflowStore::new(storage.clone(), QueueOverflowConfig::default()).await;
+        let (tx, _rx) = tokio::sync::oneshot::channel();
+        let mut message = test_message();
+        message.response_sender = Some(tx);
+
+        assert_eq!(store.persist(&message).await, PersistOutcome::NotReplayable);
+        assert!(storage
+            .list_keys(QUEUE_OVERFLOW_NS, None)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn cap_is_enforced_then_bypassed_by_forced() {
+        let storage = Arc::new(Storage::new_in_memory());
+        let cfg = QueueOverflowConfig {
+            max_persisted: 1,
+            ..QueueOverflowConfig::default()
+        };
+        let store = OverflowStore::new(storage.clone(), cfg).await;
+
+        assert_eq!(store.persist(&test_message()).await, PersistOutcome::Persisted);
+        // At cap now: a normal persist is rejected...
+        assert_eq!(store.persist(&test_message()).await, PersistOutcome::CapExceeded);
+        // ...but a forced persist (shutdown / repersist) still goes through.
+        assert_eq!(
+            store.persist_forced(&test_message()).await,
+            PersistOutcome::Persisted
+        );
+    }
+}

--- a/runtime/plaid/src/executor/overflow.rs
+++ b/runtime/plaid/src/executor/overflow.rs
@@ -30,22 +30,36 @@
 //!
 //! Multi-replica: delete-returns-value ensures a given ready row is claimed by at most one
 //! reloader at a time. Cross-pod recovery requires a *shared* backend (e.g. DynamoDB).
+//!
+//! # Burst design
+//!
+//! - Ingress never blocks on storage: messages go through a bounded mpsc spill channel.
+//! - Multiple concurrent persist tasks drain the channel (`spill_concurrency`).
+//! - Spill offers are rejected at a high watermark (HTTP 429) before the channel hard-fills.
+//! - HTTP returns **202** when a message is accepted onto the spill path (not yet durable).
+//! - Reload lists only `reload_batch_size` oldest keys (not the full namespace).
+//! - Age reaper runs on a slower cadence than reload.
 
 use std::collections::HashMap;
 use std::io::{Read, Write};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use crossbeam_channel::TrySendError;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use plaid_stl::messages::{LogSource, LogbacksAllowed};
+use prometheus::{
+    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
+    register_int_gauge_with_registry, HistogramVec, IntCounterVec, IntGauge, Registry,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::config::QueueOverflowConfig;
 use crate::executor::{Executor, Message};
+use crate::metrics::MetricsHandle;
 use crate::storage::Storage;
 
 /// Storage namespace holding ready (not yet claimed) overflow messages.
@@ -60,15 +74,19 @@ pub const QUEUE_OVERFLOW_INFLIGHT_NS: &str = "queue_overflow_inflight";
 /// overhead, and log a distinct error instead of letting the backend reject the write.
 const MAX_ITEM_BYTES: usize = 380 * 1024;
 
-/// Wire format version for stored message envelopes (base64 payloads).
-const STORED_MESSAGE_VERSION: u8 = 1;
+/// Wire format versions.
+const STORED_MESSAGE_V1: u8 = 1;
+const STORED_MESSAGE_V2: u8 = 2;
+
+/// Magic prefix for uncompressed v2 envelopes (before gzip).
+const V2_MAGIC: &[u8; 4] = b"POF2";
 
 /// Even forced persists (shutdown) refuse to grow the store beyond this multiple of
 /// `max_persisted`, so a crash loop cannot fill the backend without bound.
 const FORCED_CAP_MULTIPLIER: u64 = 2;
 
-/// Log a warning when the ready namespace exceeds this many keys (list cost / memory).
-const LIST_SIZE_WARN_THRESHOLD: usize = 10_000;
+/// How long a recent persist failure keeps the spill path under elevated backpressure.
+const FAILURE_BACKPRESSURE_SECS: u64 = 5;
 
 /// The result of trying to persist a single message to the overflow store.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -113,8 +131,6 @@ impl PersistOutcome {
                 );
             }
             Self::TooLarge => {
-                // persist path already logs details; keep a one-liner here for callers
-                // that only see the outcome.
                 error!(
                     "Overflow {context}: message {message_id} from {source} exceeds item size limit"
                 );
@@ -126,10 +142,315 @@ impl PersistOutcome {
             }
         }
     }
+
+    fn is_failure(self) -> bool {
+        matches!(self, Self::Failed | Self::CapExceeded | Self::TooLarge)
+    }
 }
 
-/// Compact on-disk envelope: binary fields are base64 so gzip sees compressible text and
-/// we avoid JSON's array-of-bytes blow-up (which caused many false `TooLarge` drops).
+/// Result of offering a message to the spill path (in-memory channel only).
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum SpillOffer {
+    /// Accepted onto the spill channel; persistence is still async. HTTP should return 202.
+    Accepted,
+    /// Rejected (disabled, pressure, full, or closed). HTTP should return 429; message dropped.
+    Rejected,
+}
+
+/// Prometheus metrics for the overflow path. Optional — absent when metrics are disabled.
+#[derive(Clone)]
+pub struct OverflowMetrics {
+    spill_depth: IntGauge,
+    spill_capacity: IntGauge,
+    ready_approx: IntGauge,
+    inflight_approx: IntGauge,
+    persist_total: IntCounterVec,
+    persist_seconds: HistogramVec,
+    reload_total: IntCounterVec,
+    offer_total: IntCounterVec,
+}
+
+impl OverflowMetrics {
+    pub fn register(handle: &MetricsHandle) -> Self {
+        let registry = handle.registry();
+        Self::register_with_registry(registry)
+    }
+
+    fn register_with_registry(registry: &Registry) -> Self {
+        let spill_depth = register_int_gauge_with_registry!(
+            "plaid_overflow_spill_depth",
+            "Messages currently buffered in the in-process spill channel",
+            registry
+        )
+        .expect("overflow spill_depth metric");
+
+        let spill_capacity = register_int_gauge_with_registry!(
+            "plaid_overflow_spill_capacity",
+            "Configured capacity of the in-process spill channel",
+            registry
+        )
+        .expect("overflow spill_capacity metric");
+
+        let ready_approx = register_int_gauge_with_registry!(
+            "plaid_overflow_ready_approx",
+            "Approximate ready overflow messages counted by this process",
+            registry
+        )
+        .expect("overflow ready_approx metric");
+
+        let inflight_approx = register_int_gauge_with_registry!(
+            "plaid_overflow_inflight_approx",
+            "Approximate inflight overflow messages counted by this process",
+            registry
+        )
+        .expect("overflow inflight_approx metric");
+
+        let persist_total = register_int_counter_vec_with_registry!(
+            "plaid_overflow_persist_total",
+            "Overflow persist attempts by outcome",
+            &["result"],
+            registry
+        )
+        .expect("overflow persist_total metric");
+
+        let persist_seconds = register_histogram_vec_with_registry!(
+            "plaid_overflow_persist_seconds",
+            "Wall time of a single overflow persist (encode + storage write)",
+            &["result"],
+            registry
+        )
+        .expect("overflow persist_seconds metric");
+
+        let reload_total = register_int_counter_vec_with_registry!(
+            "plaid_overflow_reload_total",
+            "Overflow reload/reclaim/reap events",
+            &["event"],
+            registry
+        )
+        .expect("overflow reload_total metric");
+
+        let offer_total = register_int_counter_vec_with_registry!(
+            "plaid_overflow_offer_total",
+            "Spill channel offer attempts by result",
+            &["result"],
+            registry
+        )
+        .expect("overflow offer_total metric");
+
+        Self {
+            spill_depth,
+            spill_capacity,
+            ready_approx,
+            inflight_approx,
+            persist_total,
+            persist_seconds,
+            reload_total,
+            offer_total,
+        }
+    }
+
+    fn record_persist(&self, outcome: PersistOutcome, elapsed: std::time::Duration) {
+        let label = outcome.as_str();
+        self.persist_total.with_label_values(&[label]).inc();
+        self.persist_seconds
+            .with_label_values(&[label])
+            .observe(elapsed.as_secs_f64());
+    }
+
+    fn record_offer(&self, offer: SpillOffer) {
+        let label = match offer {
+            SpillOffer::Accepted => "accepted",
+            SpillOffer::Rejected => "rejected",
+        };
+        self.offer_total.with_label_values(&[label]).inc();
+    }
+
+    fn record_reload_event(&self, event: &str, n: usize) {
+        if n > 0 {
+            self.reload_total.with_label_values(&[event]).inc_by(n as u64);
+        }
+    }
+}
+
+/// Shared spill-path state: depth tracking, recent failure backpressure, metrics.
+#[derive(Clone)]
+pub struct SpillIngress {
+    tx: tokio::sync::mpsc::Sender<Message>,
+    high_watermark_pct: u8,
+    /// Approximate messages currently in the spill channel (inc on offer, dec on recv).
+    depth: Arc<AtomicUsize>,
+    capacity: usize,
+    /// Unix secs of last non-success persist (for elevated backpressure).
+    last_failure_secs: Arc<AtomicU64>,
+    metrics: Option<OverflowMetrics>,
+}
+
+impl SpillIngress {
+    pub fn new(
+        tx: tokio::sync::mpsc::Sender<Message>,
+        capacity: usize,
+        high_watermark_pct: u8,
+        metrics: Option<OverflowMetrics>,
+    ) -> Self {
+        if let Some(m) = &metrics {
+            m.spill_capacity.set(capacity as i64);
+            m.spill_depth.set(0);
+        }
+        Self {
+            tx,
+            high_watermark_pct: high_watermark_pct.min(100),
+            depth: Arc::new(AtomicUsize::new(0)),
+            capacity: capacity.max(1),
+            last_failure_secs: Arc::new(AtomicU64::new(0)),
+            metrics,
+        }
+    }
+
+    pub fn sender(&self) -> tokio::sync::mpsc::Sender<Message> {
+        self.tx.clone()
+    }
+
+    pub fn depth_handle(&self) -> Arc<AtomicUsize> {
+        self.depth.clone()
+    }
+
+    pub fn failure_handle(&self) -> Arc<AtomicU64> {
+        self.last_failure_secs.clone()
+    }
+
+    pub fn metrics(&self) -> Option<OverflowMetrics> {
+        self.metrics.clone()
+    }
+
+    fn occupancy_pct(&self) -> u8 {
+        let depth = self.depth.load(Ordering::Relaxed);
+        ((depth.saturating_mul(100)) / self.capacity) as u8
+    }
+
+    fn under_failure_backpressure(&self) -> bool {
+        let last = self.last_failure_secs.load(Ordering::Relaxed);
+        if last == 0 {
+            return false;
+        }
+        now_secs().saturating_sub(last) < FAILURE_BACKPRESSURE_SECS
+    }
+
+    /// Non-blocking offer onto the spill channel with high-watermark + failure backpressure.
+    pub fn offer(&self, message: Message, log_type: &str) -> SpillOffer {
+        // Reject oversized bodies early so they never sit in the spill buffer.
+        if message.data.len() > MAX_ITEM_BYTES {
+            error!(
+                "Queue Full! [{log_type}] message {} body is {} bytes (over {MAX_ITEM_BYTES}); not spilled",
+                message.id,
+                message.data.len()
+            );
+            let offer = SpillOffer::Rejected;
+            if let Some(m) = &self.metrics {
+                m.record_offer(offer);
+            }
+            return offer;
+        }
+
+        let mut threshold = self.high_watermark_pct;
+        if self.under_failure_backpressure() {
+            // Tighten admission while storage is unhealthy so clients retry sooner.
+            threshold = threshold.min(50);
+        }
+        if self.occupancy_pct() >= threshold {
+            error!(
+                "Queue Full AND overflow spill under pressure (depth≈{}/{}, threshold={}%)! [{log_type}] log dropped!",
+                self.depth.load(Ordering::Relaxed),
+                self.capacity,
+                threshold
+            );
+            let offer = SpillOffer::Rejected;
+            if let Some(m) = &self.metrics {
+                m.record_offer(offer);
+            }
+            return offer;
+        }
+
+        match self.tx.try_send(message) {
+            Ok(()) => {
+                let d = self.depth.fetch_add(1, Ordering::Relaxed) + 1;
+                if let Some(m) = &self.metrics {
+                    m.spill_depth.set(d as i64);
+                    m.record_offer(SpillOffer::Accepted);
+                }
+                debug!("Queue Full! [{log_type}] message routed to durable overflow (202 path)");
+                SpillOffer::Accepted
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                error!(
+                    "Queue Full AND overflow spill backlog full! [{log_type}] log dropped!"
+                );
+                let offer = SpillOffer::Rejected;
+                if let Some(m) = &self.metrics {
+                    m.record_offer(offer);
+                }
+                offer
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                error!(
+                    "Queue Full and overflow spill channel closed! [{log_type}] log dropped!"
+                );
+                let offer = SpillOffer::Rejected;
+                if let Some(m) = &self.metrics {
+                    m.record_offer(offer);
+                }
+                offer
+            }
+        }
+    }
+}
+
+/// Try the executor channel first; on Full, offer to spill if configured.
+///
+/// When overflow is disabled and the queue is full, falls back to blocking `send` so
+/// data generators retain prior backpressure behaviour. Returns `Ok(())` if the message
+/// was enqueued or accepted onto spill; `Err(())` if lost or the channel disconnected.
+pub fn send_or_spill(
+    sender: &crossbeam_channel::Sender<Message>,
+    message: Message,
+    log_type: &str,
+    spill: &Option<SpillIngress>,
+) -> Result<(), ()> {
+    match sender.try_send(message) {
+        Ok(()) => Ok(()),
+        Err(TrySendError::Full(message)) => match spill {
+            Some(ingress) => match ingress.offer(message, log_type) {
+                SpillOffer::Accepted => Ok(()),
+                SpillOffer::Rejected => Err(()),
+            },
+            None => {
+                // Preserve historical blocking behaviour when overflow is off.
+                sender.send(message).map_err(|_| ())
+            }
+        },
+        Err(TrySendError::Disconnected(_)) => Err(()),
+    }
+}
+
+/// Offer a message that could not be enqueued to the spill path (non-blocking).
+///
+/// Returns [`SpillOffer::Accepted`] if the message was accepted onto the spill channel
+/// (persistence is still async — HTTP should use 202). Returns [`SpillOffer::Rejected`]
+/// if overflow is disabled or the spill path is under pressure / full / closed.
+pub fn offer_to_spill(
+    message: Message,
+    log_type: &str,
+    spill: &Option<SpillIngress>,
+) -> SpillOffer {
+    match spill {
+        Some(ingress) => ingress.offer(message, log_type),
+        None => {
+            error!("Queue Full! [{log_type}] log dropped!");
+            SpillOffer::Rejected
+        }
+    }
+}
+
+/// Compact on-disk envelope v1: binary fields are base64 so gzip sees compressible text.
 #[derive(Serialize, Deserialize)]
 struct StoredMessageV1 {
     v: u8,
@@ -143,9 +464,10 @@ struct StoredMessageV1 {
 }
 
 impl StoredMessageV1 {
+    #[cfg(test)]
     fn from_message(message: &Message) -> Self {
         Self {
-            v: STORED_MESSAGE_VERSION,
+            v: STORED_MESSAGE_V1,
             id: message.id.clone(),
             type_: message.type_.clone(),
             data_b64: base64::encode(&message.data),
@@ -206,11 +528,20 @@ pub struct OverflowStore {
     /// accounting. Uses saturating arithmetic so concurrent claims can never wrap the
     /// counter into a permanent self-DoS.
     count: AtomicU64,
+    metrics: Option<OverflowMetrics>,
 }
 
 impl OverflowStore {
     /// Build a store and seed the approximate count from ready + inflight namespaces.
     pub async fn new(storage: Arc<Storage>, config: QueueOverflowConfig) -> Self {
+        Self::new_with_metrics(storage, config, None).await
+    }
+
+    pub async fn new_with_metrics(
+        storage: Arc<Storage>,
+        config: QueueOverflowConfig,
+        metrics: Option<OverflowMetrics>,
+    ) -> Self {
         let ready = match storage.list_keys(QUEUE_OVERFLOW_NS, None).await {
             Ok(keys) => keys.len() as u64,
             Err(e) => {
@@ -230,11 +561,20 @@ impl OverflowStore {
             "Overflow store initialized with {count} persisted message(s) ({ready} ready, {inflight} inflight); max_persisted={}",
             config.max_persisted
         );
+        if let Some(m) = &metrics {
+            m.ready_approx.set(ready as i64);
+            m.inflight_approx.set(inflight as i64);
+        }
         Self {
             storage,
             config,
             count: AtomicU64::new(count),
+            metrics,
         }
+    }
+
+    pub fn config(&self) -> &QueueOverflowConfig {
+        &self.config
     }
 
     /// Current approximate persisted count (ready + inflight) for this process.
@@ -253,6 +593,23 @@ impl OverflowStore {
     /// data loss — but still refuse unbounded growth across crash loops.
     pub async fn persist_forced(&self, message: &Message) -> PersistOutcome {
         self.persist_with_key(message, true, None).await
+    }
+
+    /// Record a persist outcome for spill backpressure + metrics. Call from spill workers.
+    pub fn note_persist_outcome(
+        &self,
+        outcome: PersistOutcome,
+        elapsed: std::time::Duration,
+        last_failure_secs: Option<&AtomicU64>,
+    ) {
+        if let Some(m) = &self.metrics {
+            m.record_persist(outcome, elapsed);
+        }
+        if outcome.is_failure() {
+            if let Some(flag) = last_failure_secs {
+                flag.store(now_secs(), Ordering::Relaxed);
+            }
+        }
     }
 
     /// Persist `message`. If `existing_key` is given (a message being put back after a
@@ -323,6 +680,7 @@ impl OverflowStore {
                 // must not inflate the approximate counter.
                 if !is_restore && previous.is_none() {
                     self.count.fetch_add(1, Ordering::Relaxed);
+                    self.refresh_count_gauges();
                 }
                 PersistOutcome::Persisted
             }
@@ -336,12 +694,27 @@ impl OverflowStore {
         }
     }
 
+    fn refresh_count_gauges(&self) {
+        if let Some(m) = &self.metrics {
+            // We only track a combined count; split gauges use the same approximate for
+            // ready and leave inflight as 0 unless reclaimed/claimed paths update them.
+            m.ready_approx
+                .set(self.count.load(Ordering::Relaxed) as i64);
+        }
+    }
+
     /// Drop ready messages older than `max_message_age_secs` without reinjecting them.
-    /// Safe to run while the executor queue is full (unlike claim/reinject).
+    /// Scans only the oldest `reload_batch_size` keys (sorted); stops at the first
+    /// non-expired key so a large backlog of fresh messages is not fully listed.
     ///
     /// Returns the number of messages reaped.
     pub async fn reap_expired(&self) -> usize {
-        let keys = match self.storage.list_keys(QUEUE_OVERFLOW_NS, None).await {
+        let limit = self.config.reload_batch_size.max(1);
+        let keys = match self
+            .storage
+            .list_keys_limited(QUEUE_OVERFLOW_NS, None, limit)
+            .await
+        {
             Ok(keys) => keys,
             Err(e) => {
                 error!("Could not list overflow messages to reap: {e}");
@@ -358,8 +731,6 @@ impl OverflowStore {
 
         for key in keys {
             let Some(created) = millis_from_key(&key) else {
-                // Malformed keys never age out via the normal path; delete them so they
-                // cannot pin the namespace forever.
                 warn!("Reaping overflow message with unparseable key {key}");
                 match self.storage.delete(QUEUE_OVERFLOW_NS, &key).await {
                     Ok(Some(_)) => {
@@ -373,7 +744,8 @@ impl OverflowStore {
             };
             let age_secs = now.saturating_sub(created / 1000);
             if age_secs <= self.config.max_message_age_secs {
-                continue;
+                // Keys are oldest-first; nothing older remains in this page.
+                break;
             }
             match self.storage.delete(QUEUE_OVERFLOW_NS, &key).await {
                 Ok(Some(_)) => {
@@ -388,6 +760,10 @@ impl OverflowStore {
 
         if reaped > 0 {
             info!("Reaped {reaped} expired overflow message(s)");
+            if let Some(m) = &self.metrics {
+                m.record_reload_event("reaped", reaped);
+            }
+            self.refresh_count_gauges();
         }
         reaped
     }
@@ -395,9 +771,10 @@ impl OverflowStore {
     /// Move expired inflight leases back to the ready namespace so they can be claimed
     /// again after a crash mid-reload. Returns how many rows were reclaimed.
     pub async fn reclaim_stale_inflight(&self) -> usize {
+        let limit = self.config.reload_batch_size.max(1).saturating_mul(2);
         let keys = match self
             .storage
-            .list_keys(QUEUE_OVERFLOW_INFLIGHT_NS, None)
+            .list_keys_limited(QUEUE_OVERFLOW_INFLIGHT_NS, None, limit)
             .await
         {
             Ok(keys) => keys,
@@ -463,23 +840,32 @@ impl OverflowStore {
             }
         }
 
+        if reclaimed > 0 {
+            if let Some(m) = &self.metrics {
+                m.record_reload_event("reclaimed", reclaimed);
+            }
+        }
         reclaimed
     }
 
     /// Claim and reinject up to `reload_batch_size` overflowed messages into the executor.
     ///
     /// Returns the number of messages successfully reinjected. Stops early (leaving the
-    /// rest for a later poll) as soon as the executor queue is full, so a wedged executor
-    /// does not spin this into a claim loop. Over-age messages are dropped.
+    /// rest for a later poll) as soon as the target queue is at/above the reinject high
+    /// watermark or the executor rejects a send, so a wedged executor does not spin this
+    /// into a claim loop.
     ///
-    /// Note: this lists keys in the ready namespace each call. `reload_batch_size` bounds
-    /// how many are *claimed*, not how many keys are loaded into memory. Prefer keeping
-    /// `max_persisted` reasonable for the storage backend.
+    /// Lists only up to `reload_batch_size` oldest keys — not the full namespace.
     pub async fn reload_batch(&self, executor: &Executor) -> usize {
         // Recover anything left mid-claim by a crashed peer / prior boot first.
         let _ = self.reclaim_stale_inflight().await;
 
-        let keys = match self.storage.list_keys(QUEUE_OVERFLOW_NS, None).await {
+        let batch_limit = self.config.reload_batch_size.max(1);
+        let keys = match self
+            .storage
+            .list_keys_limited(QUEUE_OVERFLOW_NS, None, batch_limit)
+            .await
+        {
             Ok(keys) => keys,
             Err(e) => {
                 error!("Could not list overflow messages to reload: {e}");
@@ -491,22 +877,16 @@ impl OverflowStore {
             return 0;
         }
 
-        if keys.len() > LIST_SIZE_WARN_THRESHOLD {
-            warn!(
-                "Overflow ready namespace has {} keys; full list_keys each reload poll is expensive. Consider lowering max_persisted or draining backlog.",
-                keys.len()
-            );
-        }
-
-        // Keys are `{zero-padded-millis}:{id}`, so a lexical sort is oldest-first.
+        // Keys are `{zero-padded-millis}:{id}`; limited list is already oldest-first on
+        // DynamoDB/Sled. Sort for backends that do not guarantee order (in-memory).
         let mut keys = keys;
         keys.sort();
 
         let now = now_secs();
         let mut reinjected = 0usize;
-        let batch_limit = self.config.reload_batch_size;
+        let watermark = self.config.reinject_high_watermark_pct.min(100);
 
-        for key in keys.into_iter().take(batch_limit) {
+        for key in keys {
             // Step 1: claim ready row. Only one replica receives Some(value).
             let body = match self.storage.delete(QUEUE_OVERFLOW_NS, &key).await {
                 Ok(Some(value)) => value,
@@ -571,6 +951,12 @@ impl OverflowStore {
                 }
             };
 
+            // Avoid claim/restore thrash when the target queue is already near capacity.
+            if executor.queue_occupancy_pct(&message.type_) >= watermark {
+                self.return_to_ready(&key, &body, &message).await;
+                break;
+            }
+
             match executor.execute_webhook_message(message) {
                 Ok(()) => {
                     self.ack_inflight(&key).await;
@@ -596,6 +982,10 @@ impl OverflowStore {
 
         if reinjected > 0 {
             info!("Reinjected {reinjected} overflow message(s) into the executor");
+            if let Some(m) = &self.metrics {
+                m.record_reload_event("reinjected", reinjected);
+            }
+            self.refresh_count_gauges();
         }
         reinjected
     }
@@ -666,21 +1056,46 @@ fn millis_from_key(key: &str) -> Option<u64> {
     key.split(':').next()?.parse::<u64>().ok()
 }
 
-/// Encode a message to the on-disk format: gzip(json StoredMessageV1).
+/// Encode a message to the on-disk format: gzip(v2 binary envelope).
 fn encode_message(message: &Message) -> Result<Vec<u8>, String> {
-    let envelope = StoredMessageV1::from_message(message);
-    let serialized =
-        serde_json::to_vec(&envelope).map_err(|e| format!("serialize envelope: {e}"))?;
-    compress(&serialized).map_err(|e| format!("compress: {e}"))
+    let raw = encode_v2_raw(message)?;
+    compress(&raw).map_err(|e| format!("compress: {e}"))
 }
 
-/// Decode on-disk bytes. Accepts the v1 base64 envelope and falls back to legacy
-/// `serde_json::Message` payloads so an in-place upgrade does not strand rows.
+/// Length-prefixed binary envelope (v2). Smaller than base64+JSON for binary payloads.
+fn encode_v2_raw(message: &Message) -> Result<Vec<u8>, String> {
+    let mut buf = Vec::with_capacity(64 + message.data.len());
+    buf.extend_from_slice(V2_MAGIC);
+    buf.push(STORED_MESSAGE_V2);
+    write_str(&mut buf, &message.id);
+    write_str(&mut buf, &message.type_);
+    write_bytes(&mut buf, &message.data);
+    write_u32(&mut buf, message.headers.len() as u32);
+    for (k, v) in &message.headers {
+        write_str(&mut buf, k);
+        write_bytes(&mut buf, v);
+    }
+    write_u32(&mut buf, message.query_params.len() as u32);
+    for (k, v) in &message.query_params {
+        write_str(&mut buf, k);
+        write_bytes(&mut buf, v);
+    }
+    let meta = serde_json::to_vec(&(&message.source, &message.logbacks_allowed))
+        .map_err(|e| format!("serialize meta: {e}"))?;
+    write_bytes(&mut buf, &meta);
+    Ok(buf)
+}
+
+/// Decode on-disk bytes. Accepts v2 binary, v1 base64 envelope, and legacy Message JSON.
 fn decode_message(bytes: &[u8]) -> Result<Message, String> {
     let decompressed = decompress(bytes).map_err(|e| format!("decompress: {e}"))?;
 
+    if decompressed.starts_with(V2_MAGIC) {
+        return decode_v2_raw(&decompressed);
+    }
+
     if let Ok(env) = serde_json::from_slice::<StoredMessageV1>(&decompressed) {
-        if env.v == STORED_MESSAGE_VERSION {
+        if env.v == STORED_MESSAGE_V1 {
             return env.into_message();
         }
     }
@@ -688,6 +1103,84 @@ fn decode_message(bytes: &[u8]) -> Result<Message, String> {
     // Legacy: direct Message JSON (array-of-bytes data field).
     serde_json::from_slice::<Message>(&decompressed)
         .map_err(|e| format!("deserialize legacy or v1 message: {e}"))
+}
+
+fn decode_v2_raw(raw: &[u8]) -> Result<Message, String> {
+    if raw.len() < 5 || &raw[..4] != V2_MAGIC {
+        return Err("bad v2 magic".into());
+    }
+    if raw[4] != STORED_MESSAGE_V2 {
+        return Err(format!("unsupported v2 version {}", raw[4]));
+    }
+    let mut i = 5usize;
+    let id = read_str(raw, &mut i)?;
+    let type_ = read_str(raw, &mut i)?;
+    let data = read_bytes(raw, &mut i)?;
+    let header_count = read_u32(raw, &mut i)? as usize;
+    let mut headers = HashMap::with_capacity(header_count);
+    for _ in 0..header_count {
+        let k = read_str(raw, &mut i)?;
+        let v = read_bytes(raw, &mut i)?;
+        headers.insert(k, v);
+    }
+    let qp_count = read_u32(raw, &mut i)? as usize;
+    let mut query_params = HashMap::with_capacity(qp_count);
+    for _ in 0..qp_count {
+        let k = read_str(raw, &mut i)?;
+        let v = read_bytes(raw, &mut i)?;
+        query_params.insert(k, v);
+    }
+    let meta = read_bytes(raw, &mut i)?;
+    let (source, logbacks_allowed): (LogSource, LogbacksAllowed) =
+        serde_json::from_slice(&meta).map_err(|e| format!("deserialize meta: {e}"))?;
+    Ok(Message {
+        id,
+        type_,
+        data,
+        headers,
+        query_params,
+        source,
+        logbacks_allowed,
+        response_sender: None,
+        module: None,
+    })
+}
+
+fn write_u32(buf: &mut Vec<u8>, v: u32) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+
+fn write_str(buf: &mut Vec<u8>, s: &str) {
+    write_bytes(buf, s.as_bytes());
+}
+
+fn write_bytes(buf: &mut Vec<u8>, b: &[u8]) {
+    write_u32(buf, b.len() as u32);
+    buf.extend_from_slice(b);
+}
+
+fn read_u32(buf: &[u8], i: &mut usize) -> Result<u32, String> {
+    if *i + 4 > buf.len() {
+        return Err("truncated u32".into());
+    }
+    let v = u32::from_le_bytes(buf[*i..*i + 4].try_into().unwrap());
+    *i += 4;
+    Ok(v)
+}
+
+fn read_bytes(buf: &[u8], i: &mut usize) -> Result<Vec<u8>, String> {
+    let len = read_u32(buf, i)? as usize;
+    if *i + len > buf.len() {
+        return Err("truncated bytes".into());
+    }
+    let out = buf[*i..*i + len].to_vec();
+    *i += len;
+    Ok(out)
+}
+
+fn read_str(buf: &[u8], i: &mut usize) -> Result<String, String> {
+    let bytes = read_bytes(buf, i)?;
+    String::from_utf8(bytes).map_err(|e| format!("utf8: {e}"))
 }
 
 /// Inflight blob: 8-byte big-endian claimed_at_secs || original ready body.
@@ -709,7 +1202,8 @@ fn unwrap_inflight(blob: &[u8]) -> Option<(u64, Vec<u8>)> {
 }
 
 fn compress(data: &[u8]) -> std::io::Result<Vec<u8>> {
-    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    // Fast compression: spill path is latency-sensitive under burst.
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
     encoder.write_all(data)?;
     encoder.finish()
 }
@@ -735,38 +1229,84 @@ fn now_secs() -> u64 {
         .unwrap_or(0)
 }
 
-/// Offer a message that could not be enqueued to the spill channel (non-blocking).
-///
-/// Returns `true` if the message was accepted onto the spill path (persistence is async).
-/// Returns `false` if overflow is disabled or the spill backlog itself is saturated /
-/// closed — the message is then dropped and the caller should treat it as lost.
-pub fn offer_to_spill(
-    message: Message,
-    log_type: &str,
-    spill_sender: &Option<tokio::sync::mpsc::Sender<Message>>,
-) -> bool {
-    match spill_sender {
-        Some(tx) => match tx.try_send(message) {
-            Ok(()) => {
-                debug!("Queue Full! [{log_type}] message routed to durable overflow");
-                true
+/// Run concurrent spill workers until cancellation, then force-drain remaining messages.
+pub async fn run_spill_workers(
+    store: Arc<OverflowStore>,
+    mut rx: tokio::sync::mpsc::Receiver<Message>,
+    depth: Arc<AtomicUsize>,
+    last_failure_secs: Arc<AtomicU64>,
+    concurrency: usize,
+    cancellation: tokio_util::sync::CancellationToken,
+) {
+    let concurrency = concurrency.max(1);
+    let mut in_flight = tokio::task::JoinSet::new();
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => {
+                // Drain buffered messages with forced persist.
+                while let Ok(message) = rx.try_recv() {
+                    dec_depth(&depth, store.metrics.as_ref());
+                    while in_flight.len() >= concurrency {
+                        let _ = in_flight.join_next().await;
+                    }
+                    let store = store.clone();
+                    let last_failure_secs = last_failure_secs.clone();
+                    in_flight.spawn(async move {
+                        let start = Instant::now();
+                        let id = message.id.clone();
+                        let source = message.source.clone();
+                        let outcome = store.persist_forced(&message).await;
+                        store.note_persist_outcome(outcome, start.elapsed(), Some(&last_failure_secs));
+                        outcome.log_if_not_persisted("spill-shutdown", &id, &source);
+                    });
+                }
+                while in_flight.join_next().await.is_some() {}
+                break;
             }
-            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                error!(
-                    "Queue Full AND overflow spill backlog full! [{log_type}] log dropped!"
-                );
-                false
+            maybe_msg = rx.recv() => {
+                match maybe_msg {
+                    Some(message) => {
+                        dec_depth(&depth, store.metrics.as_ref());
+                        while in_flight.len() >= concurrency {
+                            let _ = in_flight.join_next().await;
+                        }
+                        let store = store.clone();
+                        let last_failure_secs = last_failure_secs.clone();
+                        in_flight.spawn(async move {
+                            let start = Instant::now();
+                            let id = message.id.clone();
+                            let source = message.source.clone();
+                            let outcome = store.persist(&message).await;
+                            store.note_persist_outcome(outcome, start.elapsed(), Some(&last_failure_secs));
+                            outcome.log_if_not_persisted("spill", &id, &source);
+                        });
+                    }
+                    None => {
+                        // All senders dropped; finish in-flight work.
+                        while in_flight.join_next().await.is_some() {}
+                        break;
+                    }
+                }
             }
-            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                error!(
-                    "Queue Full and overflow spill channel closed! [{log_type}] log dropped!"
-                );
-                false
+        }
+    }
+    info!("Overflow spill workers shut down");
+}
+
+fn dec_depth(depth: &AtomicUsize, metrics: Option<&OverflowMetrics>) {
+    let mut cur = depth.load(Ordering::Relaxed);
+    loop {
+        let next = cur.saturating_sub(1);
+        match depth.compare_exchange_weak(cur, next, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => {
+                if let Some(m) = metrics {
+                    m.spill_depth.set(next as i64);
+                }
+                break;
             }
-        },
-        None => {
-            error!("Queue Full! [{log_type}] log dropped!");
-            false
+            Err(actual) => cur = actual,
         }
     }
 }
@@ -832,25 +1372,33 @@ mod tests {
     }
 
     #[test]
-    fn envelope_is_much_smaller_than_legacy_json_array_for_binary() {
-        // 50 KiB of binary: legacy JSON array-of-bytes is enormous; v1+gzip should fit
-        // comfortably under the DynamoDB item guard.
+    fn v2_envelope_is_smaller_than_v1_for_binary() {
         let message = test_message_with_data(vec![0xABu8; 50 * 1024]);
-        let encoded = encode_message(&message).unwrap();
+        let v2 = encode_message(&message).unwrap();
         assert!(
-            encoded.len() < MAX_ITEM_BYTES,
+            v2.len() < MAX_ITEM_BYTES,
             "encoded {} bytes should be under limit",
-            encoded.len()
+            v2.len()
         );
 
-        // Legacy path for comparison: raw Message JSON then gzip.
-        let legacy = compress(&serde_json::to_vec(&message).unwrap()).unwrap();
+        let v1_raw = serde_json::to_vec(&StoredMessageV1::from_message(&message)).unwrap();
+        let v1 = compress(&v1_raw).unwrap();
         assert!(
-            encoded.len() < legacy.len(),
-            "v1 envelope ({}) should beat legacy json-array ({})",
-            encoded.len(),
-            legacy.len()
+            v2.len() <= v1.len(),
+            "v2 envelope ({}) should not exceed v1 ({})",
+            v2.len(),
+            v1.len()
         );
+    }
+
+    #[test]
+    fn legacy_v1_envelope_still_decodes() {
+        let message = test_message();
+        let v1_raw = serde_json::to_vec(&StoredMessageV1::from_message(&message)).unwrap();
+        let encoded = compress(&v1_raw).unwrap();
+        let restored = decode_message(&encoded).unwrap();
+        assert_eq!(restored.id, message.id);
+        assert_eq!(restored.data, message.data);
     }
 
     fn test_message() -> Message {
@@ -920,12 +1468,10 @@ mod tests {
             store.persist(&test_message()).await,
             PersistOutcome::CapExceeded
         );
-        // Forced bypasses soft cap...
         assert_eq!(
             store.persist_forced(&test_message()).await,
             PersistOutcome::Persisted
         );
-        // ...but hard cap (2x) still binds: count is 2, hard is 2, so next forced fails.
         assert_eq!(
             store.persist_forced(&test_message()).await,
             PersistOutcome::CapExceeded
@@ -937,11 +1483,9 @@ mod tests {
         let storage = Arc::new(Storage::new_in_memory());
         let store = OverflowStore::new(storage, QueueOverflowConfig::default()).await;
         assert_eq!(store.approximate_count(), 0);
-        // Simulate claiming messages we never counted (peer-written rows).
         store.saturating_dec();
         store.saturating_dec();
         assert_eq!(store.approximate_count(), 0);
-        // Cap must still allow persists after underflow attempts.
         assert_eq!(store.persist(&test_message()).await, PersistOutcome::Persisted);
     }
 
@@ -1008,7 +1552,6 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        // Claimed far in the past → lease expired.
         storage
             .insert(
                 QUEUE_OVERFLOW_INFLIGHT_NS.to_string(),
@@ -1084,15 +1627,13 @@ mod tests {
         };
         let store = OverflowStore::new(storage.clone(), cfg).await;
 
-        // Insert directly with an ancient key so age check fires.
         let message = test_message();
         let encoded = encode_message(&message).unwrap();
-        let ancient_key = overflow_key(1_000, &message.id); // year ~1970
+        let ancient_key = overflow_key(1_000, &message.id);
         storage
             .insert(QUEUE_OVERFLOW_NS.to_string(), ancient_key, encoded)
             .await
             .unwrap();
-        // Manually bump count to match (persist path would have).
         store.count.store(1, Ordering::Relaxed);
 
         let reaped = store.reap_expired().await;
@@ -1126,5 +1667,47 @@ mod tests {
         let b = storage.delete(QUEUE_OVERFLOW_NS, &key).await.unwrap();
         assert!(a.is_some());
         assert!(b.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_keys_limited_returns_oldest_first() {
+        let storage = Arc::new(Storage::new_in_memory());
+        for i in 0..5u128 {
+            storage
+                .insert(
+                    QUEUE_OVERFLOW_NS.to_string(),
+                    overflow_key(1000 + i, &format!("id{i}")),
+                    vec![i as u8],
+                )
+                .await
+                .unwrap();
+        }
+        let keys = storage
+            .list_keys_limited(QUEUE_OVERFLOW_NS, None, 2)
+            .await
+            .unwrap();
+        assert_eq!(keys.len(), 2);
+        assert!(keys[0] < keys[1]);
+        assert_eq!(millis_from_key(&keys[0]), Some(1000));
+    }
+
+    #[tokio::test]
+    async fn spill_offer_rejects_at_high_watermark() {
+        let (tx, _rx) = tokio::sync::mpsc::channel::<Message>(4);
+        let ingress = SpillIngress::new(tx, 4, 50, None);
+        // Fill to 50% (2/4) — next offer at exactly threshold is rejected.
+        assert_eq!(
+            ingress.offer(test_message(), "t"),
+            SpillOffer::Accepted
+        );
+        assert_eq!(
+            ingress.offer(test_message(), "t"),
+            SpillOffer::Accepted
+        );
+        // depth=2, capacity=4 → 50% >= 50 → reject
+        assert_eq!(
+            ingress.offer(test_message(), "t"),
+            SpillOffer::Rejected
+        );
     }
 }

--- a/runtime/plaid/src/metrics/mod.rs
+++ b/runtime/plaid/src/metrics/mod.rs
@@ -47,6 +47,11 @@ impl MetricsHandle {
         self.registry.register(collector)
     }
 
+    /// Borrow the underlying Prometheus registry (for `register_*_with_registry` helpers).
+    pub fn registry(&self) -> &Registry {
+        &self.registry
+    }
+
     pub fn encode(&self) -> Result<String, EncodeError> {
         let metric_families = self.registry.gather();
         let mut buffer = Vec::new();

--- a/runtime/plaid/src/storage/dynamodb/mod.rs
+++ b/runtime/plaid/src/storage/dynamodb/mod.rs
@@ -154,6 +154,7 @@ impl StorageProvider for DynamoDb {
             namespace,
             prefix,
             vec![KEY].as_slice(),
+            None,
         )
         .await?;
 
@@ -175,6 +176,46 @@ impl StorageProvider for DynamoDb {
         Ok(all_keys)
     }
 
+    async fn list_keys_limited(
+        &self,
+        namespace: &str,
+        prefix: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<String>, StorageError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let mut all_keys = vec![];
+        let items = dynamodb_query(
+            &self.client,
+            &self.table_name,
+            namespace,
+            prefix,
+            vec![KEY].as_slice(),
+            Some(limit),
+        )
+        .await?;
+
+        for item in &items {
+            all_keys.push(
+                item.get(KEY)
+                    .ok_or(StorageError::Access(
+                        "Could not list storage contents".to_string(),
+                    ))?
+                    .as_s()
+                    .map_err(|_| {
+                        StorageError::Access("Could not list storage contents".to_string())
+                    })?
+                    .clone(),
+            );
+            if all_keys.len() >= limit {
+                break;
+            }
+        }
+
+        Ok(all_keys)
+    }
+
     async fn fetch_all(
         &self,
         namespace: &str,
@@ -188,6 +229,7 @@ impl StorageProvider for DynamoDb {
             namespace,
             prefix,
             vec!["key", "value"].as_slice(),
+            None,
         )
         .await?;
 
@@ -227,13 +269,15 @@ impl StorageProvider for DynamoDb {
 /// `table_name` - the name of the DynamoDB table  
 /// `namespace` - the namespace we want to query  
 /// `prefix` - [Optional] a prefix that keys must have in order to be returned by this query  
-/// `attributes_to_get` - A list of attributes to get from DynamoDB
+/// `attributes_to_get` - A list of attributes to get from DynamoDB  
+/// `limit` - [Optional] stop after collecting this many items (ascending sort-key order)
 async fn dynamodb_query(
     client: &Client,
     table_name: &str,
     namespace: &str,
     prefix: Option<&str>,
     attributes_to_get: &[&str],
+    limit: Option<usize>,
 ) -> Result<Vec<HashMap<String, AttributeValue>>, StorageError> {
     // This is necessary because the STL is converting a None prefix to an empty string,
     // which would result in passing an empty string to DynamoDB, which then complains.
@@ -282,11 +326,21 @@ async fn dynamodb_query(
     .to_string();
 
     loop {
+        let remaining = limit.map(|l| l.saturating_sub(output.len()));
+        if remaining == Some(0) {
+            break;
+        }
+
         let mut request = client
             .query()
             .consistent_read(true)
             .table_name(table_name)
             .projection_expression(projection_expression.clone());
+
+        if let Some(n) = remaining {
+            // DynamoDB Limit is per-page (before filter); we only need key projection so it matches.
+            request = request.limit(n as i32);
+        }
 
         // Set in the request the key condition expression, expression attribute names and expression attribute values
         // that we had prepared above
@@ -317,6 +371,13 @@ async fn dynamodb_query(
         // Add retrieved items to our growing list
         if let Some(items) = response.items {
             output.extend(items);
+        }
+
+        if let Some(l) = limit {
+            if output.len() >= l {
+                output.truncate(l);
+                break;
+            }
         }
 
         // Set up for next iteration

--- a/runtime/plaid/src/storage/in_memory/mod.rs
+++ b/runtime/plaid/src/storage/in_memory/mod.rs
@@ -68,6 +68,21 @@ impl StorageProvider for InMemoryDb {
         Ok(keys)
     }
 
+    async fn list_keys_limited(
+        &self,
+        namespace: &str,
+        prefix: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<String>, StorageError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let mut keys = self.list_keys(namespace, prefix).await?;
+        keys.sort();
+        keys.truncate(limit);
+        Ok(keys)
+    }
+
     async fn fetch_all(
         &self,
         namespace: &str,

--- a/runtime/plaid/src/storage/mod.rs
+++ b/runtime/plaid/src/storage/mod.rs
@@ -125,6 +125,26 @@ pub trait StorageProvider {
         namespace: &str,
         prefix: Option<&str>,
     ) -> Result<Vec<String>, StorageError>;
+    /// List up to `limit` keys in the namespace (optionally prefix-filtered), in ascending
+    /// sort-key order when the backend supports it (DynamoDB / Sled). Used by overflow
+    /// reload/reaper to avoid loading an entire hot namespace into memory each poll.
+    ///
+    /// Default implementation falls back to `list_keys` + sort + truncate; backends should
+    /// override with a true limited query when possible.
+    async fn list_keys_limited(
+        &self,
+        namespace: &str,
+        prefix: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<String>, StorageError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let mut keys = self.list_keys(namespace, prefix).await?;
+        keys.sort();
+        keys.truncate(limit);
+        Ok(keys)
+    }
     /// Same as list_keys but will return the keys and values. An optional prefix can be provided
     /// but this only applies to the key, values have no host provided filtering.
     async fn fetch_all(
@@ -248,6 +268,18 @@ impl Storage {
         prefix: Option<&str>,
     ) -> Result<Vec<String>, StorageError> {
         self.database.list_keys(namespace, prefix).await
+    }
+
+    /// List up to `limit` keys, ascending order when the backend supports it.
+    pub async fn list_keys_limited(
+        &self,
+        namespace: &str,
+        prefix: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<String>, StorageError> {
+        self.database
+            .list_keys_limited(namespace, prefix, limit)
+            .await
     }
 
     pub async fn fetch_all(

--- a/runtime/plaid/src/storage/mod.rs
+++ b/runtime/plaid/src/storage/mod.rs
@@ -216,6 +216,11 @@ impl Storage {
         })
     }
 
+    /// Return whether the backing store persists data across reboots.
+    pub fn is_persistent(&self) -> bool {
+        self.database.is_persistent()
+    }
+
     pub async fn insert(
         &self,
         namespace: String,

--- a/runtime/plaid/src/storage/sled/mod.rs
+++ b/runtime/plaid/src/storage/sled/mod.rs
@@ -113,6 +113,40 @@ impl StorageProvider for Sled {
         Ok(keys)
     }
 
+    async fn list_keys_limited(
+        &self,
+        namespace: &str,
+        prefix: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<String>, StorageError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let tree = self
+            .db
+            .open_tree(namespace.as_bytes())
+            .map_err(|_| StorageError::Access(format!("Could not open Sled tree {namespace}")))?;
+
+        let key_iter = match prefix {
+            Some(p) => tree.scan_prefix(p),
+            None => tree.iter(),
+        };
+        // Sled iterates in ascending key order — take the first `limit` keys only.
+        let keys: Vec<String> = key_iter
+            .keys()
+            .filter_map(|x| match x {
+                Ok(v) => String::from_utf8(v.to_vec()).ok(),
+                Err(e) => {
+                    error!("Storage Error Listing Keys: {e}");
+                    None
+                }
+            })
+            .take(limit)
+            .collect();
+
+        Ok(keys)
+    }
+
     async fn fetch_all(
         &self,
         namespace: &str,


### PR DESCRIPTION
## Summary

Persist execution-queue messages that would otherwise be dropped, so they survive a queue-full burst or an ungraceful shutdown and are replayed on a later boot instead of being lost.

The feature is gated behind an optional `[executor.queue_overflow]` config block. When absent (the default) behaviour is unchanged. It requires a persistent storage backend and fails fast at startup otherwise.

### What it does
- **Spill-on-full**: the `Queue Full! log dropped!` path now hands the message to a bounded async channel; a dedicated task performs the storage write off the webhook thread, so slow storage cannot block ingress. GET-mode messages (which carry a response channel and cannot be replayed) are excluded.
- **Same-role reload**: webhook-role instances claim and reinject persisted messages in batches, backing off when the queue is full. Claiming is atomic (delete-returns-value), so multiple replicas sharing a backend cannot double-inject.
- **Timeboxed spill-on-shutdown**: the executor-drain join is bounded; if it does not finish (e.g. a wedged executor), still-queued messages are force-persisted before exit.

Messages are gzip-compressed and keyed by creation time for chronological replay, with a per-item size guard, an approximate persisted-count cap, and a max-age reaper.

### Config
```toml
[executor.queue_overflow]
max_persisted = 100000       # cap on persisted messages (default)
max_message_age_secs = 86400 # reaper age (default, 24h)
reload_batch_size = 256      # messages reinjected per poll (default)
```

### Notes / limits
- Cross-instance recovery only applies with a shared backend (e.g. DynamoDB); with a node-local backend each instance sees only its own spilled messages. Documented on the config field.
- Residual gap: a message already mid-execution on a wedged worker (not in the channel) at a hard kill is still unrecoverable, inherent to at-least-once without write-ahead-on-enqueue.
- At-least-once replay means rules should tolerate occasional reprocessing.

## Test plan
- [x] `cargo check` / `cargo clippy` clean (no new warnings)
- [x] Unit tests for key ordering, compression roundtrip, persist/reload roundtrip, GET-mode exclusion, cap enforcement/bypass
- [ ] Exercise end-to-end against a real persistent backend under a full-queue burst
- [ ] Verify shutdown spill + boot reload with a deliberately wedged executor