### PR TITLE
Add proxy routing mode for blockchain APIs

### DIFF
--- a/runtime/plaid/resources/jrp_config/apis.toml
+++ b/runtime/plaid/resources/jrp_config/apis.toml
@@ -153,9 +153,9 @@ secret_key = ""
 
 # [apis."blockchain"."evm".routing]
 # type = "nodes"
+# max_retries = 5
 
 # [apis."blockchain"."evm".routing.chains.1] # Ethereum
-# max_retries = 5
 # selection_strategy = "RoundRobin"
 
 # [[apis."blockchain"."evm".routing.chains.1.nodes]]
@@ -187,9 +187,9 @@ secret_key = ""
 # Cluster keys are parsed by name: "mainnet", "devnet", or "testnet".
 # [apis."blockchain"."solana".routing]
 # type = "nodes"
+# max_retries = 5
 
 # [apis."blockchain"."solana".routing.chains.devnet]
-# max_retries = 5
 # selection_strategy = "RoundRobin"
 
 # [[apis."blockchain"."solana".routing.chains.devnet.nodes]]

--- a/runtime/plaid/resources/jrp_config/apis.toml
+++ b/runtime/plaid/resources/jrp_config/apis.toml
@@ -149,40 +149,67 @@ secret_key = ""
 # BLOCKCHAIN EVM EXAMPLE CONFIGURATION
 # [apis."blockchain"]
 # [apis."blockchain"."evm"]
-# max_retries = 5
 # timeout_millis = 10000
 
-# [apis."blockchain"."evm".chains.1] # Ethereum 
+# [apis."blockchain"."evm".routing]
+# type = "nodes"
+
+# [apis."blockchain"."evm".routing.chains.1] # Ethereum
+# max_retries = 5
 # selection_strategy = "RoundRobin"
 
-# [[apis."blockchain"."evm".chains.1.nodes]]
+# [[apis."blockchain"."evm".routing.chains.1.nodes]]
 # uri = "https://some-node"
 # name = "Node 1"
 
-# [[apis."blockchain"."evm".chains.1.nodes]]
+# [[apis."blockchain"."evm".routing.chains.1.nodes]]
 # uri = "https://some-other-node"
 # name = "Node 2"
 
+# BLOCKCHAIN EVM PROXY MODE EXAMPLE CONFIGURATION
+# Routes every EVM chain through a single proxy, with the chain ID appended as a
+# path segment (e.g. https://some.rpc.proxy/1 for Ethereum). Works out of the box
+# for arbitrary chain IDs — no per-chain config required. Mutually exclusive with
+# the `nodes` routing mode above: configure exactly one.
+# [apis."blockchain"."evm"]
+# timeout_millis = 10000
+# [apis."blockchain"."evm".routing]
+# type = "proxy"
+# url = "https://some.rpc.proxy"
+
 # BLOCKCHAIN SOLANA EXAMPLE CONFIGURATION
 # [apis."blockchain"."solana"]
-# max_retries = 5
 # timeout_millis = 10000
 # Commitment applied to every Solana RPC call: "processed", "confirmed", or
 # "finalized". Optional; defaults to "confirmed".
 # commitment = "finalized"
 
 # Cluster keys are parsed by name: "mainnet", "devnet", or "testnet".
-# [apis."blockchain"."solana".chains.devnet]
+# [apis."blockchain"."solana".routing]
+# type = "nodes"
+
+# [apis."blockchain"."solana".routing.chains.devnet]
+# max_retries = 5
 # selection_strategy = "RoundRobin"
 
-# [[apis."blockchain"."solana".chains.devnet.nodes]]
+# [[apis."blockchain"."solana".routing.chains.devnet.nodes]]
 # uri = "https://api.devnet.solana.com"
 # name = "Solana Devnet RPC 1"
 
-# [[apis."blockchain"."solana".chains.devnet.nodes]]
+# [[apis."blockchain"."solana".routing.chains.devnet.nodes]]
 # uri = "https://some-other-solana-node"
 # name = "Solana Devnet RPC 2"
 
+# BLOCKCHAIN SOLANA PROXY MODE EXAMPLE CONFIGURATION
+# Routes every Solana cluster through a single proxy, with the cluster name
+# appended as a path segment (e.g. https://some.rpc.proxy/devnet). Mutually
+# exclusive with the `nodes` routing mode above: configure exactly one.
+# [apis."blockchain"."solana"]
+# timeout_millis = 10000
+# commitment = "finalized"
+# [apis."blockchain"."solana".routing]
+# type = "proxy"
+# url = "https://some.rpc.proxy"
 
 # KMS USING IAM
 

