### PR TITLE
Add runtime API to asynchronously merge GitHub PRs

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "47.0.0"
+version = "47.1.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -4032,7 +4032,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "47.0.0"
+version = "47.1.0"
 dependencies = [
  "aes",
  "alkali",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "47.0.0"
+version = "47.1.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "47.0.0"
+version = "47.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/github/pull_request.rs
+++ b/runtime/plaid-stl/src/github/pull_request.rs
@@ -716,7 +716,8 @@ pub struct MergePrRequest {
     pub merge_action: MergeAction,
 }
 
-/// Merges a pull request in a repository.
+/// Asynchronously merges a pull request in a repository.
+/// This returns the full response body from GitHub.
 pub fn merge_pr(
     client_id: impl Display,
     request: MergePrRequest,

--- a/runtime/plaid-stl/src/github/pull_request.rs
+++ b/runtime/plaid-stl/src/github/pull_request.rs
@@ -750,6 +750,8 @@ pub fn merge_pr(
         return Err(res.into());
     }
 
+    return_buffer.truncate(res as usize);
+
     // This should be safe because unless the Plaid runtime is expressly trying
     // to mess with us, this came from a String in the API module.
     Ok(String::from_utf8(return_buffer).unwrap())

--- a/runtime/plaid-stl/src/github/pull_request.rs
+++ b/runtime/plaid-stl/src/github/pull_request.rs
@@ -682,6 +682,78 @@ pub struct AddLabelsRequest {
     pub labels: Vec<String>,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MergeMethod {
+    Merge,
+    Squash,
+    Rebase,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MergeAction {
+    DirectMerge,
+    MergeQueue,
+    Default,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct MergePrRequest {
+    /// The account owner of the repository. The name is not case sensitive.
+    pub owner: String,
+    /// The name of the repository without the `.git` extension. The name is not case sensitive.
+    pub repo: String,
+    /// The number of the pull request to merge.
+    pub number: u32,
+    /// The title of the commit
+    pub commit_title: Option<String>,
+    /// The commit message for the merge commit.
+    pub commit_message: Option<String>,
+    /// The merge method to use. Can be one of `merge`, `squash`, or `rebase`.
+    pub merge_method: Option<MergeMethod>,
+    /// The merge action to use. Can be one of `direct_merge`, `merge_queue`, or `default`.
+    pub merge_action: MergeAction,
+}
+
+/// Merges a pull request in a repository.
+pub fn merge_pr(
+    client_id: impl Display,
+    request: MergePrRequest,
+) -> Result<String, PlaidFunctionError> {
+    extern "C" {
+        new_host_function_with_error_buffer!(github, merge_pr);
+    }
+
+    let wrapped = GithubApiWrapper {
+        client_id: client_id.to_string(),
+        params: request,
+    };
+
+    let params = serde_json::to_string(&wrapped).unwrap();
+
+    const RETURN_BUFFER_SIZE: usize = 1024 * 1024 * 5; // 5 MiB
+    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+
+    let res = unsafe {
+        github_merge_pr(
+            params.as_bytes().as_ptr(),
+            params.as_bytes().len(),
+            return_buffer.as_mut_ptr(),
+            RETURN_BUFFER_SIZE,
+        )
+    };
+    // There was an error with the Plaid system. Maybe the API is not
+    // configured.
+    if res < 0 {
+        return Err(res.into());
+    }
+
+    // This should be safe because unless the Plaid runtime is expressly trying
+    // to mess with us, this came from a String in the API module.
+    Ok(String::from_utf8(return_buffer).unwrap())
+}
+
 /// Adds labels to a pull request or issue. If you provide an empty array of labels, all labels are removed from the issue.
 ///
 /// See the [GitHub API docs](https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#add-labels-to-an-issue)

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "47.0.0"
+version = "47.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid/src/apis/github/pull_requests.rs
+++ b/runtime/plaid/src/apis/github/pull_requests.rs
@@ -1,7 +1,7 @@
 use plaid_stl::github::{
     AddLabelsRequest, CreatePullRequestRequest, GetPullRequestOptions, GetPullRequestRequest,
-    GithubApiWrapper, PullRequestRequestReviewers, PullRequestReviewEvent,
-    SubmitPullRequestReviewRequest,
+    GithubApiWrapper, MergeAction, MergeMethod, MergePrRequest, PullRequestRequestReviewers,
+    PullRequestReviewEvent, SubmitPullRequestReviewRequest,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -42,7 +42,7 @@ impl Github {
             self.validate_team_slug(&team)?;
         }
 
-        info!("Requesting reviews from users: [{}] and teams: [{}] on [{owner}/{repo}/{pull_number}] org on behalf of {module}", request.params.reviewers.join(", "), request.params.team_reviewers.join(", "));
+        info!("Requesting reviews from users: [{}] and teams: [{}] on [{owner}/{repo}/{pull_number}] on behalf of {module}", request.params.reviewers.join(", "), request.params.team_reviewers.join(", "));
 
         let address = format!("/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers");
 
@@ -149,7 +149,7 @@ impl Github {
 
         let address = format!("/repos/{owner}/{repo}/pulls");
 
-        info!("Creating pull request in [{owner}/{repo}] org on behalf of {module}");
+        info!("Creating pull request in [{owner}/{repo}] on behalf of {module}");
 
         match self
             .make_generic_post_request(&request.client_id, address, request_body, module)
@@ -190,7 +190,7 @@ impl Github {
             .options
             .map_or(Default::default(), query_string_from_options);
 
-        info!("Listing pull requests in [{owner}/{repo}] org on behalf of {module}",);
+        info!("Listing pull requests in [{owner}/{repo}] on behalf of {module}",);
         let address = format!("/repos/{owner}/{repo}/pulls?{options}");
 
         match self
@@ -224,7 +224,7 @@ impl Github {
         let repo = self.validate_repository_name(&request.params.repo)?;
 
         info!(
-            "Adding labels to issue/PR #{} in [{owner}/{repo}] org on behalf of {module}",
+            "Adding labels to issue/PR #{} in [{owner}/{repo}] on behalf of {module}",
             request.params.number
         );
 
@@ -241,6 +241,63 @@ impl Github {
             Ok((status, Ok(_))) => {
                 if status == 200 {
                     Ok(0)
+                } else {
+                    Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
+                        status,
+                    )))
+                }
+            }
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Merge a pull request asynchronously. For more info, see https://docs.github.com/en/rest/pulls/pulls?apiVersion=2026-03-10#merge-a-pull-request-asynchronously
+    pub async fn merge_pr(
+        &self,
+        params: &str,
+        module: Arc<PlaidModule>,
+    ) -> Result<String, ApiError> {
+        let request: GithubApiWrapper<MergePrRequest> =
+            serde_json::from_str(params).map_err(|_| ApiError::BadRequest)?;
+
+        let owner = self.validate_org(&request.params.owner)?;
+        let repo = self.validate_repository_name(&request.params.repo)?;
+        // We do not validate the PR number because we are deserializing to a u32, which is all the validation we need.
+        let pull_number = request.params.number;
+
+        info!("Merging PR #{pull_number} in [{owner}/{repo}] on behalf of {module}",);
+
+        let address = format!("/repos/{owner}/{repo}/pulls/{pull_number}/merge-async");
+
+        #[derive(Serialize)]
+        struct Body {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            commit_title: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            commit_message: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            merge_method: Option<MergeMethod>,
+            merge_action: MergeAction,
+        }
+
+        let body = Body {
+            commit_title: request.params.commit_title,
+            commit_message: request.params.commit_message,
+            merge_method: request.params.merge_method,
+            merge_action: request.params.merge_action,
+        };
+
+        match self
+            .make_generic_put_request(&request.client_id, address, Some(&body), module)
+            .await
+        {
+            Ok((status, Ok(data))) => {
+                if status == 200 || status == 202 {
+                    // Just return the full body to the rule. This allows us not to
+                    // have to parse the body and return a specific field, which is
+                    // more flexible for future changes to the API.
+                    Ok(data)
                 } else {
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(
                         status,

--- a/runtime/plaid/src/apis/github/repos.rs
+++ b/runtime/plaid/src/apis/github/repos.rs
@@ -535,7 +535,7 @@ impl Github {
             .await
         {
             Ok((status, _)) => {
-                if status == 200 {
+                if status == 201 {
                     Ok(0)
                 } else {
                     Err(ApiError::GitHubError(GitHubError::UnexpectedStatusCode(

--- a/runtime/plaid/src/functions/api.rs
+++ b/runtime/plaid/src/functions/api.rs
@@ -467,7 +467,12 @@ impl_new_function_with_error_buffer!(
     create_installation_access_token,
     DISALLOW_IN_TEST_MODE
 );
-impl_new_function!(github, revoke_installation_access_token, DISALLOW_IN_TEST_MODE);
+impl_new_function!(
+    github,
+    revoke_installation_access_token,
+    DISALLOW_IN_TEST_MODE
+);
+impl_new_function_with_error_buffer!(github, merge_pr, DISALLOW_IN_TEST_MODE);
 
 // GitHub Functions only available with GitHub App authentication
 impl_new_function!(github, review_fpat_requests_for_org, DISALLOW_IN_TEST_MODE);
@@ -925,6 +930,7 @@ define_api_functions! {
         "github_get_enterprise_license_status"                 => github_get_enterprise_license_status,
         "github_create_installation_access_token"                 => github_create_installation_access_token,
         "github_revoke_installation_access_token"                 => github_revoke_installation_access_token,
+        "github_merge_pr" => github_merge_pr,
 
         // Slack Calls
         "slack_post_to_named_webhook"     => slack_post_to_named_webhook,


### PR DESCRIPTION
This supports direct merge or merging via a merge queue.

On success, it returns the full body provided by GH, leaving it to the rule to parse it and extract what's relevant.