### PR TITLE
Fix DG edge case

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "46.6.0"
+version = "47.0.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -4032,7 +4032,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "46.6.0"
+version = "47.0.0"
 dependencies = [
  "aes",
  "alkali",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "46.6.0"
+version = "47.0.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "46.6.0"
+version = "47.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "46.6.0"
+version = "47.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -411,4 +411,8 @@ impl DataGenerator for Github {
     fn get_max_catchup_time(&self) -> u64 {
         self.config.max_catchup
     }
+
+    fn get_time_granularity(&self) -> u64 {
+        1_000_000 // 1 millisecond in nanoseconds
+    }
 }

--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -421,6 +421,6 @@ impl DataGenerator for Github {
     }
 
     fn get_time_granularity(&self) -> time::Duration {
-        Duration::nanoseconds(self.config.time_granularity as i64)
+        time::Duration::nanoseconds(self.config.time_granularity as i64)
     }
 }

--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -420,7 +420,7 @@ impl DataGenerator for Github {
         self.config.max_catchup
     }
 
-    fn get_time_granularity(&self) -> u64 {
-        self.config.time_granularity
+    fn get_time_granularity(&self) -> time::Duration {
+        Duration::nanoseconds(self.config.time_granularity as i64)
     }
 }

--- a/runtime/plaid/src/data/github/mod.rs
+++ b/runtime/plaid/src/data/github/mod.rs
@@ -93,6 +93,9 @@ pub struct GithubConfig {
     /// Max number of seconds for the look-back window
     #[serde(default = "default_max_catchup")]
     max_catchup: u64,
+    /// Time granularity for the GitHub API, in nanoseconds.
+    #[serde(default = "default_time_granularity")]
+    time_granularity: u64,
 }
 
 impl GithubConfig {
@@ -108,6 +111,7 @@ impl GithubConfig {
             lru_cache_size: default_lru_cache_size(),
             max_since_until: default_since_until(),
             max_catchup: default_max_catchup(),
+            time_granularity: default_time_granularity(),
         }
     }
 }
@@ -138,6 +142,10 @@ fn default_lru_cache_size() -> usize {
 
 fn default_canon_time() -> u64 {
     20
+}
+
+fn default_time_granularity() -> u64 {
+    1_000_000 // 1 millisecond in nanoseconds
 }
 
 /// Custom parser for log type
@@ -413,6 +421,6 @@ impl DataGenerator for Github {
     }
 
     fn get_time_granularity(&self) -> u64 {
-        1_000_000 // 1 millisecond in nanoseconds
+        self.config.time_granularity
     }
 }

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -568,10 +568,8 @@ pub async fn get_and_process_dg_logs(
 
     loop {
         // Get logs that happened since `last_seen`.
-        // Walk back a second from the actual value of `last_seen`, to account for problems
-        // with time granularity. E.g., events happening in the same second could be missed.
-        // Overlapping queries will prevent this problem from happening.
-        // We would introduce the issue of seeing the same log multiple times, but this is handled later.
+        // Walk forward by the smallest time granularity the API provides, because we have
+        // already seen all the logs up to `last_seen`.
         let since = dg.get_last_seen().saturating_add(dg.get_time_granularity());
 
         // Get the logs until canon_time seconds ago

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -617,6 +617,9 @@ pub async fn get_and_process_dg_logs(
                 dg.get_name(),
                 dg.get_last_seen()
             );
+            dg.set_last_seen(until);
+            // We do not persist the state in the DB. It will be persisted automatically
+            // next time we send a log for processing.
             return Ok(());
         }
 

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -589,13 +589,13 @@ pub async fn get_and_process_dg_logs(
             }
         };
 
