### PR TITLE
Make dependency check always run and add workflow concurrency grouping

### DIFF
--- a/.github/workflows/DependencyCheck.yaml
+++ b/.github/workflows/DependencyCheck.yaml
@@ -3,6 +3,10 @@ name: Dependency Minimum Age Check
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   runtime:
     runs-on: ubuntu-latest

--- a/.github/workflows/DependencyCheck.yaml
+++ b/.github/workflows/DependencyCheck.yaml
@@ -19,6 +19,7 @@ jobs:
           filters: |
             relevant:
               - "runtime/Cargo.lock"
+              - ".github/workflows/DependencyCheck.yaml"
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/DependencyCheck.yaml
+++ b/.github/workflows/DependencyCheck.yaml
@@ -12,9 +12,6 @@ jobs:
       pull-requests: read
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
       - name: Check for relevant changes
         id: filter
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -22,7 +19,9 @@ jobs:
           filters: |
             relevant:
               - "runtime/Cargo.lock"
-              - ".github/workflows/DependencyCheck.yaml"
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
         if: steps.filter.outputs.relevant == 'true'

--- a/.github/workflows/DependencyCheck.yaml
+++ b/.github/workflows/DependencyCheck.yaml
@@ -9,6 +9,7 @@ jobs:
 
     permissions:
       contents: read
+      pull-requests: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/DependencyCheck.yaml
+++ b/.github/workflows/DependencyCheck.yaml
@@ -2,9 +2,6 @@ name: Dependency Minimum Age Check
 
 on:
   pull_request:
-    paths:
-      - "runtime/Cargo.lock"
-      - ".github/workflows/DependencyCheck.yaml"
 
 jobs:
   runtime:
@@ -15,15 +12,26 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check for relevant changes
+        id: filter
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            relevant:
+              - "runtime/Cargo.lock"
+              - ".github/workflows/DependencyCheck.yaml"
 
       - name: Install Rust
+        if: steps.filter.outputs.relevant == 'true'
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: stable
           override: true
 
-      - uses: timweri/cargo-oxidate@b57953d025609b3a2d4e4563ccb216b1f3ffe0fb # v0.1.5
+      - uses: timweri/cargo-oxidate@49d33667fb3a743822022e05c60f911ee255e0f7 # v0.1.8
+        if: steps.filter.outputs.relevant == 'true'
         with:
           cargo-lock-path: runtime/Cargo.lock
           min-age-days: 14

--- a/.github/workflows/DockerChecks.yml
+++ b/.github/workflows/DockerChecks.yml
@@ -7,7 +7,7 @@ on:
     branches:  "**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/DockerChecks.yml
+++ b/.github/workflows/DockerChecks.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:  "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/DynamoDBForRules.yml
+++ b/.github/workflows/DynamoDBForRules.yml
@@ -7,7 +7,7 @@ on:
     branches:  "**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/DynamoDBForRules.yml
+++ b/.github/workflows/DynamoDBForRules.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:  "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/DynamoDBForRules.yml
+++ b/.github/workflows/DynamoDBForRules.yml
@@ -7,7 +7,7 @@ on:
     branches:  "**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/FeatureCheck.yml
+++ b/.github/workflows/FeatureCheck.yml
@@ -7,7 +7,7 @@ on:
     branches: "**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/FeatureCheck.yml
+++ b/.github/workflows/FeatureCheck.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/FeatureCheck.yml
+++ b/.github/workflows/FeatureCheck.yml
@@ -7,7 +7,7 @@ on:
     branches: "**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/Integration.yml
+++ b/.github/workflows/Integration.yml
@@ -7,7 +7,7 @@ on:
     branches:  "**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/Integration.yml
+++ b/.github/workflows/Integration.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:  "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/Integration.yml
+++ b/.github/workflows/Integration.yml
@@ -7,7 +7,7 @@ on:
     branches:  "**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/LocalDevCheck.yml
+++ b/.github/workflows/LocalDevCheck.yml
@@ -7,7 +7,7 @@ on:
     branches: "**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/LocalDevCheck.yml
+++ b/.github/workflows/LocalDevCheck.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/LocalDevCheck.yml
+++ b/.github/workflows/LocalDevCheck.yml
@@ -7,7 +7,7 @@ on:
     branches: "**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
**Problem 1: The dependency check CI blocks PRs when the relevant files are not modified**

Instead of skipping dependency check trigger when relevant files are not affected, we always run the workflow, but decide to skip within the workflow logic.

**Problem 2: When you push a new commit to a PR, CI runs for previous commits still run, wasting resources**

Add concurrency grouping for PR-based workflow runs. For branch pushes, the group ID falls back to `run_id` so it doesn't affect branch pushes.