### PR TITLE
Record module failures

### DIFF
--- a/runtime/plaid/src/executor/metrics.rs
+++ b/runtime/plaid/src/executor/metrics.rs
@@ -38,8 +38,14 @@ impl ModuleExecutionMetrics {
         )
         .expect("valid metric definition");
 
-        let module_failures = IntCounterVec::new(Opts::new("name", "help"), &["module"])
-            .expect("valid metric definition");
+        let module_failures = IntCounterVec::new(
+            Opts::new(
+                "plaid_module_failures",
+                "Total number of failures per module",
+            ),
+            &["module"],
+        )
+        .expect("valid metric definition");
 
         handle
             .register(Box::new(computation_percentage.clone()))

--- a/runtime/plaid/src/executor/metrics.rs
+++ b/runtime/plaid/src/executor/metrics.rs
@@ -10,7 +10,7 @@ use crate::metrics::MetricsHandle;
 use super::thread_pools::ExecutionThreadPools;
 use super::Message;
 
-/// Histograms for per-module execution stats, updated after each successful run.
+/// Metrics for per-module execution stats
 pub struct ModuleExecutionMetrics {
     computation_percentage: HistogramVec,
     execution_duration_seconds: HistogramVec,
@@ -40,8 +40,8 @@ impl ModuleExecutionMetrics {
 
         let module_failures = IntCounterVec::new(
             Opts::new(
-                "plaid_module_failures",
-                "Total number of failures per module",
+                "plaid_module_failures_total",
+                "Total number of module executions that returned a non-zero status",
             ),
             &["module"],
         )

--- a/runtime/plaid/src/executor/metrics.rs
+++ b/runtime/plaid/src/executor/metrics.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crossbeam_channel::Sender;
 use prometheus::core::{Collector, Desc};
 use prometheus::proto::MetricFamily;
-use prometheus::{GaugeVec, HistogramOpts, HistogramVec, IntGaugeVec, Opts};
+use prometheus::{GaugeVec, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts};
 
 use crate::metrics::MetricsHandle;
 
@@ -14,6 +14,7 @@ use super::Message;
 pub struct ModuleExecutionMetrics {
     computation_percentage: HistogramVec,
     execution_duration_seconds: HistogramVec,
+    module_failures: IntCounterVec,
 }
 
 impl ModuleExecutionMetrics {
@@ -37,16 +38,23 @@ impl ModuleExecutionMetrics {
         )
         .expect("valid metric definition");
 
+        let module_failures = IntCounterVec::new(Opts::new("name", "help"), &["module"])
+            .expect("valid metric definition");
+
         handle
             .register(Box::new(computation_percentage.clone()))
             .expect("expected unique collector");
         handle
             .register(Box::new(execution_duration_seconds.clone()))
             .expect("expected unique collector");
+        handle
+            .register(Box::new(module_failures.clone()))
+            .expect("expected unique collector");
 
         Self {
             computation_percentage,
             execution_duration_seconds,
+            module_failures,
         }
     }
 
@@ -62,6 +70,10 @@ impl ModuleExecutionMetrics {
         self.execution_duration_seconds
             .with_label_values(&[module])
             .observe(duration.as_secs_f64());
+    }
+
+    pub fn record_module_failure(&self, module: &str) {
+        self.module_failures.with_label_values(&[module]).inc();
     }
 }
 

--- a/runtime/plaid/src/executor/mod.rs
+++ b/runtime/plaid/src/executor/mod.rs
@@ -550,6 +550,10 @@ fn process_message_with_module(
     let error = match entrypoint.call(&mut store) {
         Ok(n) => {
             if n != 0 {
+                if let Some(metrics) = &module_execution_metrics {
+                    metrics.record_module_failure(&module.name);
+                }
+
                 Some(ModuleExecutionError::ModuleError(
                     env.as_ref(&store)
                         .execution_error_context


### PR DESCRIPTION
This pull request adds new metrics to track module failures in the executor, improving observability for error monitoring. The main change is the introduction of a new `IntCounterVec` metric to count failures per module, along with the necessary code to increment this metric when a module fails during execution.

**Metrics enhancements:**

* Added a new `IntCounterVec` named `module_failures` to the `ModuleExecutionMetrics` struct to count the number of failures per module.
* Registered the new `module_failures` metric with the metrics handle during initialization.
* Implemented a new method `record_module_failure` in `ModuleExecutionMetrics` to increment the failure counter for a specific module.
* Updated the executor logic in `process_message_with_module` to record a module failure using the new metric whenever a module returns a non-zero value (indicating an error).