### PR TITLE
Parse Slack Email in Slack profile

### DIFF
--- a/runtime/plaid-stl/src/slack/mod.rs
+++ b/runtime/plaid-stl/src/slack/mod.rs
@@ -531,6 +531,7 @@ pub struct SlackUser {
 
 #[derive(Serialize, Deserialize)]
 pub struct SlackUserProfile {
+    pub email: String,
     pub status_text: String,
     pub status_emoji: String,
 }

--- a/runtime/plaid-stl/src/slack/mod.rs
+++ b/runtime/plaid-stl/src/slack/mod.rs
@@ -531,7 +531,7 @@ pub struct SlackUser {
 
 #[derive(Serialize, Deserialize)]
 pub struct SlackUserProfile {
-    pub email: String,
+    pub email: Option<String>,
     pub status_text: String,
     pub status_emoji: String,
 }


### PR DESCRIPTION
The `email` field is available here:
- https://docs.slack.dev/reference/methods/users.info/
- https://docs.slack.dev/reference/methods/users.profile.get/
- https://docs.slack.dev/reference/methods/users.lookupByEmail/


Marked as optional because of this: <img width="805" height="190" alt="Screenshot 2026-07-29 at 16 02 20" src="https://github.com/user-attachments/assets/0559c9a6-fe5b-4f42-bcee-9a196fa9b60d" />