-        if until < dg.get_last_seen() {
+        if until <= dg.get_last_seen() {
             // We are in a strange situation. E.g., we have just booted, so
             // last_seen = now and until = now - canon_time, which makes until < last_seen.
             // This does not make sense, but it's not really an error. We return and, at some
             // point, we will run again with a 'sensible' set of parameters.
             debug!(
-                "[{}] Waiting for canonicalization: {until} (until) < {} (last seen).",
+                "[{}] Waiting for canonicalization: {until} (until) <= {} (last seen).",
                 dg.get_name(),
                 dg.get_last_seen(),
             );

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -405,7 +405,7 @@ pub trait DataGenerator {
     fn get_max_catchup_time(&self) -> u64;
 
     /// Get the time granularity provided by the data source API, in nanoseconds.
-    fn get_time_granularity(&self) -> u64;
+    fn get_time_granularity(&self) -> time::Duration;
 }
 
 /// Get the system time in seconds from the Epoch
@@ -572,9 +572,7 @@ pub async fn get_and_process_dg_logs(
         // with time granularity. E.g., events happening in the same second could be missed.
         // Overlapping queries will prevent this problem from happening.
         // We would introduce the issue of seeing the same log multiple times, but this is handled later.
-        let since = dg
-            .get_last_seen()
-            .saturating_add(time::Duration::nanoseconds(dg.get_time_granularity() as i64));
+        let since = dg.get_last_seen().saturating_add(dg.get_time_granularity());
 
         // Get the logs until canon_time seconds ago
         let mut until = get_time() - dg.get_canon_time();

--- a/runtime/plaid/src/data/mod.rs
+++ b/runtime/plaid/src/data/mod.rs
@@ -403,6 +403,9 @@ pub trait DataGenerator {
     /// we will catch up these many seconds and _lose_ older logs. This is to enforce an upper bound
     /// and avoid unpleasant edge cases where Plaid would try to catch up months of missed logs.
     fn get_max_catchup_time(&self) -> u64;
+
+    /// Get the time granularity provided by the data source API, in nanoseconds.
+    fn get_time_granularity(&self) -> u64;
 }
 
 /// Get the system time in seconds from the Epoch
@@ -571,7 +574,7 @@ pub async fn get_and_process_dg_logs(
         // We would introduce the issue of seeing the same log multiple times, but this is handled later.
         let since = dg
             .get_last_seen()
-            .saturating_sub(time::Duration::seconds(1));
+            .saturating_add(time::Duration::nanoseconds(dg.get_time_granularity() as i64));
 
         // Get the logs until canon_time seconds ago
         let mut until = get_time() - dg.get_canon_time();

--- a/runtime/plaid/src/data/okta/mod.rs
+++ b/runtime/plaid/src/data/okta/mod.rs
@@ -51,6 +51,9 @@ pub struct OktaConfig {
     /// Max number of seconds for the look-back window
     #[serde(default = "default_max_catchup")]
     max_catchup: u64,
+    /// Time granularity for the Okta API, in nanoseconds.
+    #[serde(default = "default_time_granularity")]
+    time_granularity: u64,
 }
 
 /// Custom parser for limit. Returns an error if a limit = 0 or limit > 1000 is given
@@ -93,6 +96,11 @@ fn default_max_catchup() -> u64 {
 /// This function provides the default size of the LRU cache.
 fn default_lru_cache_size() -> usize {
     4096
+}
+
+/// This function provides the default time granularity for the Okta API, in nanoseconds.
+fn default_time_granularity() -> u64 {
+    1_000_000 // 1 millisecond in nanoseconds
 }
 
 fn default_canon_time() -> u64 {
@@ -361,6 +369,6 @@ impl DataGenerator for Okta {
     }
 
     fn get_time_granularity(&self) -> u64 {
-        1_000_000 // 1 millisecond in nanoseconds
+        self.config.time_granularity
     }
 }

--- a/runtime/plaid/src/data/okta/mod.rs
+++ b/runtime/plaid/src/data/okta/mod.rs
@@ -368,7 +368,7 @@ impl DataGenerator for Okta {
         self.config.max_catchup
     }
 
-    fn get_time_granularity(&self) -> u64 {
-        self.config.time_granularity
+    fn get_time_granularity(&self) -> time::Duration {
+        Duration::nanoseconds(self.config.time_granularity as i64)
     }
 }

--- a/runtime/plaid/src/data/okta/mod.rs
+++ b/runtime/plaid/src/data/okta/mod.rs
@@ -369,6 +369,6 @@ impl DataGenerator for Okta {
     }
 
     fn get_time_granularity(&self) -> time::Duration {
-        Duration::nanoseconds(self.config.time_granularity as i64)
+        time::Duration::nanoseconds(self.config.time_granularity as i64)
     }
 }

--- a/runtime/plaid/src/data/okta/mod.rs
+++ b/runtime/plaid/src/data/okta/mod.rs
@@ -359,4 +359,8 @@ impl DataGenerator for Okta {
     fn get_max_catchup_time(&self) -> u64 {
         self.config.max_catchup
     }
+
+    fn get_time_granularity(&self) -> u64 {
+        1_000_000 // 1 millisecond in nanoseconds
+    }
 }


### PR DESCRIPTION
This fixes an edge case with data generators where all the logs obtained in a single API call have the same timestamp, because of a burst. As a result, the `since..until` window would get stuck, and so the whole DG.

Instead, now we calculate the new `since` by taking the last seen timestamp and incrementing it by the smallest time unit that the remote API supports.

The underlying assumptions are that
1. When we fetch logs in a `since..until` window, we get _all_ the logs in that window. Pagination is used to ensure this.
2. When we see at least one log with timestamp `t`, then we have seen all the logs with timestamp `t`. This is because however many there are, they are all in the same `since..until` and, by assumption 1, we have seen all of them.