### PR TITLE
Add PostMode for webhooks

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "46.3.0"
+version = "46.4.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -4032,7 +4032,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "46.3.0"
+version = "46.4.0"
 dependencies = [
  "aes",
  "alkali",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "46.3.0"
+version = "46.4.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "46.3.0"
+version = "46.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/lib.rs
+++ b/runtime/plaid-stl/src/lib.rs
@@ -35,6 +35,7 @@ pub enum PlaidFunctionError {
     Unknown,
     FailedToLogBack,
     LogbackBudgetExhausted,
+    InvalidHttpResponseStatus,
 }
 
 impl Error for PlaidFunctionError {}
@@ -59,6 +60,7 @@ impl core::fmt::Display for PlaidFunctionError {
             PlaidFunctionError::Unknown => write!(f, "An unknown error occurred. This can happen if the Plaid runtime is newer than the STL this rule was compiled against."),
             PlaidFunctionError::FailedToLogBack => write!(f, "Failed to dispatch log message: the receiver is disconnected or at capacity"),
             PlaidFunctionError::LogbackBudgetExhausted => write!(f, "Logback budget exhausted"),
+            PlaidFunctionError::InvalidHttpResponseStatus => write!(f, "Invalid HTTP response status"),
         }
     }
 }
@@ -82,6 +84,7 @@ impl From<i32> for PlaidFunctionError {
             -14 => Self::TimeoutElapsed,
             -15 => Self::FailedToLogBack,
             -16 => Self::LogbackBudgetExhausted,
+            -17 => Self::InvalidHttpResponseStatus,
             _ => Self::Unknown,
         }
     }
@@ -90,6 +93,26 @@ impl From<i32> for PlaidFunctionError {
 impl From<PlaidFunctionError> for i32 {
     fn from(e: PlaidFunctionError) -> Self {
         e as i32
+    }
+}
+
+/// A response returned by a rule serving a webhook request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WebhookResponse {
+    /// The HTTP status to return to the webhook sender.
+    pub status: u16,
+    /// The response body to return to the webhook sender.
+    pub body: String,
+}
+
+impl WebhookResponse {
+    /// Construct a webhook response. The runtime validates that `status` is a
+    /// valid HTTP status code when the response is served.
+    pub fn new(status: u16, body: impl Into<String>) -> Self {
+        Self {
+            status,
+            body: body.into(),
+        }
     }
 }
 
