### PR TITLE
Increase return buffer size for S3 `list_objects` to fit max response

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "plaid_stl"
-version = "47.1.0"
+version = "47.2.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -4032,7 +4032,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plaid"
-version = "47.1.0"
+version = "47.2.0"
 dependencies = [
  "aes",
  "alkali",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "plaid_stl"
-version = "47.1.0"
+version = "47.2.0"
 dependencies = [
  "base64 0.13.1",
  "chrono",

--- a/runtime/plaid-stl/Cargo.toml
+++ b/runtime/plaid-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid_stl"
-version = "47.1.0"
+version = "47.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/runtime/plaid-stl/src/aws/s3.rs
+++ b/runtime/plaid-stl/src/aws/s3.rs
@@ -448,15 +448,18 @@ pub fn list_objects(
     let request =
         serde_json::to_string(&request).map_err(|_| PlaidFunctionError::InternalApiError)?;
 
-    let return_buff_size = 1024 * 1000;
-    let mut return_buffer = vec![0; return_buff_size];
+    // A max-sized ListObjectsV2 response (1,000 keys) plus JSON encoding overhead
+    // (field names, quotes, commas) and the continuation token can exceed smaller
+    // buffers
+    let return_buffer_size = 1024 * 1024 * 4; // 4 MiB
+    let mut return_buffer = vec![0; return_buffer_size];
 
     let res = unsafe {
         aws_s3_list_objects(
             request.as_ptr(),
             request.len(),
             return_buffer.as_mut_ptr(),
-            return_buff_size,
+            return_buffer_size,
         )
     };
 

--- a/runtime/plaid-stl/src/aws/s3.rs
+++ b/runtime/plaid-stl/src/aws/s3.rs
@@ -448,14 +448,15 @@ pub fn list_objects(
     let request =
         serde_json::to_string(&request).map_err(|_| PlaidFunctionError::InternalApiError)?;
 
-    let mut return_buffer = vec![0; RETURN_BUFFER_SIZE];
+    let return_buff_size = 1024 * 1000;
+    let mut return_buffer = vec![0; return_buff_size];
 
     let res = unsafe {
         aws_s3_list_objects(
             request.as_ptr(),
             request.len(),
             return_buffer.as_mut_ptr(),
-            RETURN_BUFFER_SIZE,
+            return_buff_size,
         )
     };
 

--- a/runtime/plaid/Cargo.toml
+++ b/runtime/plaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "47.1.0"
+version = "47.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Summary
The `list_objects` S3 API was allocating a 4 KB return buffer (the shared `RETURN_BUFFER_SIZE`), which is far too small to hold a full S3 list response. This increases the `list_objects` return buffer to 4 MiB, sized to accommodate the maximum possible S3 ListObjects response with headroom for serialization overhead.

## Changes

- **`runtime/plaid-stl/src/aws/s3.rs`**: Replaced the shared `RETURN_BUFFER_SIZE` (4 KB) usage in `list_objects` with a local `return_buffer_size` of `1024 * 1024 * 4` bytes (4 MiB), applied to both the buffer allocation and the host function call. This matches the return buffer size already used by the other AWS host calls in `aws/dynamodb.rs` and `aws/kms.rs`.
- **`runtime/plaid-stl/Cargo.toml`**, **`runtime/plaid/Cargo.toml`**: Bumped version from `47.1.0` to `47.2.0`.
- **`runtime/Cargo.lock`**, **`modules/Cargo.lock`**: Updated lock files to reflect the new crate versions.

## Rationale

S3's ListObjects API returns up to 1,000 keys per response, and each object key can be up to 1,024 bytes in length (see [Amazon S3 object keys documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html)). The raw key bytes alone can therefore reach ~1 MB (1,000 keys × 1,024 bytes). On top of that, the response is JSON-encoded, adding overhead from field names, quotes, commas, and braces, and the `continuation_token` can contribute further when the response is truncated. A 4 MiB buffer covers this worst case with comfortable headroom and keeps `list_objects` consistent with the buffer sizing of the other AWS host functions.