### PR TITLE
Skip storage byte-size lookup for modules without storage APIs

### DIFF
--- a/runtime/plaid/src/functions/storage.rs
+++ b/runtime/plaid/src/functions/storage.rs
@@ -182,9 +182,11 @@ pub fn insert(
     let store = env.as_store_ref();
     let env_data = env.data();
 
-    let storage = if let Some(storage) = &env_data.storage {
-        storage
-    } else {
+    let Some(storage) = &env_data.storage else {
+        return FunctionErrors::ApiNotConfigured as i32;
+    };
+
+    let Some(counter) = &env_data.module.storage_current else {
         return FunctionErrors::ApiNotConfigured as i32;
     };
 
@@ -212,7 +214,7 @@ pub fn insert(
         data_buffer,
         data_buffer_len,
         env_data.module.storage_limit.clone(),
-        &env_data.module.storage_current,
+        counter,
     )
 }
 
@@ -712,9 +714,11 @@ pub fn delete(
     let store = env.as_store_ref();
     let env_data = env.data();
 
-    let storage = if let Some(storage) = &env_data.storage {
-        storage
-    } else {
+    let Some(storage) = &env_data.storage else {
+        return FunctionErrors::ApiNotConfigured as i32;
+    };
+
+    let Some(counter) = &env_data.module.storage_current else {
         return FunctionErrors::ApiNotConfigured as i32;
     };
 
@@ -740,7 +744,7 @@ pub fn delete(
         data_buffer,
         data_buffer_len,
         env_data.module.storage_limit.clone(),
-        &env_data.module.storage_current,
+        counter,
     )
 }
 

--- a/runtime/plaid/src/loader/mod.rs
+++ b/runtime/plaid/src/loader/mod.rs
@@ -321,7 +321,9 @@ pub struct PlaidModule {
     /// The maximum number of memory pages allowed to be mapped for the module
     pub page_limit: u32,
     /// The number of bytes the module is currently saving in persistent storage
-    pub storage_current: Arc<RwLock<u64>>,
+    /// 
+    /// `None` when the module is not using any storage APIs 
+    pub storage_current: Option<Arc<RwLock<u64>>>,
     /// The maximum number of bytes the module can save in persistent storage
     pub storage_limit: LimitValue,
     /// Any additional data the module is given at loading time
@@ -407,9 +409,15 @@ impl PlaidModule {
         let mut module = Module::new(&engine, module_bytes).map_err(Errors::CompileError)?;
         module.set_name(&filename);
 
-        // Validate that every import the module requires can be satisfied
+        // Check if the module uses storage and validate that every import the module requires
+        // can be satisfied
+        let mut uses_storage = false;
         for import in module.imports() {
             let function_name = import.name();
+
+            if function_name.starts_with("storage") {
+                uses_storage = true;
+            }
 
             // Before 0.2.102, it's __wbingen*
             // From wasm-bindgen 0.2.102 to 0.2.104, it's __wbg_wbindgen*
@@ -426,7 +434,11 @@ impl PlaidModule {
             }
         }
 
-        let storage_current = Arc::new(RwLock::new(0));
+        let storage_current = if uses_storage {
+            Some(Arc::new(RwLock::new(0)))
+        } else {
+            None
+        };
 
         Ok(Self {
             name: filename.to_string(),
@@ -445,13 +457,17 @@ impl PlaidModule {
     }
 
     fn log_load_info(&self) {
-        let storage_current_bytes = *self.storage_current.read().unwrap();
+        let storage_current_bytes = self
+            .storage_current
+            .as_ref()
+            .map(|counter| *counter.read().unwrap())
+            .unwrap_or(0);
+        
         info!(
-            "Name: [{}] Computation Limit: [{}] Memory Limit: [{} pages] Storage: [{}/{} bytes used] Log Type: [{}]. Test Mode: [{}]",
+            "Name: [{}] Computation Limit: [{}] Memory Limit: [{} pages] Storage: [{storage_current_bytes}/{} bytes used] Log Type: [{}]. Test Mode: [{}]",
             self.name,
             self.computation_limit,
             self.page_limit,
-            storage_current_bytes,
             self.storage_limit,
             self.logtype,
             self.test_mode,
@@ -516,13 +532,17 @@ async fn populate_storage_sizes(
     stream::iter(modules.into_iter().map(|module| {
         let storage = storage.clone();
         async move {
+            let Some(counter) = &module.storage_current else {
+                return Some(module)
+            };
+
             match storage
                 .get_namespace_byte_size(&module.name)
                 .await
                 .map_err(Errors::StorageError)
             {
                 Ok(bytes) => {
-                    *module.storage_current.write().unwrap() = bytes;
+                    *counter.write().unwrap() = bytes;
                     Some(module)
                 }
                 Err(e) => {


### PR DESCRIPTION
## Summary
Avoid a round trip to the storage backend for every module at boot. Modules that do not import any storage API now skip the namespace byte-size lookup entirely, reducing startup latency when many modules are loaded.

## Changes
- `runtime/plaid/src/loader/mod.rs`
  - Changed `PlaidModule::storage_current` from `Arc<RwLock<u64>>` to `Option<Arc<RwLock<u64>>>`, where `None` indicates the module does not use storage APIs.
  - Detect storage usage in a single pass over module imports during compilation.
  - `populate_storage_sizes` now returns modules unchanged when `storage_current` is `None`, skipping the backend lookup.
  - `log_load_info` reads the byte count through the optional counter, defaulting to `0`.
- `runtime/plaid/src/functions/storage.rs`
  - `insert` and `delete` now return `ApiNotConfigured` when the module has no storage counter

## Rationale
Previously every module triggered a storage byte-size lookup at load, even when it never used storage. Making the counter optional lets the loader skip that work for modules that do not need it

## Performance/Operational Impact
- Reduces boot-time storage backend round trips to only modules that actually use storage.
- No change to runtime behavior for modules that do use storage.