@@ -291,6 +314,82 @@ macro_rules! entrypoint_with_source_and_response {
             match main(log, source) {
                 Ok(Some(response)) => {
                     let response_bytes = response.as_bytes().to_vec();
+                    unsafe {
+                        set_response(response_bytes.as_ptr(), response_bytes.len() as u32);
+                    };
+                    0
+                }
+                Ok(None) => 0,
+                Err(e) => {
+                    set_error_context(&e.to_string());
+                    1
+                }
+            }
+        }
+    };
+}
+
+/// Generate an entrypoint for a rule that returns a body and HTTP status for a
+/// webhook request. The rule's `main` function must return
+/// `Result<Option<WebhookResponse>, _>`.
+#[macro_export]
+macro_rules! entrypoint_with_source_and_webhook_response {
+    () => {
+        use plaid_stl::{plaid::set_error_context, set_panic_hook};
+
+        #[no_mangle]
+        pub unsafe extern "C" fn entrypoint() -> i32 {
+            extern "C" {
+                fn fetch_data_and_source(data_buffer: *mut u8, buffer_size: u32) -> i32;
+                fn set_response_status(status: u32) -> i32;
+                fn set_response(data_buffer: *const u8, buffer_size: u32);
+            }
+
+            let buffer_size = fetch_data_and_source(vec![].as_mut_ptr(), 0);
+            let buffer_size = if buffer_size < 4 {
+                return -3;
+            } else {
+                buffer_size as u32
+            };
+
+            let mut data_buffer = vec![0; buffer_size as usize];
+
+            let copied_size = fetch_data_and_source(data_buffer.as_mut_ptr(), buffer_size);
+            let copied_size = if copied_size < 4 {
+                return -4;
+            } else {
+                copied_size as u32
+            };
+
+            if copied_size != buffer_size {
+                return -1;
+            }
+
+            let log_length = u32::from_le_bytes(data_buffer[0..4].try_into().unwrap()) as usize;
+
+            let log = &data_buffer[4..4 + log_length];
+            let log = match String::from_utf8(log.to_vec()) {
+                Ok(s) => s,
+                Err(_) => return -2,
+            };
+
+            let log_source = &data_buffer[4 + log_length..];
+            let source = match serde_json::from_slice::<LogSource>(log_source) {
+                Ok(s) => s,
+                Err(_) => return -2,
+            };
+
+            set_panic_hook!();
+
+            match main(log, source) {
+                Ok(Some(response)) => {
+                    let status_result = unsafe { set_response_status(response.status.into()) };
+                    if status_result != 0 {
+                        set_error_context("Invalid HTTP response status");
+                        return 1;
+                    }
+
+                    let response_bytes = response.body.as_bytes().to_vec();
                     unsafe {
                         set_response(response_bytes.as_ptr(), response_bytes.len() as u32);
                     };

--- a/runtime/plaid-stl/src/plaid/mod.rs
+++ b/runtime/plaid-stl/src/plaid/mod.rs
@@ -216,6 +216,20 @@ pub fn get_response() -> Result<String, PlaidFunctionError> {
     }
 }
 
+/// Set the HTTP status returned when this rule serves a webhook response.
+pub fn set_response_status(status: u16) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        fn set_response_status(status: u32) -> i32;
+    }
+
+    let result = unsafe { set_response_status(status.into()) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(result.into())
+    }
+}
+
 /// Give the runtime more context about an error encountered during execution
 pub fn set_error_context(context: &str) {
     extern "C" {

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "46.3.0"
+version = "46.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -22,6 +22,7 @@ use executor::metrics::{ModuleExecutionMetrics, QueueMetrics};
 use executor::*;
 use plaid::metrics::MetricsHandle;
 use plaid_stl::messages::LogSource;
+use serde::Deserialize;
 use storage::Storage;
 use tokio::{
     signal::{
@@ -69,6 +70,7 @@ impl std::error::Error for Errors {}
 
 enum PostResponseAction {
     Static(String),
+    Slack(Option<String>),
     Rule {
         name: String,
         receiver: tokio::sync::oneshot::Receiver<Option<ResponseMessage>>,
@@ -76,6 +78,22 @@ enum PostResponseAction {
         timeout_seconds: u64,
     },
     MissingRule(String),
+}
+
+#[derive(Deserialize)]
+struct SlackWebhookRequest {
+    #[serde(rename = "type")]
+    request_type: String,
+    challenge: Option<String>,
+}
+
+fn slack_challenge(body: &[u8]) -> Option<String> {
+    let request: SlackWebhookRequest = serde_json::from_slice(body).ok()?;
+    if request.request_type == "url_verification" {
+        request.challenge
+    } else {
+        None
+    }
 }
 
 async fn post_handler(
@@ -139,6 +157,9 @@ async fn post_handler(
     let post_response = match webhook_configuration.post_mode.as_ref() {
         Some(post_mode) => match &post_mode.response_mode {
             PostResponseMode::Static(body) => Some(PostResponseAction::Static(body.clone())),
+            PostResponseMode::Slack => {
+                Some(PostResponseAction::Slack(slack_challenge(&message.data)))
+            }
             PostResponseMode::Rule(name) => match modules.get(name) {
                 Some(rule) => {
                     let (response_sender, response_receiver) = tokio::sync::oneshot::channel();
@@ -185,6 +206,10 @@ async fn post_handler(
         Some(PostResponseAction::Static(body)) => {
             return warp::reply::with_status(body, StatusCode::OK).into_response();
         }
+        Some(PostResponseAction::Slack(Some(challenge))) => {
+            return warp::reply::with_status(challenge, StatusCode::OK).into_response();
+        }
+        Some(PostResponseAction::Slack(None)) => {}
         Some(PostResponseAction::MissingRule(name)) => {
             error!("Got a POST request to {webhook} but the response rule [{name}] does not exist");
             return warp::reply::with_status(warp::reply(), StatusCode::BAD_GATEWAY)
@@ -210,7 +235,9 @@ async fn post_handler(
 
             match tokio::time::timeout(Duration::from_secs(timeout_seconds), receiver).await {
                 Ok(Ok(Some(response))) => match StatusCode::from_u16(response.code) {
-                    Ok(status) => return warp::reply::with_status(response.body, status).into_response(),
+                    Ok(status) => {
+                        return warp::reply::with_status(response.body, status).into_response()
+                    }
                     Err(e) => {
                         error!("Response rule [{name}] for webhook {webhook} returned an invalid status: {e}");
                         return warp::reply::with_status(warp::reply(), StatusCode::BAD_GATEWAY)

--- a/runtime/plaid/src/bin/plaid.rs
+++ b/runtime/plaid/src/bin/plaid.rs
@@ -8,8 +8,8 @@ use plaid::{
     apis::ApiError,
     cache::Cache,
     config::{
-        CachingMode, ConfigurationWithRoles, GetMode, ResponseMode, WebhookConfig,
-        WebhookServerConfiguration,
+        CachingMode, ConfigurationWithRoles, GetMode, PostResponseMode, ResponseMode,
+        WebhookConfig, WebhookServerConfiguration,
     },
     loader::PlaidModule,
     logging::Logger,
@@ -41,13 +41,13 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use crossbeam_channel::TrySendError;
 use warp::{
     http::{HeaderMap, StatusCode},
-    path, Filter,
+    path, Filter, Reply,
 };
 
 #[derive(Debug)]
@@ -67,77 +67,177 @@ impl std::fmt::Display for Errors {
 
 impl std::error::Error for Errors {}
 
+enum PostResponseAction {
+    Static(String),
+    Rule {
+        name: String,
+        receiver: tokio::sync::oneshot::Receiver<Option<ResponseMessage>>,
+        message: Message,
+        timeout_seconds: u64,
+    },
+    MissingRule(String),
+}
+
 async fn post_handler(
     webhook: String,
     body: impl Stream<Item = Result<impl Buf, warp::Error>> + Unpin + Send + Sync,
     headers: HeaderMap,
     webhooks: HashMap<String, WebhookConfig>,
+    modules: Arc<HashMap<String, Arc<PlaidModule>>>,
     exec: Arc<Executor>,
-) -> impl warp::Reply {
+) -> warp::reply::Response {
     // The status code we'll return. Defaults to 200, but is bumped to 429 if the
     // execution system's bounded queue is full so the sender can back off and retry.
     let mut status = StatusCode::OK;
-    // If this is a webhook that is configured
-    if let Some(webhook_configuration) = webhooks.get(&webhook) {
-        // If the webhook has a label, use that as the source, otherwise use the webhook address
-        let source = match webhook_configuration.label {
-            Some(ref label) => LogSource::WebhookPost(label.to_string()),
-            None => LogSource::WebhookPost(webhook.to_string()),
-        };
 
-        let logbacks_allowed = webhook_configuration.logbacks_allowed.clone();
+    // If this is a webhook that is configured get the configuration for it,
+    // otherwise return an empty 200 to avoid leaking information about what webhooks are configured.
+    let Some(webhook_configuration) = webhooks.get(&webhook) else {
+        return warp::reply::with_status(warp::reply(), status).into_response();
+    };
 
-        // Read the body with size limit
-        let full_body = match read_body_with_limit(body, webhook_configuration.max_body_size).await
-        {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                error!("Error reading body for webhook: {webhook}: {e}");
-                // We still return a 200 to avoid leaking information
-                return Box::new(warp::reply::with_status(warp::reply(), StatusCode::OK));
-            }
-        };
+    // If the webhook has a label, use that as the source, otherwise use the webhook address
+    let source = match webhook_configuration.label {
+        Some(ref label) => LogSource::WebhookPost(label.to_string()),
+        None => LogSource::WebhookPost(webhook.to_string()),
+    };
 
-        // Create the message we're going to send into the execution system.
-        let mut message = Message::new(
-            webhook_configuration.log_type.to_owned(),
-            full_body,
-            source,
-            logbacks_allowed,
-        );
+    let logbacks_allowed = webhook_configuration.logbacks_allowed.clone();
 
-        for requested_header in webhook_configuration.headers.iter() {
-            // TODO: Investigate if this should be get_all?
-            // Without this we don't support receiving multiple headers with the same name
-            // I don't know if this is an issue or not, practically, or if there are security implications.
-            if let Some(value) = headers.get(requested_header) {
-                message
-                    .headers
-                    .insert(requested_header.to_string(), value.as_bytes().to_vec());
-            }
+    // Read the body with size limit
+    let full_body = match read_body_with_limit(body, webhook_configuration.max_body_size).await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            error!("Error reading body for webhook: {webhook}: {e}");
+            // We still return a 200 to avoid leaking information
+            return warp::reply::with_status(warp::reply(), StatusCode::OK).into_response();
         }
+    };
 
-        // Webhook exists, buffer log
-        if let Err(e) = exec.execute_webhook_message(message) {
-            match e {
-                TrySendError::Full(_) => {
-                    error!(
-                        "Queue Full! [{}] log dropped!",
-                        webhook_configuration.log_type
-                    );
-                    // The bounded queue to the execution system is full: signal
-                    // backpressure to the caller instead of silently dropping the log.
-                    status = StatusCode::TOO_MANY_REQUESTS;
-                }
-                // TODO: Have this actually cause Plaid to exit
-                TrySendError::Disconnected(_) => panic!(
-                    "The execution system is no longer accepting messages. Nothing can continue."
-                ),
-            }
+    // Create the message we're going to send into the execution system.
+    let mut message = Message::new(
+        webhook_configuration.log_type.to_owned(),
+        full_body,
+        source,
+        logbacks_allowed,
+    );
+
+    for requested_header in webhook_configuration.headers.iter() {
+        // TODO: Investigate if this should be get_all?
+        // Without this we don't support receiving multiple headers with the same name
+        // I don't know if this is an issue or not, practically, or if there are security implications.
+        if let Some(value) = headers.get(requested_header) {
+            message
+                .headers
+                .insert(requested_header.to_string(), value.as_bytes().to_vec());
         }
     }
+
+    // Prepare the post response before moving the normal message into its
+    // configured execution queue. The response action is handled only after
+    // normal fan-out has been accepted.
+    let post_response = match webhook_configuration.post_mode.as_ref() {
+        Some(post_mode) => match &post_mode.response_mode {
+            PostResponseMode::Static(body) => Some(PostResponseAction::Static(body.clone())),
+            PostResponseMode::Rule(name) => match modules.get(name) {
+                Some(rule) => {
+                    let (response_sender, response_receiver) = tokio::sync::oneshot::channel();
+                    let mut response_message = message.create_duplicate();
+                    response_message.response_sender = Some(response_sender);
+                    response_message.module = Some(rule.clone());
+                    Some(PostResponseAction::Rule {
+                        name: name.clone(),
+                        receiver: response_receiver,
+                        message: response_message,
+                        timeout_seconds: post_mode.response_timeout_seconds,
+                    })
+                }
+                None => Some(PostResponseAction::MissingRule(name.clone())),
+            },
+        },
+        None => None,
+    };
+
+    // Webhook exists, buffer log for normal fan-out.
+    if let Err(e) = exec.execute_webhook_message(message) {
+        match e {
+            TrySendError::Full(_) => {
+                error!(
+                    "Queue Full! [{}] log dropped!",
+                    webhook_configuration.log_type
+                );
+                // The bounded queue to the execution system is full: signal
+                // backpressure to the caller instead of silently dropping the log.
+                status = StatusCode::TOO_MANY_REQUESTS;
+            }
+            // TODO: Have this actually cause Plaid to exit
+            TrySendError::Disconnected(_) => panic!(
+                "The execution system is no longer accepting messages. Nothing can continue."
+            ),
+        }
+    }
+
+    if status != StatusCode::OK {
+        return warp::reply::with_status(warp::reply(), status).into_response();
+    }
+
+    match post_response {
+        Some(PostResponseAction::Static(body)) => {
+            return warp::reply::with_status(body, StatusCode::OK).into_response();
+        }
+        Some(PostResponseAction::MissingRule(name)) => {
+            error!("Got a POST request to {webhook} but the response rule [{name}] does not exist");
+            return warp::reply::with_status(warp::reply(), StatusCode::BAD_GATEWAY)
+                .into_response();
+        }
+        Some(PostResponseAction::Rule {
+            name,
+            receiver,
+            message,
+            timeout_seconds,
+        }) => {
+            if let Err(e) = exec.execute_webhook_message(message) {
+                match e {
+                    TrySendError::Full(_) => {
+                        error!("Queue Full! Response rule [{name}] for webhook {webhook} was not run");
+                        return warp::reply::with_status(warp::reply(), StatusCode::TOO_MANY_REQUESTS).into_response();
+                    }
+                    TrySendError::Disconnected(_) => panic!(
+                        "The execution system is no longer accepting messages. Nothing can continue."
+                    ),
+                }
+            }
+
+            match tokio::time::timeout(Duration::from_secs(timeout_seconds), receiver).await {
+                Ok(Ok(Some(response))) => match StatusCode::from_u16(response.code) {
+                    Ok(status) => return warp::reply::with_status(response.body, status).into_response(),
+                    Err(e) => {
+                        error!("Response rule [{name}] for webhook {webhook} returned an invalid status: {e}");
+                        return warp::reply::with_status(warp::reply(), StatusCode::BAD_GATEWAY)
+                            .into_response();
+                    }
+                },
+                Ok(Ok(None)) => {
+                    warn!("Response rule [{name}] for webhook {webhook} did not return a response");
+                    return warp::reply::with_status(warp::reply(), StatusCode::BAD_GATEWAY)
+                        .into_response();
+                }
+                Ok(Err(_)) => {
+                    error!("Response rule [{name}] for webhook {webhook} failed before returning a response");
+                    return warp::reply::with_status(warp::reply(), StatusCode::BAD_GATEWAY)
+                        .into_response();
+                }
+                Err(_) => {
+                    error!("Response rule [{name}] for webhook {webhook} timed out after {timeout_seconds} seconds");
+                    return warp::reply::with_status(warp::reply(), StatusCode::GATEWAY_TIMEOUT)
+                        .into_response();
+                }
+            }
+        }
+        None => {}
+    }
     // Empty response, with the status code determined above.
-    Box::new(warp::reply::with_status(warp::reply(), status))
+    warp::reply::with_status(warp::reply(), status).into_response()
 }
 
 /// Read the body of a request with a maximum size limit
@@ -483,11 +583,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let webhooks = config.webhooks.clone();
             let exec = executor.clone();
+            let post_modules = modules_by_name.clone();
             let post_route = warp::post()
                 .and(path!("webhook" / String))
                 .and(warp::body::stream())
                 .and(warp::header::headers_cloned())
                 .and(with(webhooks))
+                .and(with(post_modules))
                 .and(with(exec.clone()))
                 .then(post_handler);
 

--- a/runtime/plaid/src/config.rs
+++ b/runtime/plaid/src/config.rs
@@ -70,7 +70,7 @@ pub struct GetMode {
 
 /// How a webhook should respond to a POST request.
 ///
-/// Unlike [`GetMode`], POST responses are never cached. A rule response is
+/// Unlike [`GetMode`], POST responses are never cached. Rule responses are
 /// generated synchronously while normal webhook fan-out continues separately.
 #[derive(Clone)]
 pub enum PostResponseMode {
@@ -78,6 +78,8 @@ pub enum PostResponseMode {
     Rule(String),
     /// Return a static response body.
     Static(String),
+    /// Handle Slack URL verification requests in the runtime.
+    Slack,
 }
 
 /// Configuration for an optional POST response.
@@ -311,9 +313,13 @@ where
     D: de::Deserializer<'de>,
 {
     let mode = String::deserialize(deserializer)?;
+    if matches!(mode.as_str(), "Slack" | "slack") {
+        return Ok(PostResponseMode::Slack);
+    }
+
     let (mode, data) = mode.split_once(':').ok_or_else(|| {
         serde::de::Error::custom(
-            "Must provide a post response mode and context, for example 'rule:module.wasm'",
+            "Must provide a post response mode and context, for example 'rule:module.wasm', or use 'slack'",
         )
     })?;
 
@@ -327,7 +333,7 @@ where
         "Rule" | "rule" => Ok(PostResponseMode::Rule(data.to_owned())),
         "Static" | "static" => Ok(PostResponseMode::Static(data.to_owned())),
         x => Err(serde::de::Error::custom(format!(
-            "{x} is an unknown post response mode. Must be 'rule' or 'static'"
+            "{x} is an unknown post response mode. Must be 'rule', 'static', or 'slack'"
         ))),
     }
 }
@@ -370,6 +376,25 @@ mod tests {
         );
 
         assert!(config.is_err());
+    }
+
+    #[test]
+    fn deserializes_slack_post_mode() {
+        let config: WebhookConfig = toml::from_str(
+            r#"
+            log_type = "slack"
+            headers = []
+
+            [post_mode]
+            response_mode = "slack"
+            "#,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            config.post_mode.unwrap().response_mode,
+            PostResponseMode::Slack
+        ));
     }
 }
 

--- a/runtime/plaid/src/config.rs
+++ b/runtime/plaid/src/config.rs
@@ -68,6 +68,32 @@ pub struct GetMode {
     pub response_mode: ResponseMode,
 }
 
+/// How a webhook should respond to a POST request.
+///
+/// Unlike [`GetMode`], POST responses are never cached. A rule response is
+/// generated synchronously while normal webhook fan-out continues separately.
+#[derive(Clone)]
+pub enum PostResponseMode {
+    /// Respond by running a Plaid WASM module.
+    Rule(String),
+    /// Return a static response body.
+    Static(String),
+}
+
+/// Configuration for an optional POST response.
+#[derive(Deserialize, Clone)]
+pub struct PostMode {
+    /// How the webhook should respond to a POST request.
+    #[serde(deserialize_with = "post_response_mode_deserializer")]
+    pub response_mode: PostResponseMode,
+    /// Maximum time to wait for a response rule before returning a gateway timeout.
+    #[serde(
+        default = "default_post_response_timeout_seconds",
+        deserialize_with = "validate_post_response_timeout_seconds"
+    )]
+    pub response_timeout_seconds: u64,
+}
+
 /// Configuration for a particular webhook within a WebhookServer to accept
 /// logs and send them to a logging channel
 #[derive(Deserialize, Clone)]
@@ -85,6 +111,8 @@ pub struct WebhookConfig {
     pub max_body_size: usize,
     /// See GetMode
     pub get_mode: Option<GetMode>,
+    /// See PostMode. When unset, POST requests retain the legacy empty 200 response.
+    pub post_mode: Option<PostMode>,
     /// An optional label for the webhook. If this is populated, it will be
     /// passed as the source to to the modules instead of the webhook address.
     /// You may want to do this to reduce the secrets modules have access to.
@@ -183,6 +211,23 @@ fn default_webhook_body_size() -> usize {
     1024 * 256
 }
 
+fn default_post_response_timeout_seconds() -> u64 {
+    10
+}
+
+fn validate_post_response_timeout_seconds<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = u64::deserialize(deserializer)?;
+    if value == 0 {
+        return Err(serde::de::Error::custom(
+            "Webhook POST response timeout must not be 0",
+        ));
+    }
+    Ok(value)
+}
+
 /// Validate that the webhook body size limit is not zero.
 fn validate_webhook_body_size<'de, D>(deserializer: D) -> Result<usize, D::Error>
 where
@@ -258,6 +303,74 @@ where
             )))
         }
     })
+}
+
+/// Deserialized for a webhook's POST response mode.
+fn post_response_mode_deserializer<'de, D>(deserializer: D) -> Result<PostResponseMode, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    let mode = String::deserialize(deserializer)?;
+    let (mode, data) = mode.split_once(':').ok_or_else(|| {
+        serde::de::Error::custom(
+            "Must provide a post response mode and context, for example 'rule:module.wasm'",
+        )
+    })?;
+
+    if data.is_empty() {
+        return Err(serde::de::Error::custom(
+            "Must provide context for the post response mode",
+        ));
+    }
+
+    match mode {
+        "Rule" | "rule" => Ok(PostResponseMode::Rule(data.to_owned())),
+        "Static" | "static" => Ok(PostResponseMode::Static(data.to_owned())),
+        x => Err(serde::de::Error::custom(format!(
+            "{x} is an unknown post response mode. Must be 'rule' or 'static'"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_rule_post_mode() {
+        let config: WebhookConfig = toml::from_str(
+            r#"
+            log_type = "example"
+            headers = []
+
+            [post_mode]
+            response_mode = "rule:response.wasm"
+            "#,
+        )
+        .unwrap();
+
+        let post_mode = config.post_mode.unwrap();
+        assert_eq!(post_mode.response_timeout_seconds, 10);
+        assert!(matches!(
+            post_mode.response_mode,
+            PostResponseMode::Rule(ref name) if name == "response.wasm"
+        ));
+    }
+
+    #[test]
+    fn rejects_get_only_post_mode() {
+        let config = toml::from_str::<WebhookConfig>(
+            r#"
+            log_type = "example"
+            headers = []
+
+            [post_mode]
+            response_mode = "facebook:token"
+            "#,
+        );
+
+        assert!(config.is_err());
+    }
 }
 
 /// Configure Plaid with config file and secrets read from arguments (or use default values).

--- a/runtime/plaid/src/executor/mod.rs
+++ b/runtime/plaid/src/executor/mod.rs
@@ -30,14 +30,13 @@ use std::sync::{Arc, Weak};
 use std::thread::{self, JoinHandle};
 use std::time::Instant;
 
-/// When a rule is used to generate a response to a GET request, this structure
-/// is what is passed from the executor to the async webhook runtime.
+/// When a rule is used to generate a webhook response, this structure is what
+/// is passed from the executor to the async webhook runtime.
 #[derive(Serialize, Deserialize)]
 pub struct ResponseMessage {
-    /// Currently unused because there is no API to set this and how it should
-    /// treated by the higher level cache is still to be defined.
+    /// The HTTP status selected by the response rule.
     pub code: u16,
-    /// The data the rule intends to return in the serviced GET request.
+    /// The data the rule intends to return in the serviced webhook request.
     pub body: String,
 }
 
@@ -206,8 +205,13 @@ pub struct Env {
     /// Memory for host-guest communication
     pub memory: Option<Memory>,
     // A special value that can be filled to leave a string response available after
-    // the module has execute. Generally this is used for GET mode responses.
+    // the module has executed. Generally this is used for webhook responses.
     pub response: Option<String>,
+    /// The HTTP status selected by a response rule.
+    pub response_status: Option<u16>,
+    /// An invalid status supplied by a rule. This turns the invocation into a
+    /// response failure even when the rule ignores the host function result.
+    pub invalid_response_status: Option<u32>,
     // Context about error encountered by the module during its execution
     pub execution_error_context: Option<String>,
     /// Available for immediate logback during normal operation; `None` during shutdown drain.
@@ -358,6 +362,8 @@ fn prepare_for_execution(
         external_logging_system: els.clone(),
         memory: None,
         response,
+        response_status: None,
+        invalid_response_status: None,
         execution_error_context: None,
         immediate_sender,
         delayed_log_sender,
@@ -433,26 +439,12 @@ fn update_persistent_response(
     plaid_module: &Arc<PlaidModule>,
     env: &FunctionEnv<Env>,
     mut store: &mut Store,
-    response_sender: Option<OneShotSender<Option<ResponseMessage>>>,
 ) -> Result<(), ExecutorError> {
     match (
         env.as_mut(&mut store).response.clone(),
         &plaid_module.persistent_response,
     ) {
         (None, _) => {
-            // We need to check if there might be a tokio task serving a GET
-            // that is waiting on this response. If the rule doesn't give one, we
-            // need to ensure we send a None to wake up that task and complete it
-            if let Some(sender) = response_sender {
-                if let Err(_) = sender.send(None) {
-                    error!("[{}] was servicing a request that returned no response and failed to send!", plaid_module.name);
-                } else {
-                    error!(
-                        "[{}] was servicing a request that returned no response!",
-                        plaid_module.name
-                    );
-                }
-            }
             // There was no response to save
             return Ok(());
         }
@@ -469,17 +461,6 @@ fn update_persistent_response(
                 match pr.data.write() {
                     Ok(mut data) => {
                         *data = Some(response.clone());
-                        if let Some(sender) = response_sender {
-                            if let Err(_) = sender.send(Some(ResponseMessage {
-                                code: 200,
-                                body: response,
-                            })) {
-                                error!(
-                                    "[{}] was servicing a request but sending the response failed!",
-                                    plaid_module.name
-                                );
-                            }
-                        }
                         info!("{} updated its persistent response", plaid_module.name);
                         Ok(())
                     }
@@ -619,8 +600,30 @@ fn process_message_with_module(
         );
     }
 
+    if let Some(invalid_status) = env.as_ref(&store).invalid_response_status {
+        els.log_module_error(
+            module.name.clone(),
+            format!("Invalid HTTP response status: {invalid_status}"),
+            message.data.clone(),
+        )?;
+        return Ok(());
+    }
+
+    if let Some(sender) = message.response_sender {
+        let response = env.as_ref(&store).response.clone().map(|body| ResponseMessage {
+            code: env.as_ref(&store).response_status.unwrap_or(200),
+            body,
+        });
+        if sender.send(response).is_err() {
+            error!(
+                "[{}] was servicing a request but sending the response failed!",
+                module.name
+            );
+        }
+    }
+
     // Update the persistent response
-    if let Err(e) = update_persistent_response(&module, &env, &mut store, message.response_sender) {
+    if let Err(e) = update_persistent_response(&module, &env, &mut store) {
         let _ = els.log_module_error(
             module.name.clone(),
             format!("Failed to update persistent response: {e}"),

--- a/runtime/plaid/src/executor/mod.rs
+++ b/runtime/plaid/src/executor/mod.rs
@@ -605,6 +605,9 @@ fn process_message_with_module(
     }
 
     if let Some(invalid_status) = env.as_ref(&store).invalid_response_status {
+        if let Some(sender) = message.response_sender {
+            let _ = sender.send(None);
+        }
         els.log_module_error(
             module.name.clone(),
             format!("Invalid HTTP response status: {invalid_status}"),

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -821,6 +821,7 @@ define_api_functions! {
         // so are broken out into their own module.
         "get_response"             => super::response::get_response,
         "set_response"             => super::response::set_response,
+        "set_response_status"      => super::response::set_response_status,
         "set_error_context"        => super::internal::set_error_context,
         "print_debug_string"       => super::internal::print_debug_string,
         "storage_insert"           => super::storage::insert,

--- a/runtime/plaid/src/functions/mod.rs
+++ b/runtime/plaid/src/functions/mod.rs
@@ -34,6 +34,7 @@ pub enum FunctionErrors {
     TimeoutElapsed = -14,
     FailedToLogBack = -15,
     LogbackBudgetExhausted = -16,
+    InvalidHttpResponseStatus = -17,
 }
 
 #[derive(Debug)]

--- a/runtime/plaid/src/functions/response.rs
+++ b/runtime/plaid/src/functions/response.rs
@@ -82,3 +82,21 @@ pub fn set_response(
     let data = env.data_mut();
     data.response = Some(message);
 }
+
+/// Set the HTTP status to return when a module is serving a webhook response.
+pub fn set_response_status(mut env: FunctionEnvMut<Env>, status: u32) -> i32 {
+    let status = match u16::try_from(status) {
+        Ok(status) if (100..=599).contains(&status) => status,
+        _ => {
+            error!(
+                "{}: Invalid HTTP response status: {status}",
+                env.data().module.name
+            );
+            env.as_mut().data_mut().invalid_response_status = Some(status);
+            return FunctionErrors::InvalidHttpResponseStatus as i32;
+        }
+    };
+
+    env.as_mut().data_mut().response_status = Some(status);
+    0
+}


### PR DESCRIPTION
Add optional post_mode support while preserving normal webhook fan-out.
 
Allow response rules to return an HTTP body and status, with timeout and
failure handling. Add WebhookResponse and a matching STL entrypoint macro.

Key design decision to be discussed: a webhook POST still triggers a normal fan-out to the normal log processing channels. The optional dedicated responder is on top.

Co-authored-by: Codex CLI (GPT-5) <noreply@openai.com>