### PR TITLE
github: add GitHub API function to submit pull request reviews

### DIFF
--- a/runtime/plaid-stl/src/github/pull_request.rs
+++ b/runtime/plaid-stl/src/github/pull_request.rs
@@ -169,7 +169,7 @@ pub struct ApprovePullRequestRequest {
     /// The name of the repository without the `.git` extension. The name is not case sensitive.
     pub repo: String,
     /// The number of the pull request to approve.
-    pub pull_number: u64,
+    pub number: u32,
     /// An optional comment to leave alongside the approval.
     pub body: Option<String>,
 }
@@ -183,7 +183,7 @@ pub struct ApprovePullRequestRequest {
 /// * `client_id` - Selects which configured GitHub client to use (supports multiple clients).
 /// * `owner` - The account or organization that owns the repository.
 /// * `repo` - The name of the repository.
-/// * `pull_number` - The number of the pull request to approve.
+/// * `number` - The number of the pull request to approve.
 /// * `body` - An optional comment to leave alongside the approval.
 ///
 /// ## Returns
@@ -193,7 +193,7 @@ pub fn approve_pull_request(
     client_id: impl Display,
     owner: impl Display,
     repo: impl Display,
-    pull_number: u64,
+    number: u32,
     body: Option<impl Display>,
 ) -> Result<String, PlaidFunctionError> {
     extern "C" {
@@ -204,7 +204,7 @@ pub fn approve_pull_request(
     let request = ApprovePullRequestRequest {
         owner: owner.to_string(),
         repo: repo.to_string(),
-        pull_number,
+        number,
         body: body.map(|b| b.to_string()),
     };
 

--- a/runtime/plaid-stl/src/github/pull_request.rs
+++ b/runtime/plaid-stl/src/github/pull_request.rs
@@ -187,7 +187,7 @@ pub struct ApprovePullRequestRequest {
 /// * `body` - An optional comment to leave alongside the approval.
 ///
 /// ## Returns
-/// * `Ok(String)` with the raw JSON of the created review, or
+/// * `Ok(())` if the review was successfully submitted, or
 /// * `Err(PlaidFunctionError)` if the request fails.
 pub fn approve_pull_request(
     client_id: impl Display,
@@ -195,11 +195,10 @@ pub fn approve_pull_request(
     repo: impl Display,
     number: u32,
     body: Option<impl Display>,
-) -> Result<String, PlaidFunctionError> {
+) -> Result<(), PlaidFunctionError> {
     extern "C" {
-        new_host_function_with_error_buffer!(github, approve_pull_request);
+        new_host_function!(github, approve_pull_request);
     }
-    const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
 
     let request = ApprovePullRequestRequest {
         owner: owner.to_string(),
@@ -214,14 +213,8 @@ pub fn approve_pull_request(
     };
     let request = serde_json::to_string(&wrapped).unwrap();
 
-    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
     let res = unsafe {
-        github_approve_pull_request(
-            request.as_bytes().as_ptr(),
-            request.as_bytes().len(),
-            return_buffer.as_mut_ptr(),
-            RETURN_BUFFER_SIZE,
-        )
+        github_approve_pull_request(request.as_bytes().as_ptr(), request.as_bytes().len())
     };
 
     // There was an error with the Plaid system. Maybe the API is not
@@ -230,10 +223,7 @@ pub fn approve_pull_request(
         return Err(res.into());
     }
 
-    return_buffer.truncate(res as usize);
-    // This should be safe because unless the Plaid runtime is expressly trying
-    // to mess with us, this came from a String in the API module.
-    Ok(String::from_utf8(return_buffer).unwrap())
+    Ok(())
 }
 
 /// Request to fetch pull requests from a repository.

--- a/runtime/plaid-stl/src/github/pull_request.rs
+++ b/runtime/plaid-stl/src/github/pull_request.rs
@@ -161,23 +161,94 @@ pub fn pull_request_request_reviewers(
     Ok(())
 }
 
-/// Request to approve a pull request.
+/// The review action to submit as part of a pull request review.
+///
+/// GitHub requires a non-empty `body` alongside `RequestChanges` and `Comment`;
+/// it is optional for `Approve`.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum PullRequestReviewEvent {
+    /// Approve the pull request.
+    #[serde(rename = "APPROVE")]
+    Approve,
+    /// Request changes on the pull request. Requires a `body`.
+    #[serde(rename = "REQUEST_CHANGES")]
+    RequestChanges,
+    /// Leave a review comment without approving or requesting changes. Requires a `body`.
+    #[serde(rename = "COMMENT")]
+    Comment,
+}
+
+/// Request to submit a review on a pull request.
 #[derive(Serialize, Deserialize)]
-pub struct ApprovePullRequestRequest {
+pub struct SubmitPullRequestReviewRequest {
     /// The account owner of the repository. The name is not case sensitive.
     pub owner: String,
     /// The name of the repository without the `.git` extension. The name is not case sensitive.
     pub repo: String,
-    /// The number of the pull request to approve.
+    /// The number of the pull request to review.
     pub number: u32,
-    /// An optional comment to leave alongside the approval.
+    /// The review action to submit.
+    pub event: PullRequestReviewEvent,
+    /// A comment to leave alongside the review. Required unless `event` is `Approve`.
     pub body: Option<String>,
 }
 
-/// Approves a pull request by submitting an `APPROVE` review on it.
+/// Submits a review on a pull request.
 ///
 /// See the [GitHub API docs](https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#create-a-review-for-a-pull-request)
 /// for more details.
+///
+/// ## Arguments
+/// * `client_id` - Selects which configured GitHub client to use (supports multiple clients).
+/// * `owner` - The account or organization that owns the repository.
+/// * `repo` - The name of the repository.
+/// * `number` - The number of the pull request to review.
+/// * `event` - The review action to submit.
+/// * `body` - A comment to leave alongside the review. Required unless `event` is `Approve`.
+///
+/// ## Returns
+/// * `Ok(())` if the review was successfully submitted, or
+/// * `Err(PlaidFunctionError)` if the request fails.
+pub fn submit_pull_request_review(
+    client_id: impl Display,
+    owner: impl Display,
+    repo: impl Display,
+    number: u32,
+    event: PullRequestReviewEvent,
+    body: Option<impl Display>,
+) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(github, submit_pull_request_review);
+    }
+
+    let request = SubmitPullRequestReviewRequest {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        number,
+        event,
+        body: body.map(|b| b.to_string()),
+    };
+
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: request,
+    };
+    let request = serde_json::to_string(&wrapped).unwrap();
+
+    let res = unsafe {
+        github_submit_pull_request_review(request.as_bytes().as_ptr(), request.as_bytes().len())
+    };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    Ok(())
+}
+
+/// Approves a pull request by submitting an `APPROVE` review on it.
 ///
 /// ## Arguments
 /// * `client_id` - Selects which configured GitHub client to use (supports multiple clients).
@@ -196,34 +267,14 @@ pub fn approve_pull_request(
     number: u32,
     body: Option<impl Display>,
 ) -> Result<(), PlaidFunctionError> {
-    extern "C" {
-        new_host_function!(github, approve_pull_request);
-    }
-
-    let request = ApprovePullRequestRequest {
-        owner: owner.to_string(),
-        repo: repo.to_string(),
+    submit_pull_request_review(
+        client_id,
+        owner,
+        repo,
         number,
-        body: body.map(|b| b.to_string()),
-    };
-
-    let wrapped = GithubApiWrapper {
-        client_id: client_id.to_string(),
-        params: request,
-    };
-    let request = serde_json::to_string(&wrapped).unwrap();
-
-    let res = unsafe {
-        github_approve_pull_request(request.as_bytes().as_ptr(), request.as_bytes().len())
-    };
-
-    // There was an error with the Plaid system. Maybe the API is not
-    // configured.
-    if res < 0 {
-        return Err(res.into());
-    }
-
-    Ok(())
+        PullRequestReviewEvent::Approve,
+        body,
+    )
 }
 
 /// Request to fetch pull requests from a repository.

--- a/runtime/plaid-stl/src/github/pull_request.rs
+++ b/runtime/plaid-stl/src/github/pull_request.rs
@@ -161,6 +161,81 @@ pub fn pull_request_request_reviewers(
     Ok(())
 }
 
+/// Request to approve a pull request.
+#[derive(Serialize, Deserialize)]
+pub struct ApprovePullRequestRequest {
+    /// The account owner of the repository. The name is not case sensitive.
+    pub owner: String,
+    /// The name of the repository without the `.git` extension. The name is not case sensitive.
+    pub repo: String,
+    /// The number of the pull request to approve.
+    pub pull_number: u64,
+    /// An optional comment to leave alongside the approval.
+    pub body: Option<String>,
+}
+
+/// Approves a pull request by submitting an `APPROVE` review on it.
+///
+/// See the [GitHub API docs](https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#create-a-review-for-a-pull-request)
+/// for more details.
+///
+/// ## Arguments
+/// * `client_id` - Selects which configured GitHub client to use (supports multiple clients).
+/// * `owner` - The account or organization that owns the repository.
+/// * `repo` - The name of the repository.
+/// * `pull_number` - The number of the pull request to approve.
+/// * `body` - An optional comment to leave alongside the approval.
+///
+/// ## Returns
+/// * `Ok(String)` with the raw JSON of the created review, or
+/// * `Err(PlaidFunctionError)` if the request fails.
+pub fn approve_pull_request(
+    client_id: impl Display,
+    owner: impl Display,
+    repo: impl Display,
+    pull_number: u64,
+    body: Option<impl Display>,
+) -> Result<String, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(github, approve_pull_request);
+    }
+    const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
+
+    let request = ApprovePullRequestRequest {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        pull_number,
+        body: body.map(|b| b.to_string()),
+    };
+
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: request,
+    };
+    let request = serde_json::to_string(&wrapped).unwrap();
+
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+    let res = unsafe {
+        github_approve_pull_request(
+            request.as_bytes().as_ptr(),
+            request.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    Ok(String::from_utf8(return_buffer).unwrap())
+}
+
 /// Request to fetch pull requests from a repository.
 ///
 /// Represents the top-level parameters needed to query pull requests

--- a/runtime/plaid/src/apis/github/pull_requests.rs
+++ b/runtime/plaid/src/apis/github/pull_requests.rs
@@ -1,6 +1,6 @@
 use plaid_stl::github::{
-    AddLabelsRequest, CreatePullRequestRequest, GetPullRequestOptions, GetPullRequestRequest,
-    GithubApiWrapper, PullRequestRequestReviewers,
+    AddLabelsRequest, ApprovePullRequestRequest, CreatePullRequestRequest, GetPullRequestOptions,
+    GetPullRequestRequest, GithubApiWrapper, PullRequestRequestReviewers,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -62,6 +62,46 @@ impl Github {
                 } else if status == 422 {
                     warn!("Some of the reviewers or teams are not collaborators on this repository. Context: [{owner}/{repo}/{pull_number}]. Users: [{}] and teams: [{}]", request.params.reviewers.join(", "), request.params.team_reviewers.join(", "));
                     Ok(false)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Approves a pull request by submitting an `APPROVE` review on it.
+    pub async fn approve_pull_request(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
+        let request: GithubApiWrapper<ApprovePullRequestRequest> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let owner = self.validate_org(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
+        let pull_number = request.params.pull_number;
+
+        info!("Approving pull request [{owner}/{repo}/{pull_number}] on behalf of {module}");
+
+        let mut request_body = json!({ "event": "APPROVE" });
+        if let Some(body) = request.params.body {
+            request_body["body"] = json!(body);
+        }
+
+        let address = format!("/repos/{owner}/{repo}/pulls/{pull_number}/reviews");
+
+        match self
+            .make_generic_post_request(&request.client_id, address, request_body, module)
+            .await
+        {
+            Ok((status, Ok(body))) => {
+                if status == 200 {
+                    Ok(body)
                 } else {
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
                         status,

--- a/runtime/plaid/src/apis/github/pull_requests.rs
+++ b/runtime/plaid/src/apis/github/pull_requests.rs
@@ -1,6 +1,7 @@
 use plaid_stl::github::{
-    AddLabelsRequest, ApprovePullRequestRequest, CreatePullRequestRequest, GetPullRequestOptions,
-    GetPullRequestRequest, GithubApiWrapper, PullRequestRequestReviewers,
+    AddLabelsRequest, CreatePullRequestRequest, GetPullRequestOptions, GetPullRequestRequest,
+    GithubApiWrapper, PullRequestRequestReviewers, PullRequestReviewEvent,
+    SubmitPullRequestReviewRequest,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -73,31 +74,33 @@ impl Github {
         }
     }
 
-    /// Approves a pull request by submitting an `APPROVE` review on it.
-    pub async fn approve_pull_request(
+    /// Submits a review on a pull request.
+    pub async fn submit_pull_request_review(
         &self,
         params: &str,
         module: Arc<PlaidModule>,
     ) -> Result<u32, ApiError> {
         #[derive(Serialize)]
         struct SubmitReview {
-            event: &'static str,
+            event: PullRequestReviewEvent,
             #[serde(skip_serializing_if = "Option::is_none")]
             body: Option<String>,
         }
 
-        let request: GithubApiWrapper<ApprovePullRequestRequest> =
+        let request: GithubApiWrapper<SubmitPullRequestReviewRequest> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
         let owner = self.validate_org(&request.params.owner)?;
         let repo = self.validate_repository_name(&request.params.repo)?;
         let number = request.params.number;
+        let event = request.params.event;
+        self.validate_review_body(event, request.params.body.as_deref())?;
 
-        info!("Approving pull request [{owner}/{repo}/{number}] on behalf of {module}");
+        info!("Submitting {event:?} review on pull request [{owner}/{repo}/{number}] on behalf of {module}");
 
         let address = format!("/repos/{owner}/{repo}/pulls/{number}/reviews");
         let request_body = SubmitReview {
-            event: "APPROVE",
+            event,
             body: request.params.body,
         };
 

--- a/runtime/plaid/src/apis/github/pull_requests.rs
+++ b/runtime/plaid/src/apis/github/pull_requests.rs
@@ -84,16 +84,16 @@ impl Github {
 
         let owner = self.validate_org(&request.params.owner)?;
         let repo = self.validate_repository_name(&request.params.repo)?;
-        let pull_number = request.params.pull_number;
+        let number = request.params.number;
 
-        info!("Approving pull request [{owner}/{repo}/{pull_number}] on behalf of {module}");
+        info!("Approving pull request [{owner}/{repo}/{number}] on behalf of {module}");
 
         let mut request_body = json!({ "event": "APPROVE" });
         if let Some(body) = request.params.body {
             request_body["body"] = json!(body);
         }
 
-        let address = format!("/repos/{owner}/{repo}/pulls/{pull_number}/reviews");
+        let address = format!("/repos/{owner}/{repo}/pulls/{number}/reviews");
 
         match self
             .make_generic_post_request(&request.client_id, address, request_body, module)

--- a/runtime/plaid/src/apis/github/pull_requests.rs
+++ b/runtime/plaid/src/apis/github/pull_requests.rs
@@ -78,7 +78,14 @@ impl Github {
         &self,
         params: &str,
         module: Arc<PlaidModule>,
-    ) -> Result<String, ApiError> {
+    ) -> Result<u32, ApiError> {
+        #[derive(Serialize)]
+        struct SubmitReview {
+            event: &'static str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            body: Option<String>,
+        }
+
         let request: GithubApiWrapper<ApprovePullRequestRequest> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
@@ -88,20 +95,19 @@ impl Github {
 
         info!("Approving pull request [{owner}/{repo}/{number}] on behalf of {module}");
 
-        let mut request_body = json!({ "event": "APPROVE" });
-        if let Some(body) = request.params.body {
-            request_body["body"] = json!(body);
-        }
-
         let address = format!("/repos/{owner}/{repo}/pulls/{number}/reviews");
+        let request_body = SubmitReview {
+            event: "APPROVE",
+            body: request.params.body,
+        };
 
         match self
             .make_generic_post_request(&request.client_id, address, request_body, module)
             .await
         {
-            Ok((status, Ok(body))) => {
+            Ok((status, Ok(_))) => {
                 if status == 200 {
-                    Ok(body)
+                    Ok(0)
                 } else {
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
                         status,

--- a/runtime/plaid/src/apis/github/validators.rs
+++ b/runtime/plaid/src/apis/github/validators.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use plaid_stl::github::PullRequestReviewEvent;
+
 use crate::apis::ApiError;
 
 use super::{GitHubError, Github};
@@ -107,5 +109,22 @@ impl Github {
     pub fn validate_repo_id<'a>(&self, repo_id: &'a str) -> Result<&'a str, ApiError> {
         // Repo IDs are positive integers
         self.validate_pint(repo_id)
+    }
+
+    /// Ensure a pull request review has a body when GitHub requires one.
+    /// A non-empty `body` is mandatory for `RequestChanges` and `Comment`;
+    /// it is optional for `Approve`.
+    pub fn validate_review_body(
+        &self,
+        event: PullRequestReviewEvent,
+        body: Option<&str>,
+    ) -> Result<(), ApiError> {
+        match (event, body) {
+            (PullRequestReviewEvent::Approve, _) => Ok(()),
+            (_, Some(body)) if !body.is_empty() => Ok(()),
+            (_, _) => Err(ApiError::GitHubError(GitHubError::InvalidInput(format!(
+                "a non-empty body is required for review event {event:?}"
+            )))),
+        }
     }
 }

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -436,6 +436,7 @@ impl_new_function!(
     pull_request_request_reviewers,
     DISALLOW_IN_TEST_MODE
 );
+impl_new_function_with_error_buffer!(github, approve_pull_request, DISALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, get_weekly_commit_count, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, get_reference, ALLOW_IN_TEST_MODE);
 impl_new_function!(github, create_reference, DISALLOW_IN_TEST_MODE);
@@ -891,6 +892,7 @@ define_api_functions! {
         "github_delete_deploy_key"                         => github_delete_deploy_key,
         "github_create_deploy_key"                         => github_create_deploy_key,
         "github_pull_request_request_reviewers"            => github_pull_request_request_reviewers,
+        "github_approve_pull_request"                      => github_approve_pull_request,
         "github_require_signed_commits"                    => github_require_signed_commits,
         "github_get_weekly_commit_count"                   => github_get_weekly_commit_count,
         "github_add_repo_to_team"                          => github_add_repo_to_team,

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -436,7 +436,7 @@ impl_new_function!(
     pull_request_request_reviewers,
     DISALLOW_IN_TEST_MODE
 );
-impl_new_function!(github, approve_pull_request, DISALLOW_IN_TEST_MODE);
+impl_new_function!(github, submit_pull_request_review, DISALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, get_weekly_commit_count, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, get_reference, ALLOW_IN_TEST_MODE);
 impl_new_function!(github, create_reference, DISALLOW_IN_TEST_MODE);
@@ -892,7 +892,7 @@ define_api_functions! {
         "github_delete_deploy_key"                         => github_delete_deploy_key,
         "github_create_deploy_key"                         => github_create_deploy_key,
         "github_pull_request_request_reviewers"            => github_pull_request_request_reviewers,
-        "github_approve_pull_request"                      => github_approve_pull_request,
+        "github_submit_pull_request_review"                => github_submit_pull_request_review,
         "github_require_signed_commits"                    => github_require_signed_commits,
         "github_get_weekly_commit_count"                   => github_get_weekly_commit_count,
         "github_add_repo_to_team"                          => github_add_repo_to_team,

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -436,7 +436,7 @@ impl_new_function!(
     pull_request_request_reviewers,
     DISALLOW_IN_TEST_MODE
 );
-impl_new_function_with_error_buffer!(github, approve_pull_request, DISALLOW_IN_TEST_MODE);
+impl_new_function!(github, approve_pull_request, DISALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, get_weekly_commit_count, ALLOW_IN_TEST_MODE);
 impl_new_function_with_error_buffer!(github, get_reference, ALLOW_IN_TEST_MODE);
 impl_new_function!(github, create_reference, DISALLOW_IN_TEST_MODE);


### PR DESCRIPTION
## Summary

This PR introduces a new GitHub API function that enables Plaid modules to submit a review on a pull request.

## Changes

- **STL**: Added `PullRequestReviewEvent` enum, `SubmitPullRequestReviewRequest` struct, `submit_pull_request_review`, and `approve_pull_request` wrapper in `runtime/plaid-stl/src/github/pull_request.rs`.
- **Runtime**: Implemented `submit_pull_request_review` method in the GitHub API handler in `runtime/plaid/src/apis/github/pull_requests.rs`
- **Validation**: Added `validate_review_body` in `runtime/plaid/src/apis/github/validators.rs` to ensure non-empty `body` is provided when `event` is `RequestChanges` or `Comment`
- **Function Registration**: Added function mapping and implementation in `runtime/plaid/src/functions/api.rs`

## Rationale

This functionality is needed to enable automated approval of pull requests from Plaid modules. The implementation uses the GitHub Pull Request Reviews API endpoint `/repos/{owner}/{repo}/pulls/{number}/reviews` with caller-specified `event` and `body`.