--- a/runtime/plaid/src/apis/blockchain/common/mod.rs
+++ b/runtime/plaid/src/apis/blockchain/common/mod.rs
@@ -99,6 +99,7 @@ pub enum RoutingMode<C: ChainFamily, V> {
         chains: HashMap<C::Identifier, V>,
         /// The maximum number of retries across nodes for each RPC call.
         #[serde(default = "default_max_retries")]
+        #[serde(deserialize_with = "deserialize_non_zero_u8")]
         max_retries: u8,
     },
     /// A single proxy endpoint; the chain identifier is appended as a path segment.
@@ -107,6 +108,18 @@ pub enum RoutingMode<C: ChainFamily, V> {
         #[serde(deserialize_with = "deserialize_url")]
         url: Url,
     },
+}
+
+fn deserialize_non_zero_u8<'de, D>(deserializer: D) -> Result<u8, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    let retries = u8::deserialize(deserializer)?;
+    if retries == 0 {
+        return Err(de::Error::custom("max_retries must be greater than 0"));
+    }
+
+    Ok(retries)
 }
 
 pub struct BlockchainClient<C: ChainFamily> {

--- a/runtime/plaid/src/apis/blockchain/common/mod.rs
+++ b/runtime/plaid/src/apis/blockchain/common/mod.rs
@@ -85,7 +85,11 @@ impl BlockchainError {
 ///   with the chain identifier appended as a path segment. Works out of the box
 ///   for arbitrary chain identifiers — no per-chain config required.
 #[derive(Deserialize)]
-#[serde(tag = "type", bound(deserialize = "V: Deserialize<'de>"))]
+#[serde(
+    rename_all = "lowercase",
+    tag = "type",
+    bound(deserialize = "V: Deserialize<'de>")
+)]
 pub enum RoutingMode<C: ChainFamily, V> {
     /// Per-chain node pools (the original behavior).
     Nodes {
@@ -164,13 +168,19 @@ where
         .collect()
 }
 
-/// Deserializes a string into a [`Url`]
+/// Deserializes a string into a hierarchical [`Url`].
 fn deserialize_url<'de, D>(deserializer: D) -> Result<Url, D::Error>
 where
     D: de::Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    Url::parse(&s).map_err(de::Error::custom)
+    let url = Url::parse(&s).map_err(de::Error::custom)?;
+    if url.cannot_be_a_base() {
+        return Err(de::Error::custom(format!(
+            "proxy URL must be hierarchical (support path segments), got: {s}"
+        )));
+    }
+    Ok(url)
 }
 
 #[derive(Deserialize)]

--- a/runtime/plaid/src/apis/blockchain/common/mod.rs
+++ b/runtime/plaid/src/apis/blockchain/common/mod.rs
@@ -24,6 +24,7 @@ use serde::{de, Deserialize, Serialize};
 use std::{
     collections::HashMap, fmt::Display, hash::Hash, str::FromStr, sync::Arc, time::Duration,
 };
+use url::Url;
 
 /// Identifies a chain family which can be interacted with through Json-RPC 2.0. This trait is
 /// mainly used as a type parameter to BlockchainClient.
@@ -75,10 +76,38 @@ impl BlockchainError {
     }
 }
 
+/// How a [`BlockchainClient`] routes RPC calls to a chain.
+///
+/// Two mutually exclusive modes, selected per chain family via config:
+/// - [`RoutingMode::Nodes`]: each chain is explicitly configured with its own
+///   node pool and selection strategy. Only configured chains are reachable.
+/// - [`RoutingMode::Proxy`]: all chains route through a single proxy endpoint,
+///   with the chain identifier appended as a path segment. Works out of the box
+///   for arbitrary chain identifiers — no per-chain config required.
+#[derive(Deserialize)]
+#[serde(tag = "type", bound(deserialize = "V: Deserialize<'de>"))]
+pub enum RoutingMode<C: ChainFamily, V> {
+    /// Per-chain node pools (the original behavior).
+    Nodes {
+        /// Per-chain configuration, keyed by the family's identifier.
+        /// TOML keys arrive as strings and are parsed via `Identifier: FromStr`.
+        #[serde(deserialize_with = "deserialize_chains")]
+        chains: HashMap<C::Identifier, V>,
+        /// The maximum number of retries across nodes for each RPC call.
+        #[serde(default = "default_max_retries")]
+        max_retries: u8,
+    },
+    /// A single proxy endpoint; the chain identifier is appended as a path segment.
+    Proxy {
+        /// The proxy base URL
+        #[serde(deserialize_with = "deserialize_url")]
+        url: Url,
+    },
+}
+
 pub struct BlockchainClient<C: ChainFamily> {
-    pub node_selector: HashMap<C::Identifier, NodeSelector>,
+    pub routing: RoutingMode<C, NodeSelector>,
     pub client: Client,
-    pub max_retries: u8,
     pub options: C::Options,
 }
 
