### PR TITLE
Implement `eth_feeHistory`

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "46.0.0"
+version = "46.1.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3990,7 +3990,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "46.0.0"
+version = "46.1.0"
 dependencies = [
  "aes",
  "alkali",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "46.0.0"
+version = "46.1.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "46.0.0"
+version = "46.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/blockchain/evm/mod.rs
+++ b/runtime/plaid-stl/src/blockchain/evm/mod.rs
@@ -8,8 +8,8 @@ pub use utils::{parse_basic_rpc_response, parse_detailed_rpc_response, EvmError}
 use crate::{
     blockchain::evm::types::{
         BasicRpcResponse, BlockTag, ChainId, DetailedRpcResponse, EstimateGasRequest,
-        EthCallRequest, GetAddressMetadataRequest, GetBlockRequest, GetGasPriceRequest,
-        GetLogsRequest, GetTransactionRequest,
+        EthCallRequest, GetAddressMetadataRequest, GetBlockRequest, GetFeeHistoryRequest,
+        GetGasPriceRequest, GetLogsRequest, GetTransactionRequest,
     },
     PlaidFunctionError,
 };
@@ -417,6 +417,54 @@ pub fn get_block(
 
     let res = unsafe {
         blockchain_evm_get_block(
+            request.as_ptr(),
+            request.len(),
+            return_buffer.as_mut_ptr(),
+            DETAILED_RETURN_BUFFER_SIZE,
+        )
+    };
+
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+
+    match std::str::from_utf8(&return_buffer) {
+        Ok(x) => Ok(serde_json::from_str(x).map_err(|_| PlaidFunctionError::InternalApiError)?),
+        Err(_) => Err(PlaidFunctionError::InternalApiError),
+    }
+}
+
+/// Returns historical fee market data for up to `block_count` blocks ending at `block_tag`.
+/// The response includes base fee per gas and gas-used ratio for each block, and effective
+/// priority fee percentiles when `reward_percentiles` is provided.
+///
+/// See https://www.alchemy.com/docs/chains/abstract/abstract-api-endpoints/eth-fee-history for more details.
+pub fn get_fee_history(
+    chain_id: impl Into<ChainId>,
+    block_count: u16,
+    block_tag: BlockTag,
+    reward_percentiles: Option<Vec<u8>>,
+) -> Result<DetailedRpcResponse, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(blockchain_evm, get_fee_history);
+    }
+
+    let request = GetFeeHistoryRequest {
+        chain_id: chain_id.into(),
+        block_count,
+        block_tag,
+        reward_percentiles,
+    };
+
+    let request =
+        serde_json::to_string(&request).map_err(|_| PlaidFunctionError::ErrorCouldNotSerialize)?;
+
+    let mut return_buffer = vec![0; DETAILED_RETURN_BUFFER_SIZE];
+
+    let res = unsafe {
+        blockchain_evm_get_fee_history(
             request.as_ptr(),
             request.len(),
             return_buffer.as_mut_ptr(),

--- a/runtime/plaid-stl/src/blockchain/evm/types.rs
+++ b/runtime/plaid-stl/src/blockchain/evm/types.rs
@@ -426,8 +426,8 @@ pub struct FeeHistory {
     /// An array of block base fees per blob gas in wei. This includes the next block after the newest of the returned range,
     /// because this value can be derived from the newest block. Zeroes are returned for pre-EIP-4844 blocks.
     #[serde(rename = "baseFeePerBlobGas")]
-    pub base_fee_per_blob_gas: Vec<String>,
+    pub base_fee_per_blob_gas: Option<Vec<String>>,
     /// An array of block blob gas used ratios. These are calculated as the ratio of blobGasUsed and the maximum blob gas per block.
     #[serde(rename = "blobGasUsedRatio")]
-    pub blob_gas_used_ratio: Vec<f64>,
+    pub blob_gas_used_ratio: Option<Vec<f64>>,
 }

--- a/runtime/plaid-stl/src/blockchain/evm/types.rs
+++ b/runtime/plaid-stl/src/blockchain/evm/types.rs
@@ -392,3 +392,42 @@ pub enum BlockTransactions {
     /// Full transaction objects
     Full(Vec<Transaction>),
 }
+
+#[derive(Serialize, Deserialize)]
+pub struct GetFeeHistoryRequest {
+    /// Chain to query
+    pub chain_id: ChainId,
+    /// The number of blocks in the requested range. Must be greater than zero.
+    /// Clients may return fewer blocks if not all blocks are available.
+    pub block_count: u16,
+    /// Block tag to query
+    pub block_tag: BlockTag,
+    /// An optional array of percentile values (between 0 and 100) in ascending order.
+    /// For each block in the requested range, the transactions are sorted by effective priority fee per gas,
+    /// and the corresponding effective priority fee per gas at each percentile is returned.
+    pub reward_percentiles: Option<Vec<u8>>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct FeeHistory {
+    /// The block number of the oldest block in the returned range.
+    #[serde(rename = "oldestBlock")]
+    pub oldest_block: String,
+    /// An array of block base fees per gas in wei. This includes the next block after the newest of the returned range,
+    /// because this value can be derived from the newest block. Zeroes are returned for pre-EIP-1559 blocks.
+    #[serde(rename = "baseFeePerGas")]
+    pub base_fee_per_gas: Vec<String>,
+    /// An array of block gas used ratios. These are calculated as the ratio of gasUsed and gasLimit.
+    #[serde(rename = "gasUsedRatio")]
+    pub gas_used_ratio: Vec<f64>,
+    /// A two-dimensional array of effective priority fees per gas at the requested reward percentiles.
+    /// This property is omitted if rewardPercentiles was not specified.
+    pub reward: Option<Vec<Vec<String>>>,
+    /// An array of block base fees per blob gas in wei. This includes the next block after the newest of the returned range,
+    /// because this value can be derived from the newest block. Zeroes are returned for pre-EIP-4844 blocks.
+    #[serde(rename = "baseFeePerBlobGas")]
+    pub base_fee_per_blob_gas: Vec<String>,
+    /// An array of block blob gas used ratios. These are calculated as the ratio of blobGasUsed and the maximum blob gas per block.
+    #[serde(rename = "blobGasUsedRatio")]
+    pub blob_gas_used_ratio: Vec<f64>,
+}

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "46.0.0"
+version = "46.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/blockchain/evm/mod.rs
+++ b/runtime/plaid/src/apis/blockchain/evm/mod.rs
@@ -301,7 +301,7 @@ impl BlockchainClient<Evm> {
         let node_selector = self.get_node_selector(chain_id)?;
 
         let mut params = vec![
-            Value::String(request.block_count.to_string()),
+            Value::String(format!("0x{:x}", request.block_count)),
             Value::String(request.block_tag.to_string()),
         ];
         if let Some(percentiles) = request.reward_percentiles {

--- a/runtime/plaid/src/apis/blockchain/evm/mod.rs
+++ b/runtime/plaid/src/apis/blockchain/evm/mod.rs
@@ -300,18 +300,18 @@ impl BlockchainClient<Evm> {
 
         let node_selector = self.get_node_selector(chain_id)?;
 
-        let mut params = vec![
+        let percentiles = request
+            .reward_percentiles
+            .unwrap_or_default()
+            .into_iter()
+            .map(|p| Value::Number(Number::from(p as u16)))
+            .collect::<Vec<_>>();
+
+        let params = vec![
             Value::String(format!("0x{:x}", request.block_count)),
             Value::String(request.block_tag.to_string()),
+            Value::Array(percentiles),
         ];
-        if let Some(percentiles) = request.reward_percentiles {
-            let percentiles = percentiles
-                .into_iter()
-                .map(|perc| Value::Number(Number::from(perc as u16)))
-                .collect::<Vec<_>>();
-
-            params.push(Value::Array(percentiles));
-        }
 
         let params = Value::Array(params);
         let request = JsonRpcRequest::new(RpcMethods::GetFeeHistory, Some(params));

--- a/runtime/plaid/src/apis/blockchain/evm/mod.rs
+++ b/runtime/plaid/src/apis/blockchain/evm/mod.rs
@@ -14,9 +14,10 @@ use crate::{
 };
 use plaid_stl::blockchain::evm::types::{
     ChainId, EstimateGasRequest, EthCallRequest, GetAddressMetadataRequest, GetBlockRequest,
-    GetGasPriceRequest, GetLogsRequest, GetTransactionRequest, SendRawTransactionRequest,
+    GetFeeHistoryRequest, GetGasPriceRequest, GetLogsRequest, GetTransactionRequest,
+    SendRawTransactionRequest,
 };
-use serde_json::{json, Value};
+use serde_json::{json, Number, Value};
 use std::sync::Arc;
 
 pub struct Evm;
@@ -282,6 +283,38 @@ impl BlockchainClient<Evm> {
             Value::Bool(request.hydrated_transactions),
         ]);
         let request = JsonRpcRequest::new(RpcMethods::GetBlock, Some(params));
+
+        self.execute_rpc_call(node_selector, chain_id, request, module)
+            .await
+    }
+
+    /// Returns transaction base fee per gas and effective priority fee per gas for the requested block range.
+    pub async fn get_fee_history(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
+        let request = serde_json::from_str::<GetFeeHistoryRequest>(params)
+            .map_err(BlockchainError::SerdeError)?;
+        let chain_id = request.chain_id;
+
+        let node_selector = self.get_node_selector(chain_id)?;
+
+        let mut params = vec![
+            Value::String(request.block_count.to_string()),
+            Value::String(request.block_tag.to_string()),
+        ];
+        if let Some(percentiles) = request.reward_percentiles {
+            let percentiles = percentiles
+                .into_iter()
+                .map(|perc| Value::Number(Number::from(perc as u16)))
+                .collect::<Vec<_>>();
+
+            params.push(Value::Array(percentiles));
+        }
+
+        let params = Value::Array(params);
+        let request = JsonRpcRequest::new(RpcMethods::GetFeeHistory, Some(params));
 
         self.execute_rpc_call(node_selector, chain_id, request, module)
             .await

--- a/runtime/plaid/src/apis/blockchain/evm/utils.rs
+++ b/runtime/plaid/src/apis/blockchain/evm/utils.rs
@@ -14,6 +14,7 @@ pub enum RpcMethods {
     EstimateGas,
     GetLogs,
     GetBlock,
+    GetFeeHistory,
 }
 
 impl Display for RpcMethods {
@@ -29,6 +30,7 @@ impl Display for RpcMethods {
             Self::EstimateGas => write!(f, "eth_estimateGas"),
             Self::GetLogs => write!(f, "eth_getLogs"),
             Self::GetBlock => write!(f, "eth_getBlockByNumber"),
+            Self::GetFeeHistory => write!(f, "eth_getFeeHistory"),
         }
     }
 }

--- a/runtime/plaid/src/apis/blockchain/evm/utils.rs
+++ b/runtime/plaid/src/apis/blockchain/evm/utils.rs
@@ -30,7 +30,7 @@ impl Display for RpcMethods {
             Self::EstimateGas => write!(f, "eth_estimateGas"),
             Self::GetLogs => write!(f, "eth_getLogs"),
             Self::GetBlock => write!(f, "eth_getBlockByNumber"),
-            Self::GetFeeHistory => write!(f, "eth_getFeeHistory"),
+            Self::GetFeeHistory => write!(f, "eth_feeHistory"),
         }
     }
 }

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -637,6 +637,12 @@ impl_new_sub_module_function_with_error_buffer!(blockchain, evm, eth_call, ALLOW
 impl_new_sub_module_function_with_error_buffer!(blockchain, evm, gas_price, ALLOW_IN_TEST_MODE);
 impl_new_sub_module_function_with_error_buffer!(blockchain, evm, get_logs, ALLOW_IN_TEST_MODE);
 impl_new_sub_module_function_with_error_buffer!(blockchain, evm, get_block, ALLOW_IN_TEST_MODE);
+impl_new_sub_module_function_with_error_buffer!(
+    blockchain,
+    evm,
+    get_fee_history,
+    ALLOW_IN_TEST_MODE
+);
 
 impl_new_sub_module_function_with_error_buffer!(
     blockchain,
@@ -988,6 +994,7 @@ define_api_functions! {
         "blockchain_evm_gas_price"               => blockchain_evm_gas_price,
         "blockchain_evm_get_logs"                => blockchain_evm_get_logs,
         "blockchain_evm_get_block"               => blockchain_evm_get_block,
+        "blockchain_evm_get_fee_history"         => blockchain_evm_get_fee_history,
 
         "blockchain_solana_send_signed_transaction"        => blockchain_solana_send_signed_transaction,
         "blockchain_solana_get_balance"                    => blockchain_solana_get_balance,


### PR DESCRIPTION
This pull request adds support for retrieving EVM fee history data via the `eth_feeHistory` RPC method. The main changes include introducing the `get_fee_history` function and related types, updating the API to expose this functionality, and incrementing the crate versions.

### Ethereum Fee History Support

* Added the `get_fee_history` function to `runtime/plaid-stl/src/blockchain/evm/mod.rs` to query historical fee market data, including base fee per gas, gas-used ratios, and priority fee percentiles.
* Introduced `GetFeeHistoryRequest` and `FeeHistory` types in `runtime/plaid-stl/src/blockchain/evm/types.rs` to structure requests and responses for fee history queries.
* Updated the EVM API in `runtime/plaid/src/apis/blockchain/evm/mod.rs` to expose an async `get_fee_history` method, parsing parameters and constructing the appropriate JSON-RPC request.
* Registered the new `GetFeeHistory` RPC method and mapped it to the `eth_getFeeHistory` string in `runtime/plaid/src/apis/blockchain/evm/utils.rs`.
* Added the required host function and API function wiring for `get_fee_history` in `runtime/plaid/src/functions/api.rs`.
### Version Updates

* Bumped the crate versions for `plaid` and `plaid_stl` from `46.0.0` to `46.1.0` to reflect the new feature.