### PR TITLE
Add runtime APIs to create and revoke a GH installation token

### DIFF
--- a/modules/.cargo/config.toml
+++ b/modules/.cargo/config.toml
@@ -1,2 +1,3 @@
 [build]
 target = "wasm32-unknown-unknown"
+rustflags = ["-C", "link-arg=--allow-undefined"]

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "46.4.0"
+version = "46.6.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -4032,7 +4032,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "46.4.0"
+version = "46.6.0"
 dependencies = [
  "aes",
  "alkali",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "46.4.0"
+version = "46.6.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "46.4.0"
+version = "46.6.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/github/code.rs
+++ b/runtime/plaid-stl/src/github/code.rs
@@ -1,0 +1,78 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{github::GithubApiWrapper, PlaidFunctionError};
+
+/// Parameters sent to the runtime when creating a GitHub App installation access token.
+/// See https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#create-an-installation-access-token-for-an-app
+#[derive(Serialize, Deserialize)]
+pub struct CreateInstallationAccessTokenParams {
+    pub installation_id: u64,
+    #[serde(flatten)]
+    pub body: CreateInstallationAccessTokenBody,
+}
+
+/// Body sent to the GitHub API when creating an installation access token.
+#[derive(Serialize, Deserialize)]
+pub struct CreateInstallationAccessTokenBody {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repositories: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "repository_ids")]
+    pub repository_ids: Option<Vec<u64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct InstallationAccessTokenCreationResponse {
+    pub token: String,
+    pub expires_at: String,
+}
+
+/// Create an installation access token for a GitHub App installation.
+/// See https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#create-an-installation-access-token-for-an-app for more details
+/// Note that this endpoint is only available to GitHub Apps, and not to OAuth apps or personal access tokens.
+///
+/// # Arguments
+/// * `client_id` - The client ID of the GitHub App making the request.
+/// * `params` - The parameters for creating the installation access token.
+pub fn create_installation_access_token(
+    client_id: impl Display,
+    params: &CreateInstallationAccessTokenParams,
+) -> Result<InstallationAccessTokenCreationResponse, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(github, create_installation_access_token);
+    }
+    const RETURN_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
+
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params,
+    };
+
+    let request = serde_json::to_string(&wrapped).unwrap();
+
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let res = unsafe {
+        github_create_installation_access_token(
+            request.as_bytes().as_ptr(),
+            request.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    return_buffer.truncate(res as usize);
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    let response = String::from_utf8(return_buffer).unwrap();
+    Ok(serde_json::from_str(&response).map_err(|_| PlaidFunctionError::InternalApiError)?)
+}

--- a/runtime/plaid-stl/src/github/code.rs
+++ b/runtime/plaid-stl/src/github/code.rs
@@ -13,6 +13,13 @@ pub struct CreateInstallationAccessTokenParams {
     pub body: CreateInstallationAccessTokenBody,
 }
 
+/// Parameters sent to the runtime when revoking a GitHub App installation access token.
+/// See https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28#revoke-an-installation-access-token
+#[derive(Serialize, Deserialize)]
+pub struct RevokeInstallationAccessTokenParams {
+    pub token: String,
+}
+
 /// Body sent to the GitHub API when creating an installation access token.
 #[derive(Serialize, Deserialize)]
 pub struct CreateInstallationAccessTokenBody {
@@ -75,4 +82,37 @@ pub fn create_installation_access_token(
     // to mess with us, this came from a String in the API module.
     let response = String::from_utf8(return_buffer).unwrap();
     Ok(serde_json::from_str(&response).map_err(|_| PlaidFunctionError::InternalApiError)?)
+}
+
+/// Revoke a GitHub App installation access token.
+/// See https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28#revoke-an-installation-access-token for more details
+/// The token to revoke must be provided because this endpoint authenticates with the token
+/// that is being deleted.
+///
+/// # Arguments
+/// * `token` - The installation access token to revoke.
+pub fn revoke_installation_access_token(token: impl Display) -> Result<(), PlaidFunctionError> {
+    extern "C" {
+        new_host_function!(github, revoke_installation_access_token);
+    }
+
+    let params = RevokeInstallationAccessTokenParams {
+        token: token.to_string(),
+    };
+
+    let request = serde_json::to_string(&params).unwrap();
+    let res = unsafe {
+        github_revoke_installation_access_token(
+            request.as_bytes().as_ptr(),
+            request.as_bytes().len(),
+        )
+    };
+
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    Ok(())
 }

--- a/runtime/plaid-stl/src/github/mod.rs
+++ b/runtime/plaid-stl/src/github/mod.rs
@@ -1,4 +1,5 @@
 mod actions;
+mod code;
 mod copilot;
 mod deploy_keys;
 mod enterprise;
@@ -17,6 +18,7 @@ mod team;
 mod types;
 
 pub use actions::*;
+pub use code::*;
 pub use copilot::*;
 pub use deploy_keys::*;
 pub use enterprise::*;

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "46.4.0"
+version = "46.6.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/github/code.rs
+++ b/runtime/plaid/src/apis/github/code.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use plaid_stl::github::{
     CreateInstallationAccessTokenParams, GithubApiWrapper, InstallationAccessTokenCreationResponse,
-    SearchCodeParams,
+    RevokeInstallationAccessTokenParams, SearchCodeParams,
 };
 
 use super::Github;
@@ -145,6 +145,43 @@ impl Github {
                     let response: InstallationAccessTokenCreationResponse =
                         serde_json::from_str(&body).map_err(|_| ApiError::BadRequest)?;
                     Ok(serde_json::to_string(&response).map_err(|_| ApiError::BadRequest)?)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Revoke an installation access token for a GitHub App installation.
+    /// See https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28#revoke-an-installation-access-token for more details
+    /// The token to revoke must be provided because this endpoint authenticates with the token
+    /// that is being deleted. A standalone reqwest client is used so that no configured GitHub
+    /// client is required.
+    pub async fn revoke_installation_access_token(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<u32, ApiError> {
+        let request: RevokeInstallationAccessTokenParams =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let token = &request.token;
+
+        info!("Revoking installation access token on behalf of {module}");
+
+        let address = "https://api.github.com/installation/token".to_string();
+
+        match self
+            .make_delete_request_with_token(address, None::<&String>, token.clone(), module)
+            .await
+        {
+            Ok((status, Ok(_))) => {
+                if status == 204 {
+                    Ok(0)
                 } else {
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
                         status,

--- a/runtime/plaid/src/apis/github/code.rs
+++ b/runtime/plaid/src/apis/github/code.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use plaid_stl::github::{GithubApiWrapper, SearchCodeParams};
+use plaid_stl::github::{
+    CreateInstallationAccessTokenParams, GithubApiWrapper, InstallationAccessTokenCreationResponse,
+    SearchCodeParams,
+};
 
 use super::Github;
 use crate::{
@@ -98,6 +101,50 @@ impl Github {
             Ok((status, Ok(body))) => {
                 if status == 200 {
                     Ok(body)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Create an installation access token for a GitHub App installation.
+    /// See https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#create-an-installation-access-token-for-an-app for more details
+    /// Note that this endpoint is only available to GitHub Apps, and not to OAuth apps or personal access tokens.
+    pub async fn create_installation_access_token(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
+        let request: GithubApiWrapper<CreateInstallationAccessTokenParams> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let installation_id = &request.params.installation_id.to_string();
+
+        info!(
+            "Creating installation access token for installation [{installation_id}] on behalf of {module}"
+        );
+
+        let address = format!("/app/installations/{installation_id}/access_tokens");
+
+        match self
+            .make_app_authenticated_post_request(
+                &request.client_id,
+                address,
+                &request.params.body,
+                module,
+            )
+            .await
+        {
+            Ok((status, Ok(body))) => {
+                if status == 201 {
+                    let response: InstallationAccessTokenCreationResponse =
+                        serde_json::from_str(&body).map_err(|_| ApiError::BadRequest)?;
+                    Ok(serde_json::to_string(&response).map_err(|_| ApiError::BadRequest)?)
                 } else {
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
                         status,

--- a/runtime/plaid/src/apis/github/code.rs
+++ b/runtime/plaid/src/apis/github/code.rs
@@ -123,7 +123,7 @@ impl Github {
         let request: GithubApiWrapper<CreateInstallationAccessTokenParams> =
             serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
 
-        let installation_id = &request.params.installation_id.to_string();
+        let installation_id = request.params.installation_id;
 
         info!(
             "Creating installation access token for installation [{installation_id}] on behalf of {module}"

--- a/runtime/plaid/src/apis/github/mod.rs
+++ b/runtime/plaid/src/apis/github/mod.rs
@@ -16,7 +16,7 @@ mod validators;
 
 use http::{header::USER_AGENT, HeaderMap};
 use jsonwebtoken::EncodingKey;
-use octocrab::{NoAuth, Octocrab};
+use octocrab::{auth::create_jwt, NoAuth, Octocrab};
 
 use serde::{Deserialize, Serialize};
 
@@ -70,8 +70,18 @@ pub struct Github {
     config: GithubConfig,
     /// Clients to make requests with, keyed by their identifier
     clients: HashMap<String, Octocrab>,
+    /// Raw GitHub App authentication material (app_id, private key) used to generate
+    /// short-lived JWTs for endpoints that require app-level authentication.
+    app_auth: HashMap<String, AppAuth>,
     /// Validators used to check parameters passed by modules
     validators: HashMap<&'static str, regex::Regex>,
+}
+
+/// Minimal information needed to authenticate as a GitHub App via JWT.
+#[derive(Clone)]
+pub struct AppAuth {
+    pub app_id: u64,
+    pub key: EncodingKey,
 }
 
 /// All the errors that can be encountered while executing GitHub calls
@@ -90,6 +100,7 @@ pub enum GitHubError {
 impl Github {
     pub fn new(config: GithubConfig) -> Result<Self, ApiError> {
         let clients = build_github_clients(&config.authentication)?;
+        let app_auth = build_app_auth(&config.authentication)?;
 
         // Create all the validators and compile all the regexes. If the module contains
         // any invalid regexes it will panic.
@@ -98,6 +109,7 @@ impl Github {
         Ok(Self {
             config,
             clients,
+            app_auth,
             validators,
         })
     }
@@ -167,21 +179,81 @@ impl Github {
     /// (at least currently).
     async fn make_generic_post_request<T: Serialize>(
         &self,
-        client_id: impl Display,
+        client_id: impl Display + Clone,
         uri: String,
         body: T,
         module: Arc<PlaidModule>,
     ) -> Result<(u16, Result<String, ApiError>), ApiError> {
-        info!("Making a post request to {uri} on behalf of {module}");
+        self.make_generic_post_request_with_headers(client_id, uri, body, None, module)
+            .await
+    }
 
-        let client = self.clients.get(&client_id.to_string()).ok_or_else(|| {
+    /// Make a generic post request to the GitHub API authenticated as the GitHub App (using a JWT).
+    /// This is useful for endpoints that require app-level authentication, such as creating an
+    /// installation access token.
+    async fn make_app_authenticated_post_request<T: Serialize>(
+        &self,
+        client_id: impl Display + Clone,
+        uri: String,
+        body: T,
+        module: Arc<PlaidModule>,
+    ) -> Result<(u16, Result<String, ApiError>), ApiError> {
+        let headers = self.app_jwt_header(client_id.to_string())?;
+        self.make_generic_post_request_with_headers(client_id, uri, body, Some(headers), module)
+            .await
+    }
+
+    /// Make a generic post request with custom headers to the GitHub API using the GitHub app library.
+    /// Note - This function does not do any validation on the provided headers. That's because
+    /// it's not exposed to the rules but only callable from within the runtime itself. Therefore
+    /// we assume that all necessary validation has already been performed by the calling function.
+    async fn make_generic_post_request_with_headers<T: Serialize>(
+        &self,
+        client_id: impl Display + Clone,
+        uri: String,
+        body: T,
+        headers: Option<HeaderMap>,
+        module: Arc<PlaidModule>,
+    ) -> Result<(u16, Result<String, ApiError>), ApiError> {
+        // We log the header names we are passing but not the values, in case they are sensitive.
+        info!(
+            "Making a post request to {uri} on behalf of {module}. Provided headers: {:?}",
+            match headers {
+                Some(ref headers) => headers
+                    .keys()
+                    .map(|v| v.as_str())
+                    .collect::<Vec<&str>>()
+                    .join(", "),
+                None => "None".to_string(),
+            }
+        );
+
+        let client_id = client_id.to_string();
+        let client = self.clients.get(&client_id).ok_or_else(|| {
             ApiError::GitHubError(GitHubError::InvalidInput(format!(
                 "Client ID not found: {}",
                 client_id
             )))
         })?;
 
-        let request = client._post(uri, Some(&body)).await;
+        let mut request = client
+            .build_request(
+                http::Request::builder()
+                    .method(http::Method::POST)
+                    .uri(&uri),
+                Some(&body),
+            )
+            .map_err(|e| ApiError::GitHubError(GitHubError::ClientError(e)))?;
+
+        if let Some(headers) = headers {
+            for (name, value) in headers {
+                if let Some(name) = name {
+                    request.headers_mut().insert(name, value);
+                }
+            }
+        }
+
+        let request = client.send(request).await;
 
         match request {
             Ok(r) => {
@@ -193,6 +265,35 @@ impl Github {
             }
             Err(e) => Err(ApiError::GitHubError(GitHubError::ClientError(e))),
         }
+    }
+
+    /// Build an `Authorization: Bearer <JWT>` header for a GitHub App client identified by
+    /// `client_id`. The JWT is generated from the configured app_id and private key using
+    /// octocrab's `create_jwt`. Returns an error if the client is not configured as an app.
+    fn app_jwt_header(&self, client_id: String) -> Result<HeaderMap, ApiError> {
+        let app_auth = self.app_auth.get(&client_id).ok_or_else(|| {
+            ApiError::GitHubError(GitHubError::InvalidInput(format!(
+                "Client ID not configured as a GitHub App: {client_id}"
+            )))
+        })?;
+
+        let app_id = app_auth.app_id.into();
+        let jwt = create_jwt(app_id, &app_auth.key).map_err(|_| {
+            ApiError::GitHubError(GitHubError::InvalidInput(format!(
+                "Failed to generate JWT for GitHub App client: {client_id}"
+            )))
+        })?;
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::AUTHORIZATION,
+            format!("Bearer {jwt}").parse().map_err(|_| {
+                ApiError::GitHubError(GitHubError::InvalidInput(
+                    "Failed to build authorization header".to_string(),
+                ))
+            })?,
+        );
+        Ok(headers)
     }
 
     /// Make a generic put request to the GitHub API using the GitHub app library. This exists
@@ -353,6 +454,49 @@ pub fn build_github_clients(
             }
 
             Ok((key.clone(), client))
+        })
+        .collect()
+}
+
+/// Extracts the raw GitHub App authentication material (app_id + private key) for each
+/// configured app client. This is used to generate short-lived JWTs for app-level endpoints.
+fn build_app_auth(
+    authentication: &HashMap<String, Authentication>,
+) -> Result<HashMap<String, AppAuth>, ApiError> {
+    if authentication.is_empty() {
+        return Err(ApiError::GitHubError(GitHubError::InvalidInput(
+            "At least one GitHub client must be configured".to_string(),
+        )));
+    }
+
+    authentication
+        .iter()
+        .filter_map(|(key, auth)| match auth {
+            Authentication::App {
+                app_id,
+                private_key,
+                ..
+            } => {
+                info!("Configuring GitHub App authentication material for [{key}]");
+                let encoding_key =
+                    EncodingKey::from_rsa_pem(private_key.as_bytes()).map_err(|_| {
+                        ApiError::GitHubError(GitHubError::InvalidInput(format!(
+                        "Failed to create encoding key from private key for GitHub API for [{key}]"
+                    )))
+                    });
+                let encoding_key = match encoding_key {
+                    Ok(key) => key,
+                    Err(e) => return Some(Err(e)),
+                };
+                Some(Ok((
+                    key.clone(),
+                    AppAuth {
+                        app_id: *app_id,
+                        key: encoding_key,
+                    },
+                )))
+            }
+            _ => None,
         })
         .collect()
 }

--- a/runtime/plaid/src/apis/github/mod.rs
+++ b/runtime/plaid/src/apis/github/mod.rs
@@ -236,26 +236,33 @@ impl Github {
             )))
         })?;
 
-        let mut request = client
-            .build_request(
-                http::Request::builder()
-                    .method(http::Method::POST)
-                    .uri(&uri),
-                Some(&body),
-            )
-            .map_err(|e| ApiError::GitHubError(GitHubError::ClientError(e)))?;
+        let response = match headers {
+            // No custom headers: use the client's built-in POST helper so we don't change the
+            // transport path for the existing POST-based GitHub API wrappers.
+            None => client._post(uri, Some(&body)).await,
+            // Custom headers provided (e.g. app-level JWT auth): build the request manually so we
+            // can override headers such as Authorization before sending.
+            Some(headers) => {
+                let mut request = client
+                    .build_request(
+                        http::Request::builder()
+                            .method(http::Method::POST)
+                            .uri(&uri),
+                        Some(&body),
+                    )
+                    .map_err(|e| ApiError::GitHubError(GitHubError::ClientError(e)))?;
 
-        if let Some(headers) = headers {
-            for (name, value) in headers {
-                if let Some(name) = name {
-                    request.headers_mut().insert(name, value);
+                for (name, value) in headers {
+                    if let Some(name) = name {
+                        request.headers_mut().insert(name, value);
+                    }
                 }
+
+                client.send(request).await
             }
-        }
+        };
 
-        let request = client.send(request).await;
-
-        match request {
+        match response {
             Ok(r) => {
                 let status = r.status().as_u16();
                 let body = client.body_to_string(r).await.map_err(|e| {

--- a/runtime/plaid/src/apis/github/mod.rs
+++ b/runtime/plaid/src/apis/github/mod.rs
@@ -404,6 +404,38 @@ impl Github {
             Err(e) => Err(ApiError::GitHubError(GitHubError::ClientError(e))),
         }
     }
+
+    /// Make a DELETE request to the GitHub API with a custom `Authorization: Bearer <token>`
+    /// header using a standalone reqwest client. This is needed for endpoints that require
+    /// authenticating with a token that is different from the configured client, such as
+    /// revoking an installation access token.
+    async fn make_delete_request_with_token<T: Serialize>(
+        &self,
+        uri: String,
+        body: Option<&T>,
+        token: String,
+        module: Arc<PlaidModule>,
+    ) -> Result<(u16, Result<String, ApiError>), ApiError> {
+        info!("Making a delete request to {uri} on behalf of {module} with provided token");
+
+        let client = reqwest::Client::new();
+        let mut request = client
+            .delete(&uri)
+            .header(http::header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(USER_AGENT, format!("Rust/Plaid{}", env!("CARGO_PKG_VERSION")));
+
+        if let Some(body) = body {
+            request = request.json(body);
+        }
+
+        let response = request.send().await.map_err(|e| ApiError::NetworkError(e))?;
+
+        let status = response.status().as_u16();
+        let body = response.text().await.map_err(|e| {
+            ApiError::GitHubError(GitHubError::GraphQLRequestError(e.to_string()))
+        });
+        Ok((status, body))
+    }
 }
 
 /// Builds an instance of a Github API client

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -462,6 +462,11 @@ impl_new_function!(
     DISALLOW_IN_TEST_MODE
 );
 impl_new_function_with_error_buffer!(github, get_enterprise_license_status, ALLOW_IN_TEST_MODE);
+impl_new_function_with_error_buffer!(
+    github,
+    create_installation_access_token,
+    DISALLOW_IN_TEST_MODE
+);
 
 // GitHub Functions only available with GitHub App authentication
 impl_new_function!(github, review_fpat_requests_for_org, DISALLOW_IN_TEST_MODE);
@@ -917,6 +922,7 @@ define_api_functions! {
         "github_grant_repo_access_to_org_installation"    => github_grant_repo_access_to_org_installation,
         "github_remove_repo_access_from_org_installation" => github_remove_repo_access_from_org_installation,
         "github_get_enterprise_license_status"                 => github_get_enterprise_license_status,
+        "github_create_installation_access_token"                 => github_create_installation_access_token,
 
         // Slack Calls
         "slack_post_to_named_webhook"     => slack_post_to_named_webhook,

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -467,6 +467,7 @@ impl_new_function_with_error_buffer!(
     create_installation_access_token,
     DISALLOW_IN_TEST_MODE
 );
+impl_new_function!(github, revoke_installation_access_token, DISALLOW_IN_TEST_MODE);
 
 // GitHub Functions only available with GitHub App authentication
 impl_new_function!(github, review_fpat_requests_for_org, DISALLOW_IN_TEST_MODE);
@@ -923,6 +924,7 @@ define_api_functions! {
         "github_remove_repo_access_from_org_installation" => github_remove_repo_access_from_org_installation,
         "github_get_enterprise_license_status"                 => github_get_enterprise_license_status,
         "github_create_installation_access_token"                 => github_create_installation_access_token,
+        "github_revoke_installation_access_token"                 => github_revoke_installation_access_token,
 
         // Slack Calls
         "slack_post_to_named_webhook"     => slack_post_to_named_webhook,

--- a/testing/just_run_please.sh
+++ b/testing/just_run_please.sh
@@ -33,4 +33,4 @@ mkdir -p compiled_modules
 cp modules/target/wasm32-unknown-unknown/release/just_run_please.wasm compiled_modules/just_run_please.wasm
 
 cd runtime
-RUST_LOG=plaid=debug cargo run --bin=plaid --no-default-features --features=${COMPILER_BACKEND} -- --config ${CONFIG_WORKING_PATH} --secrets ${SECRETS_WORKING_PATH}
+RUST_LOG=plaid=trace cargo run --bin=plaid --no-default-features --features=${COMPILER_BACKEND} -- --config ${CONFIG_WORKING_PATH} --secrets ${SECRETS_WORKING_PATH}

--- a/testing/just_run_please.sh
+++ b/testing/just_run_please.sh
@@ -33,4 +33,4 @@ mkdir -p compiled_modules
 cp modules/target/wasm32-unknown-unknown/release/just_run_please.wasm compiled_modules/just_run_please.wasm
 
 cd runtime
-RUST_LOG=plaid=trace cargo run --bin=plaid --no-default-features --features=${COMPILER_BACKEND} -- --config ${CONFIG_WORKING_PATH} --secrets ${SECRETS_WORKING_PATH}
+RUST_LOG=plaid=debug cargo run --bin=plaid --no-default-features --features=${COMPILER_BACKEND} -- --config ${CONFIG_WORKING_PATH} --secrets ${SECRETS_WORKING_PATH}


### PR DESCRIPTION
Also reorganize how to make calls to the GH API to support authenticating as an app via a JWT (through a call to Octocrab).