@@ -108,17 +137,13 @@ pub struct NodeConfig {
 // `C::Options` are), so constrain the derive's synthesized bound to just `C::Options`.
 #[serde(bound(deserialize = "C::Options: serde::Deserialize<'de>"))]
 pub struct ChainFamilyConfig<C: ChainFamily> {
-    /// Per-chain configuration, keyed by the family's identifier.
-    /// TOML keys arrive as strings and are parsed via `Identifier: FromStr`.
-    #[serde(deserialize_with = "deserialize_chains")]
-    pub chains: HashMap<C::Identifier, ChainConfig>,
+    /// How RPC calls are routed: either explicit per-chain node pools, or a
+    /// single proxy endpoint
+    pub routing: RoutingMode<C, ChainConfig>,
     /// Timeout duration for client requests in milliseconds
     #[serde(default = "default_timeout")]
     #[serde(deserialize_with = "parse_duration")]
     pub timeout_millis: Duration,
-    /// The maximum number of retries for client requests
-    #[serde(default = "default_max_retries")]
-    pub max_retries: u8,
     /// Family-specific options (e.g. Solana commitment), read from the same table.
     #[serde(flatten, default)]
     pub options: C::Options,
@@ -127,15 +152,25 @@ pub struct ChainFamilyConfig<C: ChainFamily> {
 /// Deserializes the `chains` map by reading string TOML keys and parsing each
 /// into the family's identifier via `FromStr`. `K` is inferred as `C::Identifier`
 /// from the field type at the call site.
-fn deserialize_chains<'de, D, K>(deserializer: D) -> Result<HashMap<K, ChainConfig>, D::Error>
+fn deserialize_chains<'de, D, K, V>(deserializer: D) -> Result<HashMap<K, V>, D::Error>
 where
     D: de::Deserializer<'de>,
     K: FromStr<Err: Display> + Eq + Hash,
+    V: de::Deserialize<'de>,
 {
-    HashMap::<String, ChainConfig>::deserialize(deserializer)?
+    HashMap::<String, V>::deserialize(deserializer)?
         .into_iter()
         .map(|(key, config)| Ok((key.parse().map_err(de::Error::custom)?, config)))
         .collect()
+}
+
+/// Deserializes a string into a [`Url`]
+fn deserialize_url<'de, D>(deserializer: D) -> Result<Url, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    Url::parse(&s).map_err(de::Error::custom)
 }
 
 #[derive(Deserialize)]
@@ -160,88 +195,110 @@ impl<C: ChainFamily> BlockchainClient<C> {
             .build()
             .expect("Failed to build blockchain reqwest client");
 
-        let node_selector = config
-            .chains
-            .into_iter()
-            .map(|(chain_id, config)| {
-                let selector = NodeSelector::new(config.nodes, config.selection_strategy);
-                (chain_id, selector)
-            })
-            .collect();
+        let routing = match config.routing {
+            RoutingMode::Nodes {
+                chains,
+                max_retries,
+            } => RoutingMode::Nodes {
+                chains: chains
+                    .into_iter()
+                    .map(|(chain_id, config)| {
+                        let selector = NodeSelector::new(config.nodes, config.selection_strategy);
+                        (chain_id, selector)
+                    })
+                    .collect::<HashMap<_, _>>(),
+                max_retries,
+            },
+            RoutingMode::Proxy { url } => RoutingMode::Proxy { url },
+        };
 
         Self {
             client,
-            node_selector,
-            max_retries: config.max_retries,
+            routing,
             options: config.options,
         }
     }
 
-    /// Look up the node selector for a chain identifier, erroring if none is configured.
-    pub fn get_node_selector(&self, identifier: C::Identifier) -> Result<&NodeSelector, ApiError> {
-        self.node_selector.get(&identifier).ok_or_else(|| {
-            BlockchainError::NoNodes {
-                identifier: identifier.to_string(),
-            }
-            .into()
-        })
-    }
-
     /// Execute a JSON-RPC call with automatic retry and failure handling.
     ///
-    /// This handles:
-    /// - Retry logic up to `max_retries` attempts
-    /// - Automatic failure marking to deprioritize bad nodes
+    /// Behavior depends on the routing mode:
+    /// - **Proxy mode**: a single attempt against the proxy URL (proxies are
+    ///   expected to handle retry internally).
+    /// - **Node mode**: retries up to `max_retries` attempts across the chain's
+    ///   node pool, advancing past failing nodes.
     ///
     /// It is generic over the method type `M`, so each chain family reuses this
-    /// loop with its own set of RPC method names.
+    /// with its own set of RPC method names.
     pub async fn execute_rpc_call<M: Serialize + Display, P: Serialize>(
         &self,
-        selector: &NodeSelector,
         identifier: C::Identifier,
         json_rpc_request: JsonRpcRequest<'_, M, P>,
         module: Arc<PlaidModule>,
     ) -> Result<String, ApiError> {
-        let mut last_error = BlockchainError::AllNodesFailed;
-
         debug!(
             "Module [{module}] is attempting to call [{}] on chain [{}]",
             json_rpc_request.method, identifier,
         );
-        for attempt in 1..=self.max_retries {
-            // Get the next node to try
-            let Some(node) = selector.select_node() else {
-                return Err(BlockchainError::NoNodes {
-                    identifier: identifier.to_string(),
-                }
-                .into());
-            };
 
-            trace!(
-                "Attempt {attempt}/{} for RPC call [{}] using node [{}] on behalf of module [{module}]",
-                self.max_retries,
-                json_rpc_request.method,
-                node.name
-            );
-
-            // Make the RPC call using the existing utility
-            match json_rpc_request.execute(&self.client, &node.uri).await {
-                Ok(response) => {
-                    return Ok(response);
-                }
-                Err(e) => {
-                    // If the error is not retryable, return immediately
-                    if !e.is_retryable() {
-                        return Err(e.into());
+        match &self.routing {
+            // Proxy mode: route every chain through the single proxy URL, with the
+            // chain identifier appended as a path segment.
+            RoutingMode::Proxy { url } => {
+                // Append the chain identifier as a path segment
+                let rpc = format!("{}/{identifier}", url.as_str().trim_end_matches('/'));
+                trace!(
+                    "RPC call [{}] via proxy on behalf of module [{module}]",
+                    json_rpc_request.method,
+                );
+                json_rpc_request
+                    .execute(&self.client, &rpc)
+                    .await
+                    .map_err(Into::into)
+            }
+            // Node mode: look up the chain's node pool and rotate through it,
+            // retrying across nodes and deprioritizing failing ones.
+            RoutingMode::Nodes {
+                chains: node_selector,
+                max_retries,
+            } => {
+                let Some(selector) = node_selector.get(&identifier) else {
+                    return Err(BlockchainError::NoNodes {
+                        identifier: identifier.to_string(),
                     }
+                    .into());
+                };
 
-                    // Call failed, mark node as failed and try next
-                    selector.mark_current_node_failed();
-                    last_error = e;
+                let mut last_error = BlockchainError::AllNodesFailed;
+                for attempt in 1..=*max_retries {
+                    let Some(node) = selector.select_node() else {
+                        return Err(BlockchainError::NoNodes {
+                            identifier: identifier.to_string(),
+                        }
+                        .into());
+                    };
+
+                    trace!(
+                        "Attempt {attempt}/{max_retries} for RPC call [{}] using node [{}] on behalf of module [{module}]",
+                        json_rpc_request.method,
+                        node.name
+                    );
+
+                    match json_rpc_request.execute(&self.client, &node.uri).await {
+                        Ok(response) => return Ok(response),
+                        Err(e) => {
+                            // If the error is not retryable, return immediately.
+                            if !e.is_retryable() {
+                                return Err(e.into());
+                            }
+                            // Call failed, mark node as failed and try next.
+                            selector.mark_current_node_failed();
+                            last_error = e;
+                        }
+                    }
                 }
+
+                Err(last_error.into())
             }
         }
-
-        Err(last_error.into())
     }
 }

--- a/runtime/plaid/src/apis/blockchain/common/node_selection.rs
+++ b/runtime/plaid/src/apis/blockchain/common/node_selection.rs
@@ -49,7 +49,12 @@ impl NodeSelector {
 }
 
 impl NodeSelector {
-    /// Select a node based on the selection strategy
+    /// Select a node based on the selection strategy.
+    ///
+    /// RoundRobin returns the current node without advancing the index — the
+    /// index only advances on failure (see [`Self::mark_current_node_failed`]),
+    /// so concurrent calls stay "sticky" to the same node until it fails. Random
+    /// picks a node independently each call.
     pub fn select_node(&self) -> Option<NodeConfig> {
         if self.nodes.is_empty() {
             return None;

--- a/runtime/plaid/src/apis/blockchain/evm/mod.rs
+++ b/runtime/plaid/src/apis/blockchain/evm/mod.rs
@@ -45,13 +45,10 @@ impl BlockchainClient<Evm> {
             .map_err(BlockchainError::SerdeError)?;
         let chain_id = request.chain_id;
 
-        let node_selector = self.get_node_selector(chain_id)?;
-
         let params = Value::Array(vec![Value::String(request.hash)]);
         let request = JsonRpcRequest::new(RpcMethods::GetTransactionByHash, Some(params));
 
-        self.execute_rpc_call(node_selector, chain_id, request, module)
-            .await
+        self.execute_rpc_call(chain_id, request, module).await
     }
 
     /// Returns the receipt of a transaction by transaction hash.
@@ -66,13 +63,10 @@ impl BlockchainClient<Evm> {
             .map_err(BlockchainError::SerdeError)?;
         let chain_id = request.chain_id;
 
-        let node_selector = self.get_node_selector(chain_id)?;
-
         let params = Value::Array(vec![Value::String(request.hash)]);
         let request = JsonRpcRequest::new(RpcMethods::GetTransactionReceipt, Some(params));
 
-        self.execute_rpc_call(node_selector, chain_id, request, module)
-            .await
+        self.execute_rpc_call(chain_id, request, module).await
     }
 
     /// Creates new message call transaction or a contract creation for signed transactions.
@@ -85,13 +79,10 @@ impl BlockchainClient<Evm> {
             .map_err(BlockchainError::SerdeError)?;
         let chain_id = request.chain_id;
 
-        let node_selector = self.get_node_selector(chain_id)?;
-
         let params = Value::Array(vec![Value::String(request.signed_tx)]);
         let request = JsonRpcRequest::new(RpcMethods::SendRawTransaction, Some(params));
 
-        self.execute_rpc_call(node_selector, chain_id, request, module)
-            .await
+        self.execute_rpc_call(chain_id, request, module).await
     }
 
     /// Returns the number of transactions sent from an address.
@@ -104,16 +95,13 @@ impl BlockchainClient<Evm> {
             .map_err(BlockchainError::SerdeError)?;
         let chain_id = request.chain_id;
 
-        let node_selector = self.get_node_selector(chain_id)?;
-
         let params = Value::Array(vec![
             Value::String(request.address),
             Value::String(request.block_tag.to_string()),
         ]);
         let request = JsonRpcRequest::new(RpcMethods::GetTransactionCount, Some(params));
 
-        self.execute_rpc_call(node_selector, chain_id, request, module)
-            .await
+        self.execute_rpc_call(chain_id, request, module).await
     }
 
     /// Returns the balance of the account at a given address.
@@ -126,16 +114,13 @@ impl BlockchainClient<Evm> {
             .map_err(BlockchainError::SerdeError)?;
         let chain_id = request.chain_id;
 
-        let node_selector = self.get_node_selector(chain_id)?;
-
         let params = Value::Array(vec![
             Value::String(request.address),
             Value::String(request.block_tag.to_string()),
         ]);
         let request = JsonRpcRequest::new(RpcMethods::GetBalance, Some(params));
 
-        self.execute_rpc_call(node_selector, chain_id, request, module)
-            .await
+        self.execute_rpc_call(chain_id, request, module).await
     }
 
     /// Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
@@ -147,8 +132,6 @@ impl BlockchainClient<Evm> {
         let request = serde_json::from_str::<EstimateGasRequest>(params)
             .map_err(BlockchainError::SerdeError)?;
         let chain_id = request.chain_id;
-
-        let node_selector = self.get_node_selector(chain_id)?;
 
         let mut object = serde_json::Map::new();
         if let Some(from) = request.from {
@@ -170,8 +153,7 @@ impl BlockchainClient<Evm> {
         ]);
         let request = JsonRpcRequest::new(RpcMethods::EstimateGas, Some(params));
 
-        self.execute_rpc_call(node_selector, chain_id, request, module)
-            .await
+        self.execute_rpc_call(chain_id, request, module).await
     }
 
     /// Executes a new message call immediately without creating a transaction on the blockchain.
@@ -185,14 +167,11 @@ impl BlockchainClient<Evm> {
             serde_json::from_str::<EthCallRequest>(params).map_err(BlockchainError::SerdeError)?;
         let chain_id = request.chain_id;
 
-        let node_selector = self.get_node_selector(chain_id)?;
-
         let object = json!({ "to": request.to, "data": request.data });
         let params = Value::Array(vec![object, Value::String(request.block_tag.to_string())]);
         let request = JsonRpcRequest::new(RpcMethods::Call, Some(params));
 
-        self.execute_rpc_call(node_selector, chain_id, request, module)
-            .await
+        self.execute_rpc_call(chain_id, request, module).await
     }
 
     /// Returns an estimate of the current price per gas in wei. For example, the Besu client examines the last 100 blocks and returns the median gas unit price by default.
@@ -205,12 +184,9 @@ impl BlockchainClient<Evm> {
             .map_err(BlockchainError::SerdeError)?;
         let chain_id = request.chain_id;
 
-        let node_selector = self.get_node_selector(chain_id)?;
-
         let request = JsonRpcRequest::<_, ()>::new(RpcMethods::GasPrice, None);
 
-        self.execute_rpc_call(node_selector, chain_id, request, module)
-            .await
+        self.execute_rpc_call(chain_id, request, module).await
     }
 
     /// Returns an array of all logs matching a given filter object.
@@ -222,8 +198,6 @@ impl BlockchainClient<Evm> {
         let request =
             serde_json::from_str::<GetLogsRequest>(params).map_err(BlockchainError::SerdeError)?;
         let chain_id = request.chain_id;
-
-        let node_selector = self.get_node_selector(chain_id)?;
 
         let mut object = serde_json::Map::new();
         object.insert(
@@ -262,8 +236,7 @@ impl BlockchainClient<Evm> {
 
         let request = JsonRpcRequest::new(RpcMethods::GetLogs, Some(params));
 
-        self.execute_rpc_call(node_selector, chain_id, request, module)
-            .await
+        self.execute_rpc_call(chain_id, request, module).await
     }
 
     /// Returns information about a block by block number or tag.
@@ -276,16 +249,13 @@ impl BlockchainClient<Evm> {
             serde_json::from_str::<GetBlockRequest>(params).map_err(BlockchainError::SerdeError)?;
         let chain_id = request.chain_id;
 
-        let node_selector = self.get_node_selector(chain_id)?;
-
         let params = serde_json::Value::Array(vec![
             Value::String(request.block_tag.to_string()),
             Value::Bool(request.hydrated_transactions),
         ]);
         let request = JsonRpcRequest::new(RpcMethods::GetBlock, Some(params));
 
-        self.execute_rpc_call(node_selector, chain_id, request, module)
-            .await
+        self.execute_rpc_call(chain_id, request, module).await
     }
 
     /// Returns transaction base fee per gas and effective priority fee per gas for the requested block range.
@@ -297,8 +267,6 @@ impl BlockchainClient<Evm> {
         let request = serde_json::from_str::<GetFeeHistoryRequest>(params)
             .map_err(BlockchainError::SerdeError)?;
         let chain_id = request.chain_id;
-
-        let node_selector = self.get_node_selector(chain_id)?;
 
         let percentiles = request
             .reward_percentiles
@@ -316,7 +284,6 @@ impl BlockchainClient<Evm> {
         let params = Value::Array(params);
         let request = JsonRpcRequest::new(RpcMethods::GetFeeHistory, Some(params));
 
-        self.execute_rpc_call(node_selector, chain_id, request, module)
-            .await
+        self.execute_rpc_call(chain_id, request, module).await
     }
 }

--- a/runtime/plaid/src/apis/blockchain/solana/mod.rs
+++ b/runtime/plaid/src/apis/blockchain/solana/mod.rs
@@ -597,7 +597,6 @@ mod tests {
             timeout_millis: Duration::from_secs(10),
             options: SolanaOptions { commitment },
         })
-        .unwrap()
     }
 
     /// Boot an embedded, offline (no mainnet fork) surfnet with a funded payer.

--- a/runtime/plaid/src/apis/blockchain/solana/mod.rs
+++ b/runtime/plaid/src/apis/blockchain/solana/mod.rs
@@ -84,8 +84,6 @@ impl BlockchainClient<Solana> {
             .map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         // [base64Tx, { "encoding": "base64", "preflightCommitment": <configured> }]
         let params = (
             request.transaction,
@@ -93,8 +91,7 @@ impl BlockchainClient<Solana> {
         );
         let request = JsonRpcRequest::new(RpcMethods::SendTransaction, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Returns the lamport balance of an account.
@@ -107,16 +104,13 @@ impl BlockchainClient<Solana> {
             serde_json::from_str::<PubkeyRequest>(params).map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         let params = (
             request.pubkey,
             json!({ "commitment": self.options.commitment }),
         );
         let request = JsonRpcRequest::new(RpcMethods::GetBalance, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Returns all information associated with an account.
@@ -132,8 +126,6 @@ impl BlockchainClient<Solana> {
             serde_json::from_str::<PubkeyRequest>(params).map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         // base64 encoding handles account data of any size (base58, the default, caps out).
         let params = (
             request.pubkey,
@@ -141,8 +133,7 @@ impl BlockchainClient<Solana> {
         );
         let request = JsonRpcRequest::new(RpcMethods::GetAccountInfo, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Returns the slot that has reached the default commitment level.
@@ -155,13 +146,10 @@ impl BlockchainClient<Solana> {
             serde_json::from_str::<ClusterRequest>(params).map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         let params = Value::Array(vec![json!({ "commitment": self.options.commitment })]);
         let request = JsonRpcRequest::new(RpcMethods::GetSlot, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Returns the latest blockhash, used as the recent blockhash when building transactions.
@@ -174,13 +162,10 @@ impl BlockchainClient<Solana> {
             serde_json::from_str::<ClusterRequest>(params).map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         let params = Value::Array(vec![json!({ "commitment": self.options.commitment })]);
         let request = JsonRpcRequest::new(RpcMethods::GetLatestBlockhash, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Returns the current cluster-wide transaction count.
@@ -197,13 +182,10 @@ impl BlockchainClient<Solana> {
             serde_json::from_str::<ClusterRequest>(params).map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         let params = Value::Array(vec![json!({ "commitment": self.options.commitment })]);
         let request = JsonRpcRequest::new(RpcMethods::GetTransactionCount, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Returns details for a confirmed transaction by signature.
@@ -219,16 +201,13 @@ impl BlockchainClient<Solana> {
             .map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         let params = (
             request.signature,
             json!({ "commitment": self.options.commitment, "maxSupportedTransactionVersion": 0 }),
         );
         let request = JsonRpcRequest::new(RpcMethods::GetTransaction, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Returns the processing statuses of a batch of transaction signatures.
@@ -244,16 +223,13 @@ impl BlockchainClient<Solana> {
             .map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         let params = (
             request.signatures,
             json!({ "searchTransactionHistory": request.search_transaction_history }),
         );
         let request = JsonRpcRequest::new(RpcMethods::GetSignatureStatuses, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Returns identity and transaction information about a confirmed block.
@@ -268,8 +244,6 @@ impl BlockchainClient<Solana> {
             serde_json::from_str::<GetBlockRequest>(params).map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         let params = (
             json!(request.slot),
             json!({
@@ -282,8 +256,7 @@ impl BlockchainClient<Solana> {
         );
         let request = JsonRpcRequest::new(RpcMethods::GetBlock, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Reads multiple accounts in a single call.
@@ -299,15 +272,13 @@ impl BlockchainClient<Solana> {
             .map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
         let params = (
             request.pubkeys,
             json!({ "encoding": "base64", "commitment": self.options.commitment }),
         );
         let request = JsonRpcRequest::new(RpcMethods::GetMultipleAccounts, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Enumerates all accounts owned by a program.
@@ -322,8 +293,6 @@ impl BlockchainClient<Solana> {
         let request = serde_json::from_str::<GetProgramAccountsRequest>(params)
             .map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
-
-        let node_selector = self.get_node_selector(cluster)?;
 
         let mut config = serde_json::Map::new();
         config.insert("encoding".to_string(), json!("base64"));
@@ -358,8 +327,7 @@ impl BlockchainClient<Solana> {
         let params = (request.program_id, Value::Object(config));
         let request = JsonRpcRequest::new(RpcMethods::GetProgramAccounts, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Lists the SPL token accounts owned by a wallet, filtered by mint or token program.
@@ -371,8 +339,6 @@ impl BlockchainClient<Solana> {
         let request = serde_json::from_str::<GetTokenAccountsByOwnerRequest>(params)
             .map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
-
-        let node_selector = self.get_node_selector(cluster)?;
 
         // Prefer a mint filter when given; otherwise scope to a token program
         // (defaulting to SPL Token).
@@ -392,8 +358,7 @@ impl BlockchainClient<Solana> {
         );
         let request = JsonRpcRequest::new(RpcMethods::GetTokenAccountsByOwner, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Returns the token balance of an SPL token account.
@@ -406,16 +371,13 @@ impl BlockchainClient<Solana> {
             serde_json::from_str::<PubkeyRequest>(params).map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         let params = (
             request.pubkey,
             json!({ "commitment": self.options.commitment }),
         );
         let request = JsonRpcRequest::new(RpcMethods::GetTokenAccountBalance, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Returns the total supply of an SPL mint.
@@ -428,16 +390,13 @@ impl BlockchainClient<Solana> {
             serde_json::from_str::<PubkeyRequest>(params).map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         let params = (
             request.pubkey,
             json!({ "commitment": self.options.commitment }),
         );
         let request = JsonRpcRequest::new(RpcMethods::GetTokenSupply, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Returns the lamports required for an account of a given size to be rent-exempt.
@@ -452,8 +411,6 @@ impl BlockchainClient<Solana> {
             .map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         let params = (
             json!(request.data_length),
             json!({ "commitment": self.options.commitment }),
@@ -461,8 +418,7 @@ impl BlockchainClient<Solana> {
         let request =
             JsonRpcRequest::new(RpcMethods::GetMinimumBalanceForRentExemption, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Returns the fee the cluster would charge for a serialized message.
@@ -477,16 +433,13 @@ impl BlockchainClient<Solana> {
             .map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         let params = (
             request.message,
             json!({ "commitment": self.options.commitment }),
         );
         let request = JsonRpcRequest::new(RpcMethods::GetFeeForMessage, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Returns recent prioritization (priority) fees, optionally scoped to accounts.
@@ -501,13 +454,10 @@ impl BlockchainClient<Solana> {
             .map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         let params = (!request.addresses.is_empty()).then_some(request.addresses);
         let request = JsonRpcRequest::new(RpcMethods::GetRecentPrioritizationFees, params);
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Simulates a signed transaction without submitting it.
@@ -523,16 +473,13 @@ impl BlockchainClient<Solana> {
             .map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         let params = (
             request.transaction,
             json!({ "encoding": "base64", "commitment": self.options.commitment }),
         );
         let request = JsonRpcRequest::new(RpcMethods::SimulateTransaction, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 
     /// Returns signatures for transactions involving an address, most recent first.
@@ -547,8 +494,6 @@ impl BlockchainClient<Solana> {
             .map_err(BlockchainError::SerdeError)?;
         let cluster = request.cluster;
 
-        let node_selector = self.get_node_selector(cluster)?;
-
         let mut config = serde_json::Map::new();
         config.insert(
             "commitment".to_string(),
@@ -560,8 +505,7 @@ impl BlockchainClient<Solana> {
         let params = (request.address, Value::Object(config));
         let request = JsonRpcRequest::new(RpcMethods::GetSignaturesForAddress, Some(params));
 
-        self.execute_rpc_call(node_selector, cluster, request, module)
-            .await
+        self.execute_rpc_call(cluster, request, module).await
     }
 }
 
@@ -592,7 +536,7 @@ mod tests {
 
     use crate::apis::blockchain::common::{
         node_selection::SelectionStrategy, BlockchainClient, ChainConfig, ChainFamilyConfig,
-        NodeConfig,
+        NodeConfig, RoutingMode,
     };
     use crate::loader::{LimitValue, PlaidModule};
 
@@ -646,11 +590,14 @@ mod tests {
         )]);
 
         BlockchainClient::new(ChainFamilyConfig {
-            chains,
+            routing: RoutingMode::Nodes {
+                chains,
+                max_retries: 3,
+            },
             timeout_millis: Duration::from_secs(10),
-            max_retries: 3,
             options: SolanaOptions { commitment },
         })
+        .unwrap()
     }
 
     /// Boot an embedded, offline (no mainnet fork) surfnet with a funded payer.


### PR DESCRIPTION
## Summary
Introduces a `RoutingMode` enum for the blockchain RPC client that supports two mutually exclusive routing strategies: per-chain node pools (the existing behavior) and a single proxy endpoint. In proxy mode, every chain routes through one URL with the chain identifier appended as a path segment, so arbitrary chain IDs work without per-chain configuration.

## Changes
- **Code**
  - Added `RoutingMode<C, V>` enum in `runtime/plaid/src/apis/blockchain/common/mod.rs` with `Nodes` and `Proxy` variants, deserialized via a `type` tag.
  - Replaced `BlockchainClient.node_selector` and `max_retries` fields with a single `routing` field.
  - Removed `get_node_selector`; `execute_rpc_call` now dispatches on routing mode.
  - Proxy mode performs a single attempt against the proxy URL (retries are expected to be handled by the proxy); node mode retains retry-across-nodes behavior with failure deprioritization.
  - Generalized `deserialize_chains` to be generic over value type and added a `deserialize_url` helper.
  - Updated EVM and Solana call sites to drop the explicit node-selector lookup.
  - Documented the sticky round-robin behavior in `node_selection.rs`.
- **Config**
  - Updated `runtime/plaid/resources/jrp_config/apis.toml` to the new `routing` schema and added commented proxy-mode examples for EVM and Solana.

## Rationale
Proxy mode removes the need to enumerate every chain and its node pool, which is impractical when supporting arbitrary chain identifiers. Keeping node mode as the default preserves existing behavior and avoids forcing a migration on users who manage their own node pools.

## Breaking Changes
- The config schema for blockchain families changes: `chains` and `max_retries` are replaced by a `routing` block with `type = "nodes"` (per-chain `chains` and `max_retries` nested inside) or `type = "proxy"` with a `url`. Existing configs must be updated to the